### PR TITLE
add a type for input schema properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,15 @@ void main() async {
     "calculate",
     description: 'Perform basic arithmetic operations',
     inputSchemaProperties: {
-      'operation': {
-        'type': 'string',
-        'enum': ['add', 'subtract', 'multiply', 'divide'],
+      'properties': {
+        'operation': {
+          'type': 'string',
+          'enum': ['add', 'subtract', 'multiply', 'divide'],
+        },
+        'a': {'type': 'number'},
+        'b': {'type': 'number'},
       },
-      'a': {'type': 'number'},
-      'b': {'type': 'number'},
+      'required': ['operation', 'a', 'b'],
     },
     callback: ({args, extra}) async {
       final operation = args!['operation'];

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ void main() async {
   server.tool(
     "calculate",
     description: 'Perform basic arithmetic operations',
-    inputSchemaProperties: {
+    inputSchema: {
       'properties': {
         'operation': {
           'type': 'string',

--- a/lib/src/server/mcp.dart
+++ b/lib/src/server/mcp.dart
@@ -82,21 +82,21 @@ class ResourceTemplateRegistration {
 
 class _RegisteredTool {
   final String? description;
-  final Map<String, dynamic>? inputSchemaProperties;
+  final Map<String, dynamic>? inputSchema;
   final ToolCallback callback;
 
   const _RegisteredTool({
     this.description,
-    this.inputSchemaProperties,
+    this.inputSchema,
     required this.callback,
   });
 
   Tool toTool(String name) {
-    final rest = Map<String, dynamic>.from(inputSchemaProperties ?? {})
+    final inputSchemaProperties = Map<String, dynamic>.from(inputSchema ?? {})
       ..remove('required');
     final schema = ToolInputSchema(
-      properties: rest,
-      required: inputSchemaProperties?['required'],
+      properties: inputSchemaProperties,
+      required: inputSchema?['required'],
     );
     return Tool(name: name, description: description, inputSchema: schema);
   }
@@ -566,7 +566,7 @@ class McpServer {
   void tool(
     String name, {
     String? description,
-    Map<String, dynamic>? inputSchemaProperties,
+    Map<String, dynamic>? inputSchema,
     required ToolCallback callback,
   }) {
     if (_registeredTools.containsKey(name)) {
@@ -574,7 +574,7 @@ class McpServer {
     }
     _registeredTools[name] = _RegisteredTool(
       description: description,
-      inputSchemaProperties: inputSchemaProperties,
+      inputSchema: inputSchema,
       callback: callback,
     );
     _ensureToolHandlersInitialized();

--- a/lib/src/server/mcp.dart
+++ b/lib/src/server/mcp.dart
@@ -82,7 +82,7 @@ class ResourceTemplateRegistration {
 
 class _RegisteredTool {
   final String? description;
-  final Map<String, dynamic>? inputSchemaProperties;
+  final InputSchemaProperties? inputSchemaProperties;
   final ToolCallback callback;
 
   const _RegisteredTool({
@@ -561,7 +561,7 @@ class McpServer {
   void tool(
     String name, {
     String? description,
-    Map<String, dynamic>? inputSchemaProperties,
+    InputSchemaProperties? inputSchemaProperties,
     required ToolCallback callback,
   }) {
     if (_registeredTools.containsKey(name)) {

--- a/lib/src/server/mcp.dart
+++ b/lib/src/server/mcp.dart
@@ -561,15 +561,18 @@ class McpServer {
   void tool(
     String name, {
     String? description,
-    InputSchemaProperties? inputSchemaProperties,
+    Map<String, dynamic>? inputSchemaProperties,
     required ToolCallback callback,
   }) {
     if (_registeredTools.containsKey(name)) {
       throw ArgumentError("Tool name '$name' already registered.");
     }
+    final properties = inputSchemaProperties == null
+        ? null
+        : InputSchemaProperties.fromJson(inputSchemaProperties);
     _registeredTools[name] = _RegisteredTool(
       description: description,
-      inputSchemaProperties: inputSchemaProperties,
+      inputSchemaProperties: properties,
       callback: callback,
     );
     _ensureToolHandlersInitialized();

--- a/lib/src/server/mcp.dart
+++ b/lib/src/server/mcp.dart
@@ -82,7 +82,7 @@ class ResourceTemplateRegistration {
 
 class _RegisteredTool {
   final String? description;
-  final InputSchemaProperties? inputSchemaProperties;
+  final Map<String, dynamic>? inputSchemaProperties;
   final ToolCallback callback;
 
   const _RegisteredTool({
@@ -92,7 +92,12 @@ class _RegisteredTool {
   });
 
   Tool toTool(String name) {
-    final schema = ToolInputSchema(properties: inputSchemaProperties);
+    final rest = Map<String, dynamic>.from(inputSchemaProperties ?? {})
+      ..remove('required');
+    final schema = ToolInputSchema(
+      properties: rest,
+      required: inputSchemaProperties?['required'],
+    );
     return Tool(name: name, description: description, inputSchema: schema);
   }
 }
@@ -567,12 +572,9 @@ class McpServer {
     if (_registeredTools.containsKey(name)) {
       throw ArgumentError("Tool name '$name' already registered.");
     }
-    final properties = inputSchemaProperties == null
-        ? null
-        : InputSchemaProperties.fromJson(inputSchemaProperties);
     _registeredTools[name] = _RegisteredTool(
       description: description,
-      inputSchemaProperties: properties,
+      inputSchemaProperties: inputSchemaProperties,
       callback: callback,
     );
     _ensureToolHandlersInitialized();

--- a/lib/src/server/mcp.dart
+++ b/lib/src/server/mcp.dart
@@ -92,12 +92,7 @@ class _RegisteredTool {
   });
 
   Tool toTool(String name) {
-    final inputSchemaProperties = Map<String, dynamic>.from(inputSchema ?? {})
-      ..remove('required');
-    final schema = ToolInputSchema(
-      properties: inputSchemaProperties,
-      required: inputSchema?['required'],
-    );
+    final schema = ToolInputSchema.fromJson(inputSchema ?? {});
     return Tool(name: name, description: description, inputSchema: schema);
   }
 }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1754,54 +1754,23 @@ class JsonRpcPromptListChangedNotification extends JsonRpcNotification {
       const JsonRpcPromptListChangedNotification();
 }
 
-/// Represents the properties definition for a tool input schema.
-class InputSchemaProperties {
-  /// A map of property names to their schema definitions.
-  final Map<String, dynamic>? properties;
-
-  /// List of required property names.
-  final List<String>? required;
-
-  /// Additional schema properties.
-  final Map<String, dynamic> additionalProperties;
-
-  const InputSchemaProperties({
-    this.properties,
-    this.required,
-    this.additionalProperties = const {},
-  });
-
-  factory InputSchemaProperties.fromJson(Map<String, dynamic> json) {
-    final rest = Map<String, dynamic>.from(json)
-      ..remove('properties')
-      ..remove('required');
-    return InputSchemaProperties(
-      properties: json['properties'] as Map<String, dynamic>?,
-      required: (json['required'] as List<dynamic>?)?.cast<String>(),
-      additionalProperties: rest,
-    );
-  }
-
-  Map<String, dynamic> toJson() => {
-        if (properties != null) 'properties': properties,
-        if (required != null) 'required': required,
-        ...additionalProperties,
-      };
-}
-
 /// Describes the input schema for a tool, based on JSON Schema.
 class ToolInputSchema {
   /// Must be "object".
   final String type = "object";
 
   /// JSON Schema properties definition.
-  final InputSchemaProperties? properties;
+  final Map<String, dynamic>? properties;
+
+  /// Optional list of required properties.
+  final List<String>? required;
 
   /// Additional JSON Schema properties.
   final Map<String, dynamic> additionalProperties;
 
   const ToolInputSchema({
     this.properties,
+    this.required,
     this.additionalProperties = const {},
   });
 
@@ -1810,16 +1779,16 @@ class ToolInputSchema {
       ..remove('type')
       ..remove('properties');
     return ToolInputSchema(
-      properties: json['properties'] == null
-          ? null
-          : InputSchemaProperties.fromJson(json['properties'] as Map<String, dynamic>),
+      properties: json['properties'] as Map<String, dynamic>?,
+      required: (json['required'] as List<dynamic>?)?.cast<String>(),
       additionalProperties: rest,
     );
   }
 
   Map<String, dynamic> toJson() => {
         'type': type,
-        if (properties != null) 'properties': properties!.toJson(),
+        if (properties != null) 'properties': properties,
+        if (required != null) 'required': required,
         ...additionalProperties,
       };
 }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1754,15 +1754,50 @@ class JsonRpcPromptListChangedNotification extends JsonRpcNotification {
       const JsonRpcPromptListChangedNotification();
 }
 
+/// Represents the properties definition for a tool input schema.
+class InputSchemaProperties {
+  /// A map of property names to their schema definitions.
+  final Map<String, dynamic>? properties;
+
+  /// List of required property names.
+  final List<String>? required;
+
+  /// Additional schema properties.
+  final Map<String, dynamic> additionalProperties;
+
+  const InputSchemaProperties({
+    this.properties,
+    this.required,
+    this.additionalProperties = const {},
+  });
+
+  factory InputSchemaProperties.fromJson(Map<String, dynamic> json) {
+    final rest = Map<String, dynamic>.from(json)
+      ..remove('properties')
+      ..remove('required');
+    return InputSchemaProperties(
+      properties: json['properties'] as Map<String, dynamic>?,
+      required: (json['required'] as List<dynamic>?)?.cast<String>(),
+      additionalProperties: rest,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        if (properties != null) 'properties': properties,
+        if (required != null) 'required': required,
+        ...additionalProperties,
+      };
+}
+
 /// Describes the input schema for a tool, based on JSON Schema.
 class ToolInputSchema {
   /// Must be "object".
   final String type = "object";
 
-  /// JSON Schema properties definition.
-  final Map<String, dynamic>? properties;
+  /// The schema properties definition.
+  final InputSchemaProperties? properties;
 
-  /// Additional JSON Schema properties (e.g., required).
+  /// Additional JSON Schema properties.
   final Map<String, dynamic> additionalProperties;
 
   const ToolInputSchema({
@@ -1775,14 +1810,16 @@ class ToolInputSchema {
       ..remove('type')
       ..remove('properties');
     return ToolInputSchema(
-      properties: json['properties'] as Map<String, dynamic>?,
+      properties: json['properties'] == null
+          ? null
+          : InputSchemaProperties.fromJson(json['properties'] as Map<String, dynamic>),
       additionalProperties: rest,
     );
   }
 
   Map<String, dynamic> toJson() => {
         'type': type,
-        if (properties != null) 'properties': properties,
+        if (properties != null) 'properties': properties!.toJson(),
         ...additionalProperties,
       };
 }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1756,11 +1756,11 @@ class JsonRpcPromptListChangedNotification extends JsonRpcNotification {
 
 /// Describes the input schema for a tool, based on JSON Schema.
 class ToolInputSchema {
-  /// Must be "object".
-  final String type = "object";
+  /// Must be "object" at the top level.
+  final String type;
 
   /// JSON Schema properties definition.
-  final Map<String, dynamic>? properties;
+  final ToolInputSchema? properties;
 
   /// Optional list of required properties.
   final List<String>? required;
@@ -1769,6 +1769,7 @@ class ToolInputSchema {
   final Map<String, dynamic> additionalProperties;
 
   const ToolInputSchema({
+    required this.type,
     this.properties,
     this.required,
     this.additionalProperties = const {},
@@ -1780,7 +1781,10 @@ class ToolInputSchema {
       ..remove('properties')
       ..remove('required');
     return ToolInputSchema(
-      properties: json['properties'] as Map<String, dynamic>?,
+      type: json['type'] ?? "object",
+      properties: json['properties'] != null
+          ? ToolInputSchema.fromJson(json['properties'])
+          : null,
       required: (json['required'] as List<dynamic>?)?.cast<String>(),
       additionalProperties: rest,
     );

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1794,7 +1794,7 @@ class ToolInputSchema {
   /// Must be "object".
   final String type = "object";
 
-  /// The schema properties definition.
+  /// JSON Schema properties definition.
   final InputSchemaProperties? properties;
 
   /// Additional JSON Schema properties.

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1777,7 +1777,8 @@ class ToolInputSchema {
   factory ToolInputSchema.fromJson(Map<String, dynamic> json) {
     final rest = Map<String, dynamic>.from(json)
       ..remove('type')
-      ..remove('properties');
+      ..remove('properties')
+      ..remove('required');
     return ToolInputSchema(
       properties: json['properties'] as Map<String, dynamic>?,
       required: (json['required'] as List<dynamic>?)?.cast<String>(),


### PR DESCRIPTION
I think this is closer to what you were saying in #11 but it feels weird to have inputSchemaProperties.properties. I don't know. Let me know what you think and I can try to put together an actual PR