### PR TITLE
Fix: keep-alive for streamable_http server

### DIFF
--- a/example/streamable_https/test_keepalive_client.dart
+++ b/example/streamable_https/test_keepalive_client.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+void main() async {
+  print('MCP Keep-Alive Test Client');
+  print('This client will connect to the server and monitor SSE keep-alive messages\n');
+
+  try {
+    // First, initialize the session
+    print('1. Initializing session...');
+    final initClient = HttpClient();
+    final initRequest = await initClient.postUrl(Uri.parse('http://localhost:3001/mcp'));
+    
+    initRequest.headers.set('Content-Type', 'application/json');
+    initRequest.headers.set('Accept', 'application/json, text/event-stream');
+    
+    initRequest.write(jsonEncode({
+      'jsonrpc': '2.0',
+      'method': 'initialize',
+      'params': {
+        'protocolVersion': '0.1.0',
+        'capabilities': {
+          'roots': {'listChanged': true},
+          'sampling': {},
+        },
+        'clientInfo': {
+          'name': 'test-client',
+          'version': '1.0.0',
+        },
+      },
+      'id': 1,
+    }));
+    
+    final initResponse = await initRequest.close();
+    final sessionId = initResponse.headers.value('mcp-session-id');
+    
+    if (sessionId == null) {
+      print('ERROR: No session ID received');
+      return;
+    }
+    
+    print('Session initialized with ID: $sessionId');
+    
+    // Read the SSE stream
+    final responseBody = StringBuffer();
+    await for (final chunk in initResponse.transform(utf8.decoder)) {
+      responseBody.write(chunk);
+      // Print each SSE event as it arrives
+      final lines = chunk.split('\n');
+      for (final line in lines) {
+        if (line.trim().isNotEmpty) {
+          print('SSE: $line');
+        }
+      }
+    }
+    
+    // Now establish SSE connection
+    print('\n2. Establishing SSE connection to monitor keep-alive messages...');
+    final sseClient = HttpClient();
+    final sseRequest = await sseClient.getUrl(Uri.parse('http://localhost:3001/mcp'));
+    
+    sseRequest.headers.set('Accept', 'text/event-stream');
+    sseRequest.headers.set('mcp-session-id', sessionId);
+    
+    final sseResponse = await sseRequest.close();
+    
+    if (sseResponse.statusCode != 200) {
+      print('ERROR: SSE connection failed with status ${sseResponse.statusCode}');
+      return;
+    }
+    
+    print('SSE connection established, monitoring for keep-alive messages...');
+    print('(Keep-alive messages should appear every 5 seconds)\n');
+    
+    // Create a timer to track time
+    final startTime = DateTime.now();
+    Timer.periodic(Duration(seconds: 1), (timer) {
+      final elapsed = DateTime.now().difference(startTime).inSeconds;
+      stdout.write('\rElapsed time: ${elapsed}s');
+    });
+    
+    // Monitor the SSE stream
+    int keepAliveCount = 0;
+    await for (final chunk in sseResponse.transform(utf8.decoder)) {
+      final lines = chunk.split('\n');
+      for (final line in lines) {
+        if (line.startsWith(':')) {
+          // This is a comment/keep-alive message
+          keepAliveCount++;
+          print('\n[Keep-Alive #$keepAliveCount] $line');
+          stdout.write('Elapsed time: ${DateTime.now().difference(startTime).inSeconds}s');
+        } else if (line.trim().isNotEmpty) {
+          // Other SSE messages
+          print('\n[SSE Event] $line');
+        }
+      }
+    }
+    
+  } catch (e) {
+    print('Error: $e');
+  }
+}

