### PR TITLE
test(server): cover DNS rebinding deployment guidance

### DIFF
--- a/doc/transports.md
+++ b/doc/transports.md
@@ -237,6 +237,54 @@ This helper handles:
 
 Use this for remote/browser-exposed deployments.
 
+#### Deployment recipes
+
+**Safe local development**
+
+Bind only to loopback and allow the exact browser development origin that needs
+to call the MCP endpoint:
+
+```dart
+final server = StreamableMcpServer(
+  serverFactory: (sessionId) => McpServer(
+    const Implementation(name: 'local-dev-server', version: '1.0.0'),
+  ),
+  host: '127.0.0.1',
+  port: 3000,
+  path: '/mcp',
+  enableDnsRebindingProtection: true,
+  allowedHosts: {'localhost', '127.0.0.1'},
+  allowedOrigins: {'http://localhost:5173'},
+);
+```
+
+Keep DNS rebinding protection enabled even on localhost. If your browser app runs
+on a different dev-server port, add that exact origin instead of using a wildcard.
+
+**Production browser or remote deployment**
+
+Terminate TLS at your application or reverse proxy, expose only the public MCP
+hostname, and allow only the trusted web origins that should reach it:
+
+```dart
+final server = StreamableMcpServer(
+  serverFactory: (sessionId) => McpServer(
+    const Implementation(name: 'production-server', version: '1.0.0'),
+  ),
+  host: '0.0.0.0',
+  port: 3000,
+  path: '/mcp',
+  enableDnsRebindingProtection: true,
+  allowedHosts: {'mcp.example.com'},
+  allowedOrigins: {'https://app.example.com'},
+);
+```
+
+For authenticated deployments, pair these transport checks with your OAuth or
+bearer-token layer. The examples in `example/authentication/` show the MCP OAuth
+flow and PKCE shape; production clients should use PKCE S256 with cryptographic
+randomness and keep redirect URIs/origins explicit.
+
 ### Streamable HTTP Strict Defaults
 
 By default, Streamable HTTP server transports also enforce:
@@ -244,30 +292,43 @@ By default, Streamable HTTP server transports also enforce:
 - Strict `MCP-Protocol-Version` request header validation
 - Rejection of JSON-RPC batch POST payloads
 
-If you need a temporary compatibility mode during migration, disable strict checks explicitly:
+These defaults make compatibility failures visible instead of accepting requests
+that the Streamable HTTP spec no longer allows. If you need a temporary migration
+mode, disable only the specific check that blocks a known legacy client:
 
 ```dart
 final server = StreamableMcpServer(
   serverFactory: (sessionId) => McpServer(
     const Implementation(name: 'server', version: '1.0.0'),
   ),
+  // Only if a legacy client still sends older or experimental versions.
   strictProtocolVersionHeaderValidation: false,
-  rejectBatchJsonRpcPayloads: false,
-  enableDnsRebindingProtection: false,
+  // Keep DNS rebinding protection enabled and explicit.
+  enableDnsRebindingProtection: true,
+  allowedHosts: {'mcp.example.com'},
+  allowedOrigins: {'https://app.example.com'},
 );
 ```
 
-Or with low-level transport options:
+Or with low-level transport options for a legacy client that temporarily still
+sends JSON-RPC batch payloads:
 
 ```dart
 final transport = StreamableHTTPServerTransport(
   options: StreamableHTTPServerTransportOptions(
-    strictProtocolVersionHeaderValidation: false,
+    // Prefer migrating clients to non-batch Streamable HTTP requests.
     rejectBatchJsonRpcPayloads: false,
-    enableDnsRebindingProtection: false,
+    enableDnsRebindingProtection: true,
+    allowedHosts: {'mcp.example.com'},
+    allowedOrigins: {'https://app.example.com'},
   ),
 );
 ```
+
+Avoid disabling `enableDnsRebindingProtection` on browser-exposed or remote
+servers. If you must disable it for an internal compatibility test, bind to
+loopback/private networking and put the exception behind a short-lived migration
+plan.
 
 ### Server Setup (Streamable HTTP)
 

--- a/doc/transports.md
+++ b/doc/transports.md
@@ -263,8 +263,10 @@ on a different dev-server port, add that exact origin instead of using a wildcar
 
 **Production browser or remote deployment**
 
