### PR TITLE
Fix CLI publish workflow for nested package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,11 @@ jobs:
           
           if [[ "$TAG" == mcp_dart_cli-v* ]]; then
             echo "working_directory=packages/mcp_dart_cli" >> "$GITHUB_OUTPUT"
+            echo "package=mcp_dart_cli" >> "$GITHUB_OUTPUT"
             echo "📦 Package: mcp_dart_cli"
           elif [[ "$TAG" == v* ]]; then
             echo "working_directory=." >> "$GITHUB_OUTPUT"
+            echo "package=mcp_dart" >> "$GITHUB_OUTPUT"
             echo "📦 Package: mcp_dart"
           else
             echo "❌ Unknown tag format: $TAG"
@@ -33,10 +35,23 @@ jobs:
 
       - uses: dart-lang/setup-dart@v1
 
+      - name: Prepare nested package publish directory
+        id: publish-dir
+        run: |
+          if [[ "${{ steps.package-info.outputs.package }}" == "mcp_dart_cli" ]]; then
+            PUBLISH_ROOT="$RUNNER_TEMP/mcp_dart_publish"
+            rm -rf "$PUBLISH_ROOT"
+            mkdir -p "$PUBLISH_ROOT"
+            rsync -a --exclude .git --exclude .dart_tool --exclude pubspec.lock ./ "$PUBLISH_ROOT/"
+            echo "working_directory=$PUBLISH_ROOT/${{ steps.package-info.outputs.working_directory }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "working_directory=${{ steps.package-info.outputs.working_directory }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install dependencies
-        working-directory: ${{ steps.package-info.outputs.working_directory }}
+        working-directory: ${{ steps.publish-dir.outputs.working_directory }}
         run: dart pub get
 
       - name: Publish to pub.dev
-        working-directory: ${{ steps.package-info.outputs.working_directory }}
+        working-directory: ${{ steps.publish-dir.outputs.working_directory }}
         run: dart pub publish --force


### PR DESCRIPTION
## Summary

Fix the `mcp_dart_cli` publish workflow so nested package releases are published from a clean temporary copy of the repository instead of directly from `packages/mcp_dart_cli` inside the Git checkout.

The failed `mcp_dart_cli-v0.1.7` release produced an effectively empty archive (`<1 KB`) and pub.dev validation then reported missing `pubspec.yaml`, `LICENSE`, `README.md`, `CHANGELOG.md`, and `bin/mcp_dart.dart`. The files were present; `dart pub publish` was packaging the nested package incorrectly from the Git worktree.

This workflow now preserves normal top-level `mcp_dart` publishing, while CLI tags copy the repo to `$RUNNER_TEMP`, remove Git/build/cache metadata, and publish from the copied `packages/mcp_dart_cli` directory. Keeping the full repo layout preserves the CLI package's existing `mcp_dart` path override during release validation.

## Validation

- Parsed `.github/workflows/publish.yml` as YAML locally.
- Reproduced the workflow copy approach under `/private/tmp`.
- Ran `dart pub publish --dry-run` from the copied `packages/mcp_dart_cli` directory.
- Verified the dry-run now builds a real `24 KB` archive containing the expected package files and reports `0 warnings` with only the existing dependency override hint.