### PR TITLE
Preserve required fields in ToolInputSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+- Preserve required fields in ToolInputSchema
+
 ## 0.5.1
 
 - Add support for OutputScheme (<https://modelcontextprotocol.io/specification/draft/server/tools#output-schema>)

--- a/example/iostream-client-server/simple.dart
+++ b/example/iostream-client-server/simple.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:mcp_dart/mcp_dart.dart';
 import 'server_iostream.dart';
+
 /// Creates and returns a client with custom stream transport connected to a server.
 Future<void> main() async {
   // Create a client
@@ -15,7 +16,7 @@ Future<void> main() async {
   // Create custom streams for transport
   final serverToClientStreamController = StreamController<List<int>>();
   final clientToServerStreamController = StreamController<List<int>>();
-  
+
   // Create transport using custom streams
   final clientTransport = IOStreamTransport(
     stream: serverToClientStreamController.stream,

--- a/example/required_fields_demo.dart
+++ b/example/required_fields_demo.dart
@@ -1,0 +1,114 @@
+import 'package:mcp_dart/mcp_dart.dart';
+
+void main() {
+  // Create a tool with required fields - this simulates what an MCP server would send
+  final calculatorTool = Tool(
+    name: 'calculate',
+    description: 'Performs mathematical calculations',
+    inputSchema: ToolInputSchema(
+      properties: {
+        'operation': {
+          'type': 'string',
+          'enum': ['add', 'subtract', 'multiply', 'divide'],
+          'description': 'The mathematical operation to perform'
+        },
+        'a': {'type': 'number', 'description': 'First number'},
+        'b': {'type': 'number', 'description': 'Second number'},
+        'precision': {
+          'type': 'integer',
+          'description': 'Number of decimal places (optional)',
+          'default': 2
+        }
+      },
+      required: ['operation', 'a', 'b'], // ← This is now preserved!
+    ),
+    outputSchema: ToolOutputSchema(
+      properties: {
+        'result': {'type': 'number', 'description': 'The calculation result'},
+        'equation': {
+          'type': 'string',
+          'description': 'The equation that was calculated'
+        }
+      },
+      required: ['result'], // ← Output required fields also preserved!
+    ),
+  );
+
+  print('=== MCP Tool Schema Demo ===');
+  print('Tool: ${calculatorTool.name}');
+  print('Description: ${calculatorTool.description}');
+
+  // Serialize to JSON (what MCP client receives)
+  final toolJson = calculatorTool.toJson();
+  print('\n=== Serialized Tool JSON ===');
+  print('Input required fields: ${toolJson['inputSchema']['required']}');
+  print('Output required fields: ${toolJson['outputSchema']['required']}');
+
+  // This demonstrates the fix - required fields are preserved in JSON
+  print('\n=== Full Input Schema ===');
+  final inputSchema = toolJson['inputSchema'] as Map<String, dynamic>;
+  print('Type: ${inputSchema['type']}');
+  print('Required: ${inputSchema['required']}');
+  print('Properties: ${(inputSchema['properties'] as Map).keys.join(', ')}');
+
+  // Deserialize back from JSON (roundtrip test)
+  final deserializedTool = Tool.fromJson(toolJson);
+  print('\n=== Roundtrip Test ===');
+  print('Original required: ${calculatorTool.inputSchema.required}');
+  print('Deserialized required: ${deserializedTool.inputSchema.required}');
+  print(
+      'Match: ${_listsEqual(calculatorTool.inputSchema.required, deserializedTool.inputSchema.required)}');
+
+  // Convert to OpenAI function calling format
+  print('\n=== OpenAI Function Format ===');
+  final openaiFunction = <String, dynamic>{
+    'type': 'function',
+    'function': <String, dynamic>{
+      'name': calculatorTool.name,
+      'description': calculatorTool.description,
+      'parameters': calculatorTool.inputSchema.toJson(),
+    }
+  };
+
+  final functionObj = openaiFunction['function'] as Map<String, dynamic>;
+  final parameters = functionObj['parameters'] as Map<String, dynamic>;
+  print('Function name: ${functionObj['name']}');
+  print('Required parameters: ${parameters['required']}');
+  print('✓ Ready for LLM integration!');
+
+  // Convert to Anthropic Claude format
+  print('\n=== Anthropic Claude Format ===');
+  final anthropicTool = <String, dynamic>{
+    'name': calculatorTool.name,
+    'description': calculatorTool.description,
+    'input_schema': calculatorTool.inputSchema.toJson(),
+  };
+
+  final claudeSchema = anthropicTool['input_schema'] as Map<String, dynamic>;
+  print('Tool name: ${anthropicTool['name']}');
+  print('Required parameters: ${claudeSchema['required']}');
+  print('✓ Ready for Claude integration!');
+
+  // Simulate a real MCP server response
+  print('\n=== Simulated MCP Server Response ===');
+  final listToolsResult = ListToolsResult(tools: [calculatorTool]);
+  final serverResponse = listToolsResult.toJson();
+
+  print('Server response preserves required fields:');
+  final tools = serverResponse['tools'] as List;
+  final firstTool = tools[0] as Map<String, dynamic>;
+  final firstToolInputSchema = firstTool['inputSchema'] as Map<String, dynamic>;
+  print('  Tool: ${firstTool['name']}');
+  print('  Required: ${firstToolInputSchema['required']}');
+  print('✓ MCP server integration works!');
+}
+
+bool _listsEqual(List<String>? a, List<String>? b) {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  if (a.length != b.length) return false;
+  for (int i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1626,19 +1626,25 @@ class ToolInputSchema {
   /// JSON Schema properties definition.
   final Map<String, dynamic>? properties;
 
+  /// List of required property names.
+  final List<String>? required;
+
   const ToolInputSchema({
     this.properties,
+    this.required,
   });
 
   factory ToolInputSchema.fromJson(Map<String, dynamic> json) {
     return ToolInputSchema(
       properties: json['properties'] as Map<String, dynamic>?,
+      required: (json['required'] as List<dynamic>?)?.cast<String>(),
     );
   }
 
   Map<String, dynamic> toJson() => {
         'type': type,
         if (properties != null) 'properties': properties,
+        if (required != null && required!.isNotEmpty) 'required': required,
       };
 }
 
@@ -1650,19 +1656,25 @@ class ToolOutputSchema {
   /// JSON Schema properties definition.
   final Map<String, dynamic>? properties;
 
+  /// List of required property names.
+  final List<String>? required;
+
   const ToolOutputSchema({
     this.properties,
+    this.required,
   });
 
   factory ToolOutputSchema.fromJson(Map<String, dynamic> json) {
     return ToolOutputSchema(
       properties: json['properties'] as Map<String, dynamic>?,
+      required: (json['required'] as List<dynamic>?)?.cast<String>(),
     );
   }
 
   Map<String, dynamic> toJson() => {
         'type': type,
         if (properties != null) 'properties': properties,
+        if (required != null && required!.isNotEmpty) 'required': required,
       };
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mcp_dart
 description: Dart Implementation of Model Context Protocol (MCP) SDK.
-version: 0.5.1
+version: 0.5.2
 repository: https://github.com/leehack/mcp_dart
 
 environment:

--- a/test/server/iostream_test.dart
+++ b/test/server/iostream_test.dart
@@ -10,11 +10,11 @@ void main() {
     // Stream controllers for direct communication
     late StreamController<List<int>> clientToServerController;
     late StreamController<List<int>> serverToClientController;
-    
+
     // Client and server transports
     late IOStreamTransport clientTransport;
     late IOStreamTransport serverTransport;
-    
+
     // Test state management
     late Completer<void> serverCloseCompleter;
     late Completer<void> clientCloseCompleter;
@@ -22,23 +22,23 @@ void main() {
     late Completer<Error> clientErrorCompleter;
     final List<JsonRpcMessage> serverReceivedMessages = [];
     final List<JsonRpcMessage> clientReceivedMessages = [];
-    
+
     setUp(() {
       // Create fresh stream controllers for each test
       clientToServerController = StreamController<List<int>>.broadcast();
       serverToClientController = StreamController<List<int>>.broadcast();
-      
+
       // Set up transports
       clientTransport = IOStreamTransport(
         stream: serverToClientController.stream,
         sink: clientToServerController.sink,
       );
-      
+
       serverTransport = IOStreamTransport(
         stream: clientToServerController.stream,
         sink: serverToClientController.sink,
       );
-      
+
       // Reset state tracking
       serverCloseCompleter = Completer<void>();
       clientCloseCompleter = Completer<void>();
@@ -46,41 +46,41 @@ void main() {
       clientErrorCompleter = Completer<Error>();
       serverReceivedMessages.clear();
       clientReceivedMessages.clear();
-      
+
       // Configure callbacks
       serverTransport.onclose = () {
         if (!serverCloseCompleter.isCompleted) {
           serverCloseCompleter.complete();
         }
       };
-      
+
       serverTransport.onerror = (error) {
         if (!serverErrorCompleter.isCompleted) {
           serverErrorCompleter.complete(error);
         }
       };
-      
+
       serverTransport.onmessage = (message) {
         serverReceivedMessages.add(message);
       };
-      
+
       clientTransport.onclose = () {
         if (!clientCloseCompleter.isCompleted) {
           clientCloseCompleter.complete();
         }
       };
-      
+
       clientTransport.onerror = (error) {
         if (!clientErrorCompleter.isCompleted) {
           clientErrorCompleter.complete(error);
         }
       };
-      
+
       clientTransport.onmessage = (message) {
         clientReceivedMessages.add(message);
       };
     });
-    
+
     tearDown(() async {
       // Clean up resources
       await clientTransport.close();
@@ -88,28 +88,29 @@ void main() {
       await clientToServerController.close();
       await serverToClientController.close();
     });
-    
+
     // Helper to send a properly formatted message directly to a stream controller
-    void sendRawJsonMessage(StreamController<List<int>> controller, JsonRpcMessage message) {
+    void sendRawJsonMessage(
+        StreamController<List<int>> controller, JsonRpcMessage message) {
       final jsonString = "${jsonEncode(message.toJson())}\n";
       controller.add(utf8.encode(jsonString));
     }
-    
+
     test('Transports start without errors', () async {
       await serverTransport.start();
       await clientTransport.start();
-      
+
       expect(serverCloseCompleter.isCompleted, isFalse);
       expect(clientCloseCompleter.isCompleted, isFalse);
       expect(serverErrorCompleter.isCompleted, isFalse);
       expect(clientErrorCompleter.isCompleted, isFalse);
     });
-    
+
     test('Basic message passing - client to server', () async {
       // Start both sides
       await serverTransport.start();
       await clientTransport.start();
-      
+
       // Setup a completer for server message receipt
       final messageReceived = Completer<JsonRpcMessage>();
       serverTransport.onmessage = (message) {
@@ -118,27 +119,27 @@ void main() {
           messageReceived.complete(message);
         }
       };
-      
+
       // Send a message via the raw controller (bypassing transport.send())
       final pingMessage = JsonRpcPingRequest(id: 1);
       sendRawJsonMessage(clientToServerController, pingMessage);
-      
+
       // Wait for the message to be received
       final receivedMessage = await messageReceived.future.timeout(
         const Duration(seconds: 2),
         onTimeout: () => throw TimeoutException('Message not received'),
       );
-      
+
       // Verify correct message received
       expect(receivedMessage, isA<JsonRpcPingRequest>());
       expect((receivedMessage as JsonRpcPingRequest).id, 1);
     });
-    
+
     test('Basic message passing - server to client', () async {
       // Start both sides
       await serverTransport.start();
       await clientTransport.start();
-      
+
       // Setup a completer for client message receipt
       final messageReceived = Completer<JsonRpcMessage>();
       clientTransport.onmessage = (message) {
@@ -147,71 +148,73 @@ void main() {
           messageReceived.complete(message);
         }
       };
-      
+
       // Send a message from server to client
       final pingMessage = JsonRpcPingRequest(id: 2);
       sendRawJsonMessage(serverToClientController, pingMessage);
-      
+
       // Wait for the message to be received
       final receivedMessage = await messageReceived.future.timeout(
         const Duration(seconds: 2),
         onTimeout: () => throw TimeoutException('Message not received'),
       );
-      
+
       // Verify correct message received
       expect(receivedMessage, isA<JsonRpcPingRequest>());
       expect((receivedMessage as JsonRpcPingRequest).id, 2);
     });
-    
+
     test('Bidirectional communication', () async {
       // Start both sides
       await serverTransport.start();
       await clientTransport.start();
-      
+
       // Setup completers for message receipt
       final serverReceived = Completer<JsonRpcMessage>();
       final clientReceived = Completer<JsonRpcMessage>();
-      
+
       serverTransport.onmessage = (message) {
         serverReceivedMessages.add(message);
         if (!serverReceived.isCompleted) {
           serverReceived.complete(message);
         }
       };
-      
+
       clientTransport.onmessage = (message) {
         clientReceivedMessages.add(message);
         if (!clientReceived.isCompleted) {
           clientReceived.complete(message);
         }
       };
-      
+
       // Send client -> server
       sendRawJsonMessage(clientToServerController, JsonRpcPingRequest(id: 3));
-      
+
       // Send server -> client
       sendRawJsonMessage(serverToClientController, JsonRpcPingRequest(id: 4));
-      
+
       // Wait for both messages to be received
-      final serverMsg = await serverReceived.future.timeout(const Duration(seconds: 2));
-      final clientMsg = await clientReceived.future.timeout(const Duration(seconds: 2));
-      
+      final serverMsg =
+          await serverReceived.future.timeout(const Duration(seconds: 2));
+      final clientMsg =
+          await clientReceived.future.timeout(const Duration(seconds: 2));
+
       // Verify both messages
       expect(serverMsg, isA<JsonRpcPingRequest>());
       expect((serverMsg as JsonRpcPingRequest).id, 3);
-      
+
       expect(clientMsg, isA<JsonRpcPingRequest>());
       expect((clientMsg as JsonRpcPingRequest).id, 4);
     });
-    
+
     test('Multiple messages can be sent and received', () async {
       await serverTransport.start();
       await clientTransport.start();
-      
+
       const expectedMessageCount = 5;
       final receivedMessages = <JsonRpcMessage>[];
       final allMessagesReceived = Completer<void>();
-      
+
       serverTransport.onmessage = (message) {
         receivedMessages.add(message);
         if (receivedMessages.length >= expectedMessageCount) {
@@ -220,58 +223,57 @@ void main() {
           }
         }
       };
-      
+
       // Send multiple messages
       for (int i = 0; i < expectedMessageCount; i++) {
         sendRawJsonMessage(clientToServerController, JsonRpcPingRequest(id: i));
         // Add a small delay to avoid overwhelming the stream
         await Future.delayed(const Duration(milliseconds: 10));
       }
-      
+
       // Wait for all messages to be received
       await allMessagesReceived.future.timeout(const Duration(seconds: 5));
-      
+
       // Verify messages received
       expect(receivedMessages.length, expectedMessageCount);
-      
+
       // Check all expected IDs are present
-      final receivedIds = receivedMessages
-          .map((msg) => (msg as JsonRpcPingRequest).id)
-          .toSet();
-      
+      final receivedIds =
+          receivedMessages.map((msg) => (msg as JsonRpcPingRequest).id).toSet();
+
       for (int i = 0; i < expectedMessageCount; i++) {
         expect(receivedIds, contains(i));
       }
     });
-    
+
     test('Transport closes when input stream closes', () async {
       await serverTransport.start();
-      
+
       // Close the client-to-server controller
       await clientToServerController.close();
-      
+
       // Wait for server transport to close
       await serverCloseCompleter.future.timeout(
         const Duration(seconds: 2),
         onTimeout: () => throw TimeoutException('Transport not closed'),
       );
     });
-    
+
     test('Transport handles invalid JSON gracefully', () async {
       await serverTransport.start();
-      
+
       // Send invalid JSON data
       clientToServerController.add(utf8.encode('not valid json\n'));
-      
+
       // Wait for error to be reported
       final error = await serverErrorCompleter.future.timeout(
         const Duration(seconds: 2),
         onTimeout: () => throw TimeoutException('Error not reported'),
       );
-      
+
       // Verify error was reported but transport still works
       expect(error.toString(), contains('Invalid JSON'));
-      
+
       // Set up a completer for subsequent valid message
       final validMessageReceived = Completer<JsonRpcMessage>();
       serverTransport.onmessage = (message) {
@@ -280,42 +282,43 @@ void main() {
           validMessageReceived.complete(message);
         }
       };
-      
+
       // Send a valid message
       sendRawJsonMessage(clientToServerController, JsonRpcPingRequest(id: 7));
-      
+
       // Wait for valid message to be received
       final validMessage = await validMessageReceived.future.timeout(
         const Duration(seconds: 2),
-        onTimeout: () => throw TimeoutException('Valid message not received after error'),
+        onTimeout: () =>
+            throw TimeoutException('Valid message not received after error'),
       );
-      
+
       // Verify message received correctly
       expect(validMessage, isA<JsonRpcPingRequest>());
       expect((validMessage as JsonRpcPingRequest).id, 7);
     });
-    
+
     test('Cannot start transport twice', () async {
       await serverTransport.start();
-      
+
       // Attempt to start again should throw
       expect(() => serverTransport.start(), throwsA(isA<StateError>()));
     });
-    
+
     test('Cannot send messages after transport is closed', () async {
       await serverTransport.start();
       await serverTransport.close();
-      
+
       // Attempt to send message from closed transport should throw
       expect(
         () => serverTransport.send(JsonRpcPingRequest(id: 8)),
         throwsA(isA<StateError>()),
       );
     });
-    
+
     test('Partial JSON messages are buffered until complete', () async {
       await serverTransport.start();
-      
+
       // Setup a completer for message receipt
       final messageReceived = Completer<JsonRpcMessage>();
       serverTransport.onmessage = (message) {
@@ -324,85 +327,86 @@ void main() {
           messageReceived.complete(message);
         }
       };
-      
+
       // Create a message and encode it
       final message = JsonRpcPingRequest(id: 9);
       final jsonString = "${jsonEncode(message.toJson())}\n";
       final bytes = utf8.encode(jsonString);
-      
+
       // Split the message into multiple parts
       final partOne = bytes.sublist(0, bytes.length ~/ 2);
       final partTwo = bytes.sublist(bytes.length ~/ 2);
-      
+
       // Send first part and check no message is received yet
       clientToServerController.add(partOne);
       await Future.delayed(const Duration(milliseconds: 50));
       expect(serverReceivedMessages.isEmpty, isTrue);
-      
+
       // Send second part and wait for complete message
       clientToServerController.add(partTwo);
       final receivedMessage = await messageReceived.future.timeout(
         const Duration(seconds: 2),
-        onTimeout: () => throw TimeoutException('Complete message not received'),
+        onTimeout: () =>
+            throw TimeoutException('Complete message not received'),
       );
-      
+
       // Verify message was received correctly
       expect(receivedMessage, isA<JsonRpcPingRequest>());
       expect((receivedMessage as JsonRpcPingRequest).id, 9);
     });
-    
+
     test('Error in onmessage handler is caught and reported', () async {
       await serverTransport.start();
-      
+
       // Set up a completer to capture the reported error
       final errorReported = Completer<Error>();
-      
+
       // Set up an onmessage handler that throws an error
       serverTransport.onmessage = (message) {
         throw StateError('Intentional error in onmessage handler');
       };
-      
+
       // Set up an onerror handler to capture the error
       serverTransport.onerror = (error) {
         if (!errorReported.isCompleted) {
           errorReported.complete(error);
         }
       };
-      
+
       // Send a message to trigger the error
       sendRawJsonMessage(clientToServerController, JsonRpcPingRequest(id: 10));
-      
+
       // Wait for the error to be reported
       final reportedError = await errorReported.future.timeout(
         const Duration(seconds: 2),
         onTimeout: () => throw TimeoutException('Error not reported'),
       );
-      
+
       // Verify the error was reported with the correct message
       expect(reportedError, isA<StateError>());
       expect(reportedError.toString(), contains('onmessage handler'));
     });
-    
+
     test('Error in onerror handler is handled gracefully', () async {
       await serverTransport.start();
-      
+
       // Set up an onerror handler that throws another error
       serverTransport.onerror = (error) {
         throw StateError('Intentional error in onerror handler');
       };
-      
+
       // Send invalid JSON data to trigger an error
       clientToServerController.add(utf8.encode('invalid json\n'));
-      
+
       // Wait a moment to allow error processing
       await Future.delayed(const Duration(milliseconds: 100));
-      
+
       // We can't easily assert what happens here, but the transport should remain functional
       // and not crash. Let's send another valid message and make sure it works.
-      
+
       // Reset the onerror handler so it doesn't throw again
       serverTransport.onerror = null;
-      
+
       // Set up a completer for subsequent valid message
       final validMessageReceived = Completer<JsonRpcMessage>();
       serverTransport.onmessage = (message) {
@@ -411,46 +415,47 @@ void main() {
           validMessageReceived.complete(message);
         }
       };
-      
+
       // Send a valid message
       sendRawJsonMessage(clientToServerController, JsonRpcPingRequest(id: 11));
-      
+
       // Wait for valid message to be received, showing transport still works
       final validMessage = await validMessageReceived.future.timeout(
         const Duration(seconds: 2),
-        onTimeout: () => throw TimeoutException('Valid message not received after error'),
+        onTimeout: () =>
+            throw TimeoutException('Valid message not received after error'),
       );
-      
+
       // Verify message received correctly
       expect(validMessage, isA<JsonRpcPingRequest>());
       expect((validMessage as JsonRpcPingRequest).id, 11);
     });
-    
+
     test('Transport handles incomplete message at end of stream', () async {
       await serverTransport.start();
-      
+
       // Create a message but don't add the newline terminator
       final message = JsonRpcPingRequest(id: 12);
       final jsonString = jsonEncode(message.toJson()); // No newline at the end
-      
+
       // Send the incomplete message
       clientToServerController.add(utf8.encode(jsonString));
-      
+
       // Wait a moment to allow processing
       await Future.delayed(const Duration(milliseconds: 100));
-      
+
       // No message should be received since it's incomplete
       expect(serverReceivedMessages.isEmpty, isTrue);
-      
+
       // Now close the stream
       await clientToServerController.close();
-      
+
       // Wait for the transport to close
       await serverCloseCompleter.future.timeout(
         const Duration(seconds: 2),
         onTimeout: () => throw TimeoutException('Transport not closed'),
       );
-      
+
       // Verify no message was extracted from the incomplete data
       expect(serverReceivedMessages.isEmpty, isTrue);
     });

--- a/test/tool_schema_test.dart
+++ b/test/tool_schema_test.dart
@@ -1,0 +1,340 @@
+import 'package:mcp_dart/mcp_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tool Schema Required Fields Tests', () {
+    test('ToolInputSchema preserves required fields during serialization', () {
+      final schema = ToolInputSchema(
+        properties: {
+          'operation': {'type': 'string'},
+          'a': {'type': 'number'},
+          'b': {'type': 'number'},
+        },
+        required: ['operation', 'a'],
+      );
+
+      final json = schema.toJson();
+      expect(json['type'], equals('object'));
+      expect(json['properties'], isA<Map<String, dynamic>>());
+      expect(json['required'], equals(['operation', 'a']));
+    });
+
+    test('ToolInputSchema preserves required fields during deserialization',
+        () {
+      final json = {
+        'type': 'object',
+        'properties': {
+          'operation': {'type': 'string'},
+          'a': {'type': 'number'},
+          'b': {'type': 'number'},
+        },
+        'required': ['operation', 'a'],
+      };
+
+      final schema = ToolInputSchema.fromJson(json);
+      expect(schema.type, equals('object'));
+      expect(schema.properties, equals(json['properties']));
+      expect(schema.required, equals(['operation', 'a']));
+    });
+
+    test('ToolInputSchema handles empty required array', () {
+      final schema = ToolInputSchema(
+        properties: {
+          'optional': {'type': 'string'}
+        },
+        required: [],
+      );
+
+      final json = schema.toJson();
+      // Empty required array should not be included in JSON
+      expect(json.containsKey('required'), isFalse);
+    });
+
+    test('ToolInputSchema handles null required field', () {
+      final schema = ToolInputSchema(
+        properties: {
+          'optional': {'type': 'string'}
+        },
+        required: null,
+      );
+
+      final json = schema.toJson();
+      expect(json.containsKey('required'), isFalse);
+    });
+
+    test('ToolOutputSchema preserves required fields during serialization', () {
+      final schema = ToolOutputSchema(
+        properties: {
+          'result': {'type': 'string'},
+          'status': {'type': 'number'},
+        },
+        required: ['result'],
+      );
+
+      final json = schema.toJson();
+      expect(json['type'], equals('object'));
+      expect(json['properties'], isA<Map<String, dynamic>>());
+      expect(json['required'], equals(['result']));
+    });
+
+    test('ToolOutputSchema preserves required fields during deserialization',
+        () {
+      final json = {
+        'type': 'object',
+        'properties': {
+          'result': {'type': 'string'},
+          'status': {'type': 'number'},
+        },
+        'required': ['result'],
+      };
+
+      final schema = ToolOutputSchema.fromJson(json);
+      expect(schema.type, equals('object'));
+      expect(schema.properties, equals(json['properties']));
+      expect(schema.required, equals(['result']));
+    });
+
+    test('Tool preserves input schema required fields end-to-end', () {
+      final tool = Tool(
+        name: 'calculate',
+        description: 'Performs mathematical calculations',
+        inputSchema: ToolInputSchema(
+          properties: {
+            'operation': {'type': 'string'},
+            'a': {'type': 'number'},
+            'b': {'type': 'number'},
+          },
+          required: ['operation', 'a'],
+        ),
+      );
+
+      final json = tool.toJson();
+      expect(json['name'], equals('calculate'));
+      expect(json['inputSchema']['required'], equals(['operation', 'a']));
+
+      final deserialized = Tool.fromJson(json);
+      expect(deserialized.name, equals('calculate'));
+      expect(deserialized.inputSchema.required, equals(['operation', 'a']));
+    });
+
+    test('Tool preserves output schema required fields end-to-end', () {
+      final tool = Tool(
+        name: 'calculate',
+        inputSchema: ToolInputSchema(),
+        outputSchema: ToolOutputSchema(
+          properties: {
+            'result': {'type': 'number'},
+            'equation': {'type': 'string'},
+          },
+          required: ['result'],
+        ),
+      );
+
+      final json = tool.toJson();
+      expect(json['outputSchema']['required'], equals(['result']));
+
+      final deserialized = Tool.fromJson(json);
+      expect(deserialized.outputSchema?.required, equals(['result']));
+    });
+
+    test('ListToolsResult preserves tool required fields', () {
+      final tools = [
+        Tool(
+          name: 'search',
+          inputSchema: ToolInputSchema(
+            properties: {
+              'query': {'type': 'string'},
+              'limit': {'type': 'number'},
+            },
+            required: ['query'],
+          ),
+        ),
+        Tool(
+          name: 'create',
+          inputSchema: ToolInputSchema(
+            properties: {
+              'name': {'type': 'string'},
+              'data': {'type': 'object'},
+            },
+            required: ['name', 'data'],
+          ),
+        ),
+      ];
+
+      final result = ListToolsResult(tools: tools);
+      final json = result.toJson();
+
+      expect(json['tools'][0]['inputSchema']['required'], equals(['query']));
+      expect(json['tools'][1]['inputSchema']['required'],
+          equals(['name', 'data']));
+
+      final deserialized = ListToolsResult.fromJson(json);
+      expect(deserialized.tools[0].inputSchema.required, equals(['query']));
+      expect(
+          deserialized.tools[1].inputSchema.required, equals(['name', 'data']));
+    });
+
+    test('Real-world MCP server tool schema example', () {
+      // Example from a real MCP server like Hugging Face
+      final serverResponse = {
+        'tools': [
+          {
+            'name': 'space_search',
+            'description': 'Search for Hugging Face Spaces',
+            'inputSchema': {
+              'type': 'object',
+              'properties': {
+                'query': {
+                  'type': 'string',
+                  'description': 'Search query for spaces'
+                },
+                'limit': {
+                  'type': 'integer',
+                  'description': 'Maximum number of results',
+                  'default': 10
+                }
+              },
+              'required': ['query']
+            }
+          }
+        ]
+      };
+
+      final result = ListToolsResult.fromJson(serverResponse);
+      final tool = result.tools.first;
+
+      expect(tool.name, equals('space_search'));
+      expect(tool.inputSchema.required, equals(['query']));
+      expect(tool.inputSchema.properties?['query']?['type'], equals('string'));
+      expect(tool.inputSchema.properties?['limit']?['default'], equals(10));
+
+      // Verify round-trip maintains required fields
+      final serialized = result.toJson();
+      expect(
+          serialized['tools'][0]['inputSchema']['required'], equals(['query']));
+    });
+
+    test('Backward compatibility with existing code without required fields',
+        () {
+      // Existing code that doesn't specify required fields should still work
+      final tool = Tool(
+        name: 'legacy-tool',
+        inputSchema: ToolInputSchema(
+          properties: {
+            'param': {'type': 'string'}
+          },
+        ),
+      );
+
+      final json = tool.toJson();
+      expect(json['name'], equals('legacy-tool'));
+      expect(json['inputSchema'].containsKey('required'), isFalse);
+
+      final deserialized = Tool.fromJson(json);
+      expect(deserialized.name, equals('legacy-tool'));
+      expect(deserialized.inputSchema.required, isNull);
+    });
+
+    test('JSON Schema from external server without required fields', () {
+      // Some servers might not include required fields
+      final externalToolJson = {
+        'name': 'external-tool',
+        'inputSchema': {
+          'type': 'object',
+          'properties': {
+            'param': {'type': 'string'}
+          },
+          // No 'required' field
+        },
+      };
+
+      final tool = Tool.fromJson(externalToolJson);
+      expect(tool.name, equals('external-tool'));
+      expect(tool.inputSchema.required, isNull);
+
+      // Should still serialize correctly
+      final serialized = tool.toJson();
+      expect(serialized['inputSchema'].containsKey('required'), isFalse);
+    });
+  });
+
+  group('LLM Integration Tests', () {
+    test('Tool schema is compatible with OpenAI function calling format', () {
+      final tool = Tool(
+        name: 'get_weather',
+        description: 'Get weather information for a location',
+        inputSchema: ToolInputSchema(
+          properties: {
+            'location': {
+              'type': 'string',
+              'description': 'The city and state, e.g. San Francisco, CA'
+            },
+            'unit': {
+              'type': 'string',
+              'enum': ['celsius', 'fahrenheit'],
+              'description': 'Temperature unit'
+            }
+          },
+          required: ['location'],
+        ),
+      );
+
+      // Convert to OpenAI function calling format
+      final openaiFunction = {
+        'type': 'function',
+        'function': {
+          'name': tool.name,
+          'description': tool.description,
+          'parameters': tool.inputSchema.toJson(),
+        }
+      };
+
+      final function = openaiFunction['function'] as Map<String, dynamic>;
+      final parameters = function['parameters'] as Map<String, dynamic>;
+      final properties = parameters['properties'] as Map<String, dynamic>;
+      final location = properties['location'] as Map<String, dynamic>;
+
+      expect(function['name'], equals('get_weather'));
+      expect(parameters['type'], equals('object'));
+      expect(parameters['required'], equals(['location']));
+      expect(location['type'], equals('string'));
+    });
+
+    test('Tool schema is compatible with Anthropic Claude format', () {
+      final tool = Tool(
+        name: 'analyze_code',
+        description: 'Analyze code for potential issues',
+        inputSchema: ToolInputSchema(
+          properties: {
+            'code': {'type': 'string', 'description': 'The code to analyze'},
+            'language': {
+              'type': 'string',
+              'description': 'Programming language'
+            },
+            'strict': {
+              'type': 'boolean',
+              'description': 'Enable strict mode',
+              'default': false
+            }
+          },
+          required: ['code', 'language'],
+        ),
+      );
+
+      // Convert to Anthropic tool format
+      final anthropicTool = {
+        'name': tool.name,
+        'description': tool.description,
+        'input_schema': tool.inputSchema.toJson(),
+      };
+
+      expect(anthropicTool['name'], equals('analyze_code'));
+      final inputSchema = anthropicTool['input_schema'] as Map<String, dynamic>;
+      final properties = inputSchema['properties'] as Map<String, dynamic>;
+      final strict = properties['strict'] as Map<String, dynamic>;
+
+      expect(inputSchema['required'], equals(['code', 'language']));
+      expect(strict['default'], equals(false));
+    });
+  });
+}


### PR DESCRIPTION
The mcp_dart package was dropping required field information from tool schemas during type conversion, causing LLM integrations to fail. This fix preserves the `required` array from JSON Schema in both `ToolInputSchema` and `ToolOutputSchema` classes.