-Terminate TLS at your application or reverse proxy, expose only the public MCP
-hostname, and allow only the trusted web origins that should reach it:
+Terminate TLS at your reverse proxy or load balancer, expose only the public MCP
+hostname, and allow only the trusted web origins that should reach it. If your
+deployment needs the Dart process itself to accept HTTPS, provide a custom secure
+`HttpServer` setup; `StreamableMcpServer` binds its listener with plain HTTP:
 
 ```dart
 final server = StreamableMcpServer(

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -305,8 +305,7 @@ void main() {
     });
 
     group('DNS rebinding protection', () {
-      Future<HttpClientResponse> postWithHeaders(
-        StreamableHTTPServerTransport transport, {
+      Future<HttpClientResponse> postWithHeaders({
         required String host,
         String? origin,
         String body = '{}',
@@ -340,7 +339,6 @@ void main() {
         transports['/mcp'] = transport;
 
         final response = await postWithHeaders(
-          transport,
           host: 'localhost:$serverPort',
           origin: 'http://localhost:$serverPort',
           body: jsonEncode({
@@ -372,7 +370,6 @@ void main() {
         transports['/mcp'] = transport;
 
         final response = await postWithHeaders(
-          transport,
           host: 'evil.example',
           origin: 'http://localhost:$serverPort',
         );
@@ -396,7 +393,6 @@ void main() {
         transports['/mcp'] = transport;
 
         final response = await postWithHeaders(
-          transport,
           host: 'localhost:$serverPort',
           origin: 'http://evil.example',
         );

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -349,9 +349,12 @@ void main() {
           }),
         );
         final body = await utf8.decodeStream(response);
+        final decodedBody = jsonDecode(body) as Map<String, dynamic>;
+        final error = decodedBody['error'] as Map<String, dynamic>;
 
         expect(response.statusCode, equals(HttpStatus.badRequest));
-        expect(body, contains('Server not initialized'));
+        expect(error['code'], equals(ErrorCode.connectionClosed.value));
+        expect(error['message'], equals('Bad Request: Server not initialized'));
         expect(body, isNot(contains('DNS rebinding protection')));
       });
 

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -311,9 +311,6 @@ void main() {
         String? origin,
         String body = '{}',
       }) async {
-        await transport.start();
-        transports['/mcp'] = transport;
-
         final client = HttpClient();
         addTearDown(client.close);
 
@@ -333,11 +330,14 @@ void main() {
         final transport = StreamableHTTPServerTransport(
           options: StreamableHTTPServerTransportOptions(
             sessionIdGenerator: () => 'test-session-id',
+            enableDnsRebindingProtection: true,
             allowedHosts: {'localhost'},
             allowedOrigins: {'http://localhost:$serverPort'},
           ),
         );
         addTearDown(transport.close);
+        await transport.start();
+        transports['/mcp'] = transport;
 
         final response = await postWithHeaders(
           transport,
@@ -362,11 +362,14 @@ void main() {
         final transport = StreamableHTTPServerTransport(
           options: StreamableHTTPServerTransportOptions(
             sessionIdGenerator: () => 'test-session-id',
+            enableDnsRebindingProtection: true,
             allowedHosts: {'localhost'},
             allowedOrigins: {'http://localhost:$serverPort'},
           ),
         );
         addTearDown(transport.close);
+        await transport.start();
+        transports['/mcp'] = transport;
 
         final response = await postWithHeaders(
           transport,
@@ -383,11 +386,14 @@ void main() {
         final transport = StreamableHTTPServerTransport(
           options: StreamableHTTPServerTransportOptions(
             sessionIdGenerator: () => 'test-session-id',
+            enableDnsRebindingProtection: true,
             allowedHosts: {'localhost'},
             allowedOrigins: {'http://localhost:$serverPort'},
           ),
         );
         addTearDown(transport.close);
+        await transport.start();
+        transports['/mcp'] = transport;
 
         final response = await postWithHeaders(
           transport,

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:mcp_dart/src/server/streamable_https.dart';
@@ -301,6 +302,100 @@ void main() {
       await transport.close();
 
       expect(true, isTrue);
+    });
+
+    group('DNS rebinding protection', () {
+      Future<HttpClientResponse> postWithHeaders(
+        StreamableHTTPServerTransport transport, {
+        required String host,
+        String? origin,
+        String body = '{}',
+      }) async {
+        await transport.start();
+        transports['/mcp'] = transport;
+
+        final client = HttpClient();
+        addTearDown(client.close);
+
+        final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers
+          ..set(HttpHeaders.hostHeader, host)
+          ..set(HttpHeaders.acceptHeader, 'application/json, text/event-stream')
+          ..contentType = ContentType.json;
+        if (origin != null) {
+          request.headers.set('Origin', origin);
+        }
+        request.write(body);
+        return request.close();
+      }
+
+      test('allows allowlisted headers to reach session validation', () async {
+        final transport = StreamableHTTPServerTransport(
+          options: StreamableHTTPServerTransportOptions(
+            sessionIdGenerator: () => 'test-session-id',
+            allowedHosts: {'localhost'},
+            allowedOrigins: {'http://localhost:$serverPort'},
+          ),
+        );
+        addTearDown(transport.close);
+
+        final response = await postWithHeaders(
+          transport,
+          host: 'localhost:$serverPort',
+          origin: 'http://localhost:$serverPort',
+          body: jsonEncode({
+            'jsonrpc': '2.0',
+            'method': 'notifications/initialized',
+          }),
+        );
+        final body = await utf8.decodeStream(response);
+
+        expect(response.statusCode, equals(HttpStatus.badRequest));
+        expect(body, contains('Server not initialized'));
+        expect(body, isNot(contains('DNS rebinding protection')));
+      });
+
+      test('rejects requests with hosts outside the allowlist', () async {
+        final transport = StreamableHTTPServerTransport(
+          options: StreamableHTTPServerTransportOptions(
+            sessionIdGenerator: () => 'test-session-id',
+            allowedHosts: {'localhost'},
+            allowedOrigins: {'http://localhost:$serverPort'},
+          ),
+        );
+        addTearDown(transport.close);
+
+        final response = await postWithHeaders(
+          transport,
+          host: 'evil.example',
+          origin: 'http://localhost:$serverPort',
+        );
+        final body = await utf8.decodeStream(response);
+
+        expect(response.statusCode, equals(HttpStatus.forbidden));
+        expect(body, contains('DNS rebinding protection'));
+      });
+
+      test('rejects requests with origins outside the allowlist', () async {
+        final transport = StreamableHTTPServerTransport(
+          options: StreamableHTTPServerTransportOptions(
+            sessionIdGenerator: () => 'test-session-id',
+            allowedHosts: {'localhost'},
+            allowedOrigins: {'http://localhost:$serverPort'},
+          ),
+        );
+        addTearDown(transport.close);
+
+        final response = await postWithHeaders(
+          transport,
+          host: 'localhost:$serverPort',
+          origin: 'http://evil.example',
+        );
+        final body = await utf8.decodeStream(response);
+
+        expect(response.statusCode, equals(HttpStatus.forbidden));
+        expect(body, contains('DNS rebinding protection'));
+      });
     });
 
     test('session validation works correctly', () async {


### PR DESCRIPTION
## Summary
- Adds Streamable HTTP DNS rebinding coverage for allowlisted headers, blocked hosts, and blocked origins.
- Documents safe local-development and production deployment recipes with explicit Host/Origin allowlists.
- Updates compatibility-toggle guidance to avoid weakening DNS rebinding protection when migrating legacy clients.

## Production-readiness scope
- Users get tested DNS rebinding behavior for low-level `StreamableHTTPServerTransport` Host/Origin checks.
- Supported paths in this PR: Streamable HTTP deployment docs and transport-level DNS rebinding tests.
- Out of scope: full OAuth/PKCE end-to-end harness from #98; this PR keeps the first slice small and reviewable.
- Security defaults remain strict; examples keep `enableDnsRebindingProtection: true` and document explicit exceptions only for short-lived internal compatibility testing.

## Test Plan
- [x] `dart format test/server/streamable_https_test.dart`
- [x] `dart test test/server/streamable_https_test.dart`
- [x] `dart analyze`
- [x] `dart test`
- [x] Static scan of staged added lines: no hardcoded secrets, dangerous exec, or raw URL logging patterns
- [x] Independent GPT-5.5 review: passed with no security or logic blockers

Refs #98
