### PR TITLE
release: prepare 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.1.1
 
 ### Compatibility Notes (Potentially Breaking)
 
@@ -12,6 +12,12 @@
 - Fixed `JsonEnum` tool/input schema serialization to use standard JSON Schema enum output,
   improving compatibility with downstream consumers that reject the legacy
   `type: 'enum'` / `values` shape.
+- Serialized concurrent stdio transport writes so overlapping requests no longer
+  trip Dart `IOSink` write/flush errors.
+
+### Documentation
+
+- Updated installation snippets and schema/stdio transport guidance for the 2.1.1 release.
 
 ## 2.1.0
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.1.0
+  mcp_dart: ^2.1.1
 ```
 
 Then install dependencies:

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -8,7 +8,7 @@ Add the MCP Dart SDK to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.1.0
+  mcp_dart: ^2.1.1
 ```
 
 Then run:

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -7,7 +7,7 @@ Fast lookup guide for common MCP Dart SDK operations.
 ```yaml
 # pubspec.yaml
 dependencies:
-  mcp_dart: ^2.1.0
+  mcp_dart: ^2.1.1
 ```
 
 ```bash
@@ -562,6 +562,8 @@ try {
   enumValues: ['active', 'inactive', 'pending'],
 )
 ```
+
+`JsonSchema.string(enumValues: ...)` and `JsonEnum` serialize as standard JSON Schema using `enum`; `JsonEnum` also emits `enumNames` when values include titles. Legacy `type: 'enum'` / `values` input is still accepted when parsing.
 
 ### Array
 

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -111,6 +111,19 @@ server.registerTool(
 );
 ```
 
+### Enum Wire Format
+
+String enum schemas serialize as standard JSON Schema:
+
+```json
+{
+  "type": "string",
+  "enum": ["user", "admin", "moderator"]
+}
+```
+
+`JsonEnum` uses the same standard output. When enum values include display titles, it emits `enumNames` for compatibility with clients that understand title metadata; mixed primitive enums without titles emit an `enum` array without a `type`. Legacy serialized input using `type: 'enum'` / `values` is still accepted by parsers.
+
 ## Tool Annotations
 
 Provide behavioral hints to clients:

--- a/doc/transports.md
+++ b/doc/transports.md
@@ -177,6 +177,10 @@ void main() async {
 }
 ```
 
+#### 4. Concurrent Requests
+
+`StdioClientTransport` and `StdioServerTransport` serialize concurrent `send()` calls internally, so overlapping requests such as `Future.wait([...client.callTool(...)])` are safe on a single connected transport. Stdio servers should still reserve `stdout` for MCP messages and write logs to `stderr`.
+
 ## HTTP/SSE Transport
 
 ### Overview

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@
 
 MCP Dart is the official Dart implementation of the Model Context Protocol, enabling seamless integration between AI applications and external data sources, tools, and services. Build production-ready MCP servers and clients for Dart VM, Flutter, and web platforms.
 
-**Version**: 2.1.0
+**Version**: 2.1.1
 **Protocol**: MCP 2025-11-25 (backward compatible with 2025-06-18, 2025-03-26, 2024-11-05, 2024-10-07)
 **Repository**: https://github.com/leehack/mcp_dart
 **Package**: https://pub.dev/packages/mcp_dart
@@ -18,7 +18,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.1.0
+  mcp_dart: ^2.1.1
 ```
 
 Then run:
@@ -268,6 +268,8 @@ server.registerTool(
   },
 );
 ```
+
+Enum schemas serialize as standard JSON Schema. Use `JsonSchema.string(enumValues: ...)` for string enums; `JsonEnum` emits `enum`, optional `enumNames` for titled values, and still parses legacy `type: 'enum'` / `values` input.
 
 ### Resources
 
@@ -565,6 +567,8 @@ await client.connect(StdioClientTransport(
   ),
 ));
 ```
+
+Stdio transports serialize concurrent `send()` calls internally, so multiple overlapping requests can share a single connected transport safely. Keep server logs on `stderr`; `stdout` is reserved for MCP protocol messages.
 
 ### StreamableHTTP Transport
 
@@ -909,7 +913,15 @@ enum ErrorCode
 
 ## Changelog
 
-### Version 2.0.0 (Latest)
+### Version 2.1.1 (Latest)
+- **Compatibility**: `JsonEnum` now serializes to standard JSON Schema enum output while still parsing legacy `values` input.
+- **Reliability**: Stdio transports serialize concurrent writes to avoid Dart `IOSink` write/flush errors under overlapping requests.
+
+### Version 2.1.0
+- **Compatibility**: Streamable HTTP defaults are stricter for DNS rebinding protection, protocol-version validation, and JSON-RPC batch rejection.
+- **Features**: Added SDK runtime logging helpers and 2025-11-25 compatibility shims for sampling, content blocks, resource annotations, and related-task metadata.
+
+### Version 2.0.0
 - **Breaking Change**: JSON Schema `additionalProperties` now accepts either `bool` or `JsonSchema` (typed as `Object?`) to match the spec.
 - **MCP Apps Support**: Added typed `io.modelcontextprotocol/ui` metadata models and TypeScript-style helpers (`registerAppTool`, `registerAppResource`, `getUiCapability`).
 - **Compatibility**: Updated MCP Apps weather examples for host-safe tool naming and explicit `resource_link` output.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mcp_dart
 description: Dart Implementation of Model Context Protocol (MCP) SDK.
-version: 2.1.0
+version: 2.1.1
 repository: https://github.com/leehack/mcp_dart
 homepage: https://github.com/leehack/mcp_dart
 issue_tracker: https://github.com/leehack/mcp_dart/issues


### PR DESCRIPTION
## Summary
- Bump `mcp_dart` to 2.1.1 and promote unreleased notes into the release changelog.
- Update public docs and `llms.txt` install/release guidance for 2.1.1.
- Document standard JSON Schema enum output and serialized concurrent stdio writes.

## Verification
- `dart format .`
- `dart analyze`
- `dart test`
- `dart pub publish --dry-run`