--- a/example/streamable_https/test_keepalive_server.dart
+++ b/example/streamable_https/test_keepalive_server.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:mcp_dart/mcp_dart.dart';
+
+void main() async {
+  // Create HTTP server
+  final server = await HttpServer.bind(InternetAddress.anyIPv4, 3001);
+  print('MCP Keep-Alive Test Server listening on port 3001');
+  print('Keep-alive messages will be sent every 5 seconds');
+
+  // Create the MCP server
+  final mcpServer = McpServer(
+    Implementation(name: 'keepalive-test-server', version: '1.0.0'),
+  );
+
+  // Register a simple tool
+  mcpServer.tool(
+    'test-keepalive',
+    description: 'A tool that waits to test keep-alive',
+    toolInputSchema: ToolInputSchema(
+      properties: {
+        'delay': {
+          'type': 'number',
+          'description': 'Delay in seconds before responding',
+          'default': 10,
+        },
+      },
+    ),
+    callback: ({args, extra}) async {
+      final delay = (args?['delay'] as num? ?? 10).toInt();
+      print('Tool called, waiting $delay seconds...');
+      
+      // Send periodic notifications during the wait
+      for (int i = 0; i < delay; i++) {
+        await extra?.sendNotification(JsonRpcLoggingMessageNotification(
+          logParams: LoggingMessageNotificationParams(
+            level: LoggingLevel.info,
+            data: 'Waiting... ${i + 1}/$delay seconds',
+          ),
+        ));
+        await Future.delayed(Duration(seconds: 1));
+      }
+      
+      return CallToolResult.fromContent(
+        content: [
+          TextContent(text: 'Completed after $delay seconds!'),
+        ],
+      );
+    },
+  );
+
+  await for (final request in server) {
+    // Set CORS headers
+    request.response.headers.set('Access-Control-Allow-Origin', '*');
+    request.response.headers.set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+    request.response.headers.set('Access-Control-Allow-Headers', 
+        'Origin, Content-Type, Accept, mcp-session-id');
+    request.response.headers.set('Access-Control-Expose-Headers', 'mcp-session-id');
+
+    if (request.method == 'OPTIONS') {
+      request.response.statusCode = HttpStatus.ok;
+      await request.response.close();
+      continue;
+    }
+
+    if (request.uri.path != '/mcp') {
+      request.response
+        ..statusCode = HttpStatus.notFound
+        ..write('Not Found')
+        ..close();
+      continue;
+    }
+
+    try {
+      // Create transport with keep-alive enabled (5 seconds for testing)
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => generateUUID(),
+          keepAliveInterval: 5, // Send keep-alive every 5 seconds
+          enableJsonResponse: false, // Use SSE
+        ),
+      );
+
+      // Connect transport to MCP server
+      await mcpServer.connect(transport);
+
+      // Log transport events
+      transport.onclose = () {
+        print('Transport closed');
+      };
+
+      transport.onerror = (error) {
+        print('Transport error: $error');
+      };
+
+      // Handle the request
+      await transport.handleRequest(request);
+      
+      print('Request handled, SSE stream should be active with keep-alive');
+    } catch (error) {
+      print('Error handling request: $error');
+      if (!request.response.headers.contentType.toString().contains('event-stream')) {
+        request.response
+          ..statusCode = HttpStatus.internalServerError
+          ..write('Internal Server Error')
+          ..close();
+      }
+    }
+  }
+}


### PR DESCRIPTION
- ** first an foremost, thank you so much for an awesome package!!
- I have been looking around for dart specific MCP packages and this one is by far the best
- currently in app we have our own mcp server implementation for SSE with the first schema, however keeping up with all of the schema adjustments and bugs along the way have been a bit of a pain, but I am very happy to of found this package
- in testing I found an issue with after 5 min no matter what the client would disconnect from server regardless, (believe it or not I ran into this issue a month ago with our initial implementation as well), and is a pretty simple fix to just pipe over a keep-alive signal on a timer to ensrue the client does not error out

Steps to reproduce:
- configure and run a streamableHTTPServer
- connect via cursor or some sort of client
- Notice that after 5 min, you will see a disconnection

Fix: add support for a periodic keep alive signal from server -> client

Please let me know if you would like me to adjust anything and thank you again for the package!
