### PR TITLE
Fix CLI inspect with quoted pubspec package names

### DIFF
--- a/packages/mcp_dart_cli/CHANGELOG.md
+++ b/packages/mcp_dart_cli/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.7
+
+- Fix `mcp_dart inspect` for local projects whose `pubspec.yaml` package name is quoted.
+- Parse local project package names with the YAML parser shared by `inspect` and `serve`.
+- Update the CLI and simple template dependency constraint to `mcp_dart ^2.1.1`.
+
 ## 0.1.6
 
 - Update to mcp_dart 1.2.0

--- a/packages/mcp_dart_cli/lib/src/serve_command.dart
+++ b/packages/mcp_dart_cli/lib/src/serve_command.dart
@@ -1,14 +1,15 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'dart:async';
 import 'package:args/command_runner.dart';
 import 'package:mason/mason.dart';
-import 'package:yaml/yaml.dart';
 import 'package:path/path.dart' as p;
-import 'package:watcher/watcher.dart';
 import 'package:stream_transform/stream_transform.dart';
+import 'package:watcher/watcher.dart';
+
 import 'runner_script_generator.dart';
+import 'utils/pubspec_utils.dart';
 
 class ServeCommand extends Command<int> {
   @override
@@ -53,9 +54,7 @@ class ServeCommand extends Command<int> {
       return ExitCode.usage.code;
     }
 
-    final pubspecContent = pubspecFile.readAsStringSync();
-    final pubspecYaml = loadYaml(pubspecContent);
-    final packageName = pubspecYaml['name'] as String?;
+    final packageName = await readPackageNameFromPubspec(pubspecFile);
 
     if (packageName == null) {
       _logger.err('Error: Could not determine package name from pubspec.yaml.');

--- a/packages/mcp_dart_cli/lib/src/utils/mcp_connection.dart
+++ b/packages/mcp_dart_cli/lib/src/utils/mcp_connection.dart
@@ -1,12 +1,13 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:async';
 
 import 'package:mason/mason.dart';
 import 'package:mcp_dart/mcp_dart.dart' hide Logger;
 import 'package:path/path.dart' as p;
 
 import '../runner_script_generator.dart';
+import 'pubspec_utils.dart';
 
 /// A wrapper around MCP Client connection lifecycle.
 class McpConnection {
@@ -26,17 +27,7 @@ class McpConnection {
       throw 'pubspec.yaml not found in current directory.';
     }
 
-    // simplistic package name check
-    String? packageName;
-    try {
-      final lines = await pubspecFile.readAsLines();
-      for (final line in lines) {
-        if (line.trim().startsWith('name:')) {
-          packageName = line.split(':')[1].trim();
-          break;
-        }
-      }
-    } catch (_) {}
+    final packageName = await readPackageNameFromPubspec(pubspecFile);
 
     if (packageName == null) {
       throw 'Could not determine package name from pubspec.yaml.';

--- a/packages/mcp_dart_cli/lib/src/utils/pubspec_utils.dart
+++ b/packages/mcp_dart_cli/lib/src/utils/pubspec_utils.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+
+import 'package:yaml/yaml.dart';
+
+/// Reads the package name from a pubspec file.
+Future<String?> readPackageNameFromPubspec(File pubspecFile) async {
+  final pubspecContent = await pubspecFile.readAsString();
+  final pubspecYaml = loadYaml(pubspecContent);
+
+  if (pubspecYaml is! YamlMap) {
+    return null;
+  }
+
+  final packageName = pubspecYaml['name'];
+  return packageName is String ? packageName : null;
+}

--- a/packages/mcp_dart_cli/lib/src/version.dart
+++ b/packages/mcp_dart_cli/lib/src/version.dart
@@ -1,1 +1,1 @@
-const packageVersion = '0.1.6';
+const packageVersion = '0.1.7';

--- a/packages/mcp_dart_cli/pubspec.yaml
+++ b/packages/mcp_dart_cli/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   stream_transform: ^2.1.1
   watcher: ^1.2.0
   yaml: ^3.1.3
-  mcp_dart: ^1.2.0
+  mcp_dart: ^2.1.1
   mason_logger: ^0.3.3
   meta: ^1.17.0
   pub_updater: ^0.5.0

--- a/packages/mcp_dart_cli/pubspec.yaml
+++ b/packages/mcp_dart_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mcp_dart_cli
 description: CLI for Model Context Protocol (MCP) servers in Dart.
-version: 0.1.6
+version: 0.1.7
 repository: https://github.com/leehack/mcp_dart
 
 environment:

--- a/packages/mcp_dart_cli/test/src/pubspec_utils_test.dart
+++ b/packages/mcp_dart_cli/test/src/pubspec_utils_test.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:mcp_dart_cli/src/utils/pubspec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('readPackageNameFromPubspec', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync();
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    Future<String?> readName(String content) {
+      final pubspecFile = File('${tempDir.path}/pubspec.yaml')
+        ..writeAsStringSync(content);
+      return readPackageNameFromPubspec(pubspecFile);
+    }
+
+    test('reads unquoted package name', () async {
+      expect(await readName('name: my_server\n'), equals('my_server'));
+    });
+
+    test('reads double quoted package name without quotes', () async {
+      expect(await readName('name: "my_server"\n'), equals('my_server'));
+    });
+
+    test('reads single quoted package name without quotes', () async {
+      expect(await readName("name: 'my_server'\n"), equals('my_server'));
+    });
+
+    test('returns null when name is missing', () async {
+      expect(await readName('version: 1.0.0\n'), isNull);
+    });
+  });
+}

--- a/packages/templates/simple/__brick__/pubspec.yaml
+++ b/packages/templates/simple/__brick__/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   args: ^2.6.0
   logging: ^1.3.0
-  mcp_dart: ^1.2.0
+  mcp_dart: ^2.1.1
 
 dev_dependencies:
   lints: ^3.0.0


### PR DESCRIPTION
## Summary

Fixes `mcp_dart inspect` for local MCP projects whose `pubspec.yaml` package name is quoted, such as `name: "my_server"`.

The root cause was that `inspect` used manual line parsing for `pubspec.yaml`, preserving quote characters and passing them into the generated runner import. This produced invalid generated Dart such as an HTML-escaped quoted package import. The fix moves local package-name loading to a YAML parser helper and shares it between `inspect` and `serve`.

This also prepares `mcp_dart_cli` `0.1.7` for release and updates the CLI/simple-template dependency constraint to `mcp_dart ^2.1.1`.

## Validation

- `dart analyze` in `packages/mcp_dart_cli`
- `dart test` in `packages/mcp_dart_cli`
- End-to-end smoke test with a temporary MCP project using `name: "quoted_server"`; `mcp_dart inspect --wait 0` initialized successfully and generated `package:quoted_server/mcp/mcp.dart`
- `mcp_dart --version` reports `0.1.7`
- Clean-copy `dart pub publish --dry-run` for `mcp_dart_cli 0.1.7`: 0 warnings, existing dependency override hint only
- `pana` for `mcp_dart_cli`: 160/160, run with a temporary workaround for the current upstream pub.dev advisory stderr issue