### PR TITLE
Jbienz/structuredcontent

### DIFF
--- a/example/fetch-server/bin/fetch_server.dart
+++ b/example/fetch-server/bin/fetch_server.dart
@@ -95,7 +95,7 @@ void main(List<String> arguments) async {
         final response = await http.get(Uri.parse(url));
 
         if (response.statusCode != 200) {
-          return CallToolResult(
+          return CallToolResult.fromContent(
             content: [
               TextContent(
                 text:
@@ -120,7 +120,7 @@ void main(List<String> arguments) async {
             (effectiveStartIndex + maxLength).clamp(0, content.length);
         content = content.substring(effectiveStartIndex, effectiveEndIndex);
 
-        return CallToolResult(
+        return CallToolResult.fromContent(
           content: [
             TextContent(
               text: content,
@@ -128,7 +128,7 @@ void main(List<String> arguments) async {
           ],
         );
       } catch (e) {
-        return CallToolResult(
+        return CallToolResult.fromContent(
           content: [
             TextContent(
               text: 'Fetch error: ${e.toString()}',

--- a/example/iostream-client-server/server_iostream.dart
+++ b/example/iostream-client-server/server_iostream.dart
@@ -23,7 +23,7 @@ Future<McpServer> getServer() async {
       final operation = args!['operation'];
       final a = args['a'];
       final b = args['b'];
-      return CallToolResult(
+      return CallToolResult.fromContent(
         content: [
           TextContent(
             text: switch (operation) {
@@ -40,4 +40,3 @@ Future<McpServer> getServer() async {
   );
   return mcpServer;
 }
-

--- a/example/server_sse.dart
+++ b/example/server_sse.dart
@@ -23,7 +23,7 @@ Future<void> main() async {
       final operation = args!['operation'];
       final a = args['a'];
       final b = args['b'];
-      return CallToolResult(
+      return CallToolResult.fromContent(
         content: [
           TextContent(
             text: switch (operation) {

--- a/example/server_stdio.dart
+++ b/example/server_stdio.dart
@@ -27,7 +27,7 @@ void main() async {
       final operation = args!['operation'];
       final a = args['a'];
       final b = args['b'];
-      return CallToolResult(
+      return CallToolResult.fromContent(
         content: [
           TextContent(
             text: switch (operation) {

--- a/example/streamable_https/server_streamable_https.dart
+++ b/example/streamable_https/server_streamable_https.dart
@@ -72,7 +72,7 @@ McpServer getServer() {
     },
     callback: ({args, extra}) async {
       final name = args?['name'] as String? ?? 'world';
-      return CallToolResult(
+      return CallToolResult.fromContent(
         content: [
           TextContent(text: 'Hello, $name!'),
         ],
@@ -124,7 +124,7 @@ McpServer getServer() {
         data: 'Sending second greeting to $name',
       )));
 
-      return CallToolResult(
+      return CallToolResult.fromContent(
         content: [
           TextContent(text: 'Good morning, $name!'),
         ],
@@ -200,7 +200,7 @@ McpServer getServer() {
         await sleep(interval.toInt());
       }
 
-      return CallToolResult(
+      return CallToolResult.fromContent(
         content: [
           TextContent(
             text: 'Started sending periodic notifications every ${interval}ms',

--- a/example/weather.dart
+++ b/example/weather.dart
@@ -1,6 +1,7 @@
 // Dart porting of https://github.com/modelcontextprotocol/quickstart-resources/tree/main/weather-server-typescript
 import 'dart:convert';
 import 'dart:io';
+
 import 'package:mcp_dart/mcp_dart.dart';
 
 const String nwsApiBase = "https://api.weather.gov";
@@ -61,7 +62,7 @@ void main() async {
     callback: ({args, extra}) async {
       final state = (args?['state'] as String?)?.toUpperCase();
       if (state == null || state.length != 2) {
-        return CallToolResult(
+        return CallToolResult.fromContent(
           content: [TextContent(text: "Invalid state code provided.")],
           isError: true,
         );
@@ -71,14 +72,14 @@ void main() async {
       final alertsData = await makeNWSRequest(alertsUrl);
 
       if (alertsData == null) {
-        return CallToolResult(
+        return CallToolResult.fromContent(
           content: [TextContent(text: "Failed to retrieve alerts data.")],
         );
       }
 
       final features = alertsData['features'] as List<dynamic>? ?? [];
       if (features.isEmpty) {
-        return CallToolResult(
+        return CallToolResult.fromContent(
           content: [TextContent(text: "No active alerts for $state.")],
         );
       }
@@ -87,7 +88,9 @@ void main() async {
           features.map((feature) => formatAlert(feature)).join("\n");
       final alertsText = "Active alerts for $state:\n\n$formattedAlerts";
 
-      return CallToolResult(content: [TextContent(text: alertsText)]);
+      return CallToolResult.fromContent(
+        content: [TextContent(text: alertsText)],
+      );
     },
   );
 
@@ -107,7 +110,7 @@ void main() async {
       final longitude = args?['longitude'] as num?;
 
       if (latitude == null || longitude == null) {
-        return CallToolResult(
+        return CallToolResult.fromContent(
           content: [TextContent(text: "Invalid latitude or longitude.")],
           isError: true,
         );
@@ -118,7 +121,7 @@ void main() async {
       final pointsData = await makeNWSRequest(pointsUrl);
 
       if (pointsData == null) {
-        return CallToolResult(
+        return CallToolResult.fromContent(
           content: [
             TextContent(
               text:
@@ -130,7 +133,7 @@ void main() async {
 
       final forecastUrl = pointsData['properties']?['forecast'] as String?;
       if (forecastUrl == null) {
-        return CallToolResult(
+        return CallToolResult.fromContent(
           content: [
             TextContent(
               text: "Failed to get forecast URL from grid point data.",
@@ -141,7 +144,7 @@ void main() async {
 
       final forecastData = await makeNWSRequest(forecastUrl);
       if (forecastData == null) {
-        return CallToolResult(
+        return CallToolResult.fromContent(
           content: [TextContent(text: "Failed to retrieve forecast data.")],
         );
       }
@@ -149,7 +152,7 @@ void main() async {
       final periods =
           forecastData['properties']?['periods'] as List<dynamic>? ?? [];
       if (periods.isEmpty) {
-        return CallToolResult(
+        return CallToolResult.fromContent(
           content: [TextContent(text: "No forecast periods available.")],
         );
       }
@@ -168,7 +171,9 @@ void main() async {
       final forecastText =
           "Forecast for $latitude, $longitude:\n\n$formattedForecast";
 
-      return CallToolResult(content: [TextContent(text: forecastText)]);
+      return CallToolResult.fromContent(
+        content: [TextContent(text: forecastText)],
+      );
     },
   );
 

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1912,6 +1912,11 @@ class CallToolResult implements BaseResultData {
   @override
   final Map<String, dynamic>? meta;
 
+  @Deprecated(
+      'This constructor is replaced by the fromContent factory constructor and may be removed in a future version.')
+  CallToolResult({required this.content, this.isError, this.meta})
+      : structuredContent = {};
+
   CallToolResult.fromContent({required this.content, this.isError, this.meta})
       : structuredContent = {};
 

--- a/test/client/client_test.dart
+++ b/test/client/client_test.dart
@@ -1,8 +1,9 @@
-import 'package:test/test.dart';
+import 'dart:async';
+
 import 'package:mcp_dart/src/client/client.dart';
 import 'package:mcp_dart/src/shared/transport.dart';
 import 'package:mcp_dart/src/types.dart';
-import 'dart:async';
+import 'package:test/test.dart';
 
 void main() {
   group('Client', () {
@@ -498,7 +499,7 @@ class MockTransport extends Transport {
         final content = [TextContent(text: "Tool result")];
         onmessage!(JsonRpcResponse(
           id: message.id,
-          result: CallToolResult(content: content).toJson(),
+          result: CallToolResult.fromContent(content: content).toJson(),
         ));
       }
     } else if (message is JsonRpcRequest && message.method == 'prompts/get') {


### PR DESCRIPTION
### Background
This is a proposed implementation for output schema / structured content as documented in the spec here:

https://modelcontextprotocol.io/specification/draft/server/tools#output-schema

This would resolve #30.

### Implementation
I followed a similar pattern to the official typescript implementation here:

https://github.com/modelcontextprotocol/modelcontextprotocol/pull/371

Specifically, the original `CallToolResult` constructor has been changed to a factory method `CallToolResult.fromContent` and a new factory method was added `CallToolResult.fromStructuredContent`. The `fromStructuredContent` method has an optional parameter named `unstructuredFallback` that allows the developer to pass regular content for backwards compatibility with servers that do not support structured content. If this parameter is not specified, the default is to not include any fallback content. 

### Notes on Unstructured Fallback
If fallback content is specified, the spec recommends it be equivalent to the structured content. I had originally set this fallback to be a `TextContent` with the json string of the structured output, but that caused the whole payload to practically double in size. Instead, I decided to allow the developer to choose their own unstructured fallback.

### Notes on Compatibility
I didn't realize until after implementing this that structured output is still a draft part of the specification. As of 2025-05-19, Claude Desktop doesn't support this part of the spec (though other servers and clients do). Therefore, if you are currently working with Claude it's recommended to either stick with unstructured outputs or use structured outputs with unstructured fallback.

For more information, see:
https://www.reddit.com/r/mcp/comments/1kq3xyl/claude_for_desktop_issues_with_outputschema/