### PR TITLE
Add required field for tool input schema for server

### DIFF
--- a/example/iostream-client-server/server_iostream.dart
+++ b/example/iostream-client-server/server_iostream.dart
@@ -11,14 +11,17 @@ Future<McpServer> getServer() async {
   mcpServer.tool(
     "calculate",
     description: 'Perform basic arithmetic operations',
-    inputSchemaProperties: {
-      'operation': {
-        'type': 'string',
-        'enum': ['add', 'subtract', 'multiply', 'divide'],
+    toolInputSchema: ToolInputSchema(
+      properties: {
+        'operation': {
+          'type': 'string',
+          'enum': ['add', 'subtract', 'multiply', 'divide'],
+        },
+        'a': {'type': 'number'},
+        'b': {'type': 'number'},
       },
-      'a': {'type': 'number'},
-      'b': {'type': 'number'},
-    },
+      required: ['operation', 'a', 'b'],
+    ),
     callback: ({args, extra}) async {
       final operation = args!['operation'];
       final a = args['a'];

--- a/example/server_sse.dart
+++ b/example/server_sse.dart
@@ -11,14 +11,17 @@ Future<void> main() async {
   mcpServer.tool(
     "calculate",
     description: 'Perform basic arithmetic operations',
-    inputSchemaProperties: {
-      'operation': {
-        'type': 'string',
-        'enum': ['add', 'subtract', 'multiply', 'divide'],
+    toolInputSchema: ToolInputSchema(
+      properties: {
+        'operation': {
+          'type': 'string',
+          'enum': ['add', 'subtract', 'multiply', 'divide'],
+        },
+        'a': {'type': 'number'},
+        'b': {'type': 'number'},
       },
-      'a': {'type': 'number'},
-      'b': {'type': 'number'},
-    },
+      required: ['operation', 'a', 'b'],
+    ),
     callback: ({args, extra}) async {
       final operation = args!['operation'];
       final a = args['a'];

--- a/example/server_stdio.dart
+++ b/example/server_stdio.dart
@@ -15,14 +15,17 @@ void main() async {
   server.tool(
     'calculate',
     description: 'Perform basic arithmetic operations',
-    inputSchemaProperties: {
-      'operation': {
-        'type': 'string',
-        'enum': ['add', 'subtract', 'multiply', 'divide'],
+    toolInputSchema: ToolInputSchema(
+      properties: {
+        'operation': {
+          'type': 'string',
+          'enum': ['add', 'subtract', 'multiply', 'divide'],
+        },
+        'a': {'type': 'number'},
+        'b': {'type': 'number'},
       },
-      'a': {'type': 'number'},
-      'b': {'type': 'number'},
-    },
+      required: ['operation', 'a', 'b'],
+    ),
     callback: ({args, extra}) async {
       final operation = args!['operation'];
       final a = args['a'];

--- a/example/streamable_https/server_streamable_https.dart
+++ b/example/streamable_https/server_streamable_https.dart
@@ -67,9 +67,15 @@ McpServer getServer() {
   server.tool(
     'greet',
     description: 'A simple greeting tool',
-    inputSchemaProperties: {
-      'name': {'type': 'string', 'description': 'Name to greet'},
-    },
+    toolInputSchema: ToolInputSchema(
+      properties: {
+        'name': {
+          'type': 'string',
+          'description': 'Name to greet',
+        },
+      },
+      required: ['name'],
+    ),
     callback: ({args, extra}) async {
       final name = args?['name'] as String? ?? 'world';
       return CallToolResult.fromContent(
@@ -85,9 +91,15 @@ McpServer getServer() {
     'multi-greet',
     description:
         'A tool that sends different greetings with delays between them',
-    inputSchemaProperties: {
-      'name': {'type': 'string', 'description': 'Name to greet'},
-    },
+    toolInputSchema: ToolInputSchema(
+      properties: {
+        'name': {
+          'type': 'string',
+          'description': 'Name to greet',
+        },
+      },
+      required: [],
+    ),
     annotations: ToolAnnotations(
       title: 'Multiple Greeting Tool',
       readOnlyHint: true,
@@ -162,18 +174,20 @@ McpServer getServer() {
     'start-notification-stream',
     description:
         'Starts sending periodic notifications for testing resumability',
-    inputSchemaProperties: {
-      'interval': {
-        'type': 'number',
-        'description': 'Interval in milliseconds between notifications',
-        'default': 100,
+    toolInputSchema: ToolInputSchema(
+      properties: {
+        'interval': {
+          'type': 'number',
+          'description': 'Interval in milliseconds between notifications',
+          'default': 100,
+        },
+        'count': {
+          'type': 'number',
+          'description': 'Number of notifications to send (0 for 100)',
+          'default': 50,
+        },
       },
-      'count': {
-        'type': 'number',
-        'description': 'Number of notifications to send (0 for 100)',
-        'default': 50,
-      },
-    },
+    ),
     callback: ({args, extra}) async {
       final interval = args?['interval'] as num? ?? 100;
       final count = args?['count'] as num? ?? 50;

--- a/example/weather.dart
+++ b/example/weather.dart
@@ -53,12 +53,15 @@ void main() async {
   server.tool(
     "get-alerts",
     description: "Get weather alerts for a state",
-    inputSchemaProperties: {
-      "state": {
-        "type": "string",
-        "description": "Two-letter state code (e.g. CA, NY)",
+    toolInputSchema: ToolInputSchema(
+      properties: {
+        "state": {
+          "type": "string",
+          "description": "Two-letter state code (e.g. CA, NY)",
+        },
       },
-    },
+      required: ["state"],
+    ),
     callback: ({args, extra}) async {
       final state = (args?['state'] as String?)?.toUpperCase();
       if (state == null || state.length != 2) {
@@ -98,13 +101,19 @@ void main() async {
   server.tool(
     "get-forecast",
     description: "Get weather forecast for a location",
-    inputSchemaProperties: {
-      "latitude": {"type": "number", "description": "Latitude of the location"},
-      "longitude": {
-        "type": "number",
-        "description": "Longitude of the location",
+    toolInputSchema: ToolInputSchema(
+      properties: {
+        "latitude": {
+          "type": "number",
+          "description": "Latitude of the location",
+        },
+        "longitude": {
+          "type": "number",
+          "description": "Longitude of the location",
+        },
       },
-    },
+      required: ["latitude", "longitude"],
+    ),
     callback: ({args, extra}) async {
       final latitude = args?['latitude'] as num?;
       final longitude = args?['longitude'] as num?;

--- a/lib/src/server/mcp.dart
+++ b/lib/src/server/mcp.dart
@@ -82,15 +82,15 @@ class ResourceTemplateRegistration {
 
 class _RegisteredTool {
   final String? description;
-  final Map<String, dynamic>? inputSchemaProperties;
-  final Map<String, dynamic>? outputSchemaProperties;
+  final ToolInputSchema? toolInputSchema;
+  final ToolOutputSchema? toolOutputSchema;
   final ToolAnnotations? annotations;
   final ToolCallback callback;
 
   const _RegisteredTool({
     this.description,
-    this.inputSchemaProperties,
-    this.outputSchemaProperties,
+    this.toolInputSchema,
+    this.toolOutputSchema,
     this.annotations,
     required this.callback,
   });
@@ -99,11 +99,9 @@ class _RegisteredTool {
     return Tool(
       name: name,
       description: description,
-      inputSchema: ToolInputSchema(properties: inputSchemaProperties),
+      inputSchema: toolInputSchema ?? ToolInputSchema(),
       // Do not include output schema in the payload if it isn't defined
-      outputSchema: outputSchemaProperties != null
-          ? ToolOutputSchema(properties: outputSchemaProperties)
-          : null,
+      outputSchema: toolOutputSchema,
       annotations: annotations,
     );
   }
@@ -567,7 +565,11 @@ class McpServer {
   void tool(
     String name, {
     String? description,
+    ToolInputSchema? toolInputSchema,
+    ToolOutputSchema? toolOutputSchema,
+    @Deprecated('Use toolInputSchema instead')
     Map<String, dynamic>? inputSchemaProperties,
+    @Deprecated('Use toolOutputSchema instead')
     Map<String, dynamic>? outputSchemaProperties,
     ToolAnnotations? annotations,
     required ToolCallback callback,
@@ -577,8 +579,14 @@ class McpServer {
     }
     _registeredTools[name] = _RegisteredTool(
       description: description,
-      inputSchemaProperties: inputSchemaProperties,
-      outputSchemaProperties: outputSchemaProperties,
+      toolInputSchema: toolInputSchema ??
+          (inputSchemaProperties != null
+              ? ToolInputSchema(properties: inputSchemaProperties)
+              : null),
+      toolOutputSchema: toolOutputSchema ??
+          (outputSchemaProperties != null
+              ? ToolOutputSchema(properties: outputSchemaProperties)
+              : null),
       annotations: annotations,
       callback: callback,
     );


### PR DESCRIPTION
Close #35 

This pull request refactors how tool schemas are defined and registered across several example servers and the core MCP server implementation. The main change is the transition from using raw schema property maps to dedicated `ToolInputSchema` and `ToolOutputSchema` objects, improving type safety and clarity. Backwards compatibility is maintained for the old properties with deprecation notices.

### Core API and Schema Registration Changes

* The `McpServer.tool` method now accepts `toolInputSchema` and `toolOutputSchema` parameters instead of (or in addition to, for backwards compatibility) the previous `inputSchemaProperties` and `outputSchemaProperties` maps. The old parameters are marked as deprecated. (`lib/src/server/mcp.dart`)
* The `_RegisteredTool` class and related logic have been updated to store and use `ToolInputSchema` and `ToolOutputSchema` instead of raw property maps. (`lib/src/server/mcp.dart`) [[1]](diffhunk://#diff-6e100dedac02de9360401e2b3f8efdc757ffe3861cb74ee8c0907e7a2804e218L85-R93) [[2]](diffhunk://#diff-6e100dedac02de9360401e2b3f8efdc757ffe3861cb74ee8c0907e7a2804e218L102-R104) [[3]](diffhunk://#diff-6e100dedac02de9360401e2b3f8efdc757ffe3861cb74ee8c0907e7a2804e218L580-R589)

### Example Server Updates

* All example servers (`server_stdio.dart`, `server_sse.dart`, `server_streamable_https.dart`, `weather.dart`, `server_iostream.dart`) have been updated to use the new `toolInputSchema` parameter, replacing `inputSchemaProperties`. Where appropriate, required fields are now explicitly listed. [[1]](diffhunk://#diff-b2d39cef45e1ff48178e7911c9cda93191c6a7eac2da2463f84d2c152cb75a0dL18-R28) [[2]](diffhunk://#diff-65c9fc44b67961ee7e59758ea345c5b7edce904851644d53352daab74486b029L14-R24) [[3]](diffhunk://#diff-d6910e7881b0d95e822700f236fc25bdd184133ac3a248c8129d4e3e2f388c31L70-R78) [[4]](diffhunk://#diff-d6910e7881b0d95e822700f236fc25bdd184133ac3a248c8129d4e3e2f388c31L88-R102) [[5]](diffhunk://#diff-d6910e7881b0d95e822700f236fc25bdd184133ac3a248c8129d4e3e2f388c31L165-R178) [[6]](diffhunk://#diff-d6910e7881b0d95e822700f236fc25bdd184133ac3a248c8129d4e3e2f388c31R190) [[7]](diffhunk://#diff-f59e5beacbc6bcdeaa6051272521d600edee76615e3cb0dcd36d3abe38d80b87L56-R64) [[8]](diffhunk://#diff-f59e5beacbc6bcdeaa6051272521d600edee76615e3cb0dcd36d3abe38d80b87L101-R116) [[9]](diffhunk://#diff-ab3c94fcbcee4bd8bab6a6be7fe554646a7a9d9cbd3e65be1bc4364bc6943de7L14-R24)

These changes modernize the schema registration approach, making it more robust and maintainable while preserving compatibility with existing code.