### PR TITLE
fix: preserve string related request ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## Unreleased
+
+### Compatibility Notes
+
+- **Custom transports remain source-compatible while string request routing is available**:
+  - `Transport.send(... relatedRequestId: ...)` keeps the existing `int?`
+    signature for third-party custom transports and middleware.
+  - Transports that route by JSON-RPC request ID can opt into
+    `RequestIdAwareTransport.sendWithRequestId(... relatedRequestId: ...)` to
+    receive the full MCP/JSON-RPC request ID shape (`String` or `int`).
+  - Middleware wrappers that implement `RequestIdAwareTransport` should forward
+    through `sendPreservingRequestId(...)` so string IDs are not dropped.
+
+### Reliability
+
+- Preserved string JSON-RPC request IDs when handler code sends nested requests,
+  notifications, or cancellation notifications, keeping related-request routing
+  compatible with clients that use string IDs.
+
 ## 2.1.1
 
 ### Compatibility Notes (Potentially Breaking)

--- a/doc/transports.md
+++ b/doc/transports.md
@@ -747,8 +747,12 @@ class CustomTransport extends Transport {
   }
 
   @override
-  Future<void> send(JsonRpcMessage message) async {
-    // Send message
+  Future<void> send(
+    JsonRpcMessage message, {
+    int? relatedRequestId,
+  }) async {
+    // Send message. Existing transports can keep the int? relatedRequestId
+    // signature for source compatibility.
   }
 
   @override
@@ -756,19 +760,41 @@ class CustomTransport extends Transport {
     // Clean up resources
   }
 
+  @override
+  String? get sessionId => null;
+
   // Call this when receiving messages
   void receiveMessage(JsonRpcMessage message) {
-    onMessage?.call(message);
+    onmessage?.call(message);
   }
 
   // Call this on connection close
   void handleClose() {
-    onClose?.call();
+    onclose?.call();
   }
 
   // Call this on errors
-  void handleError(Object error) {
-    onError?.call(error);
+  void handleError(Error error) {
+    onerror?.call(error);
+  }
+}
+```
+
+### Request ID-aware Transports
+
+If a custom transport routes messages by JSON-RPC request ID or stream
+correlation key, implement `RequestIdAwareTransport` in addition to `Transport`
+so string request IDs are preserved:
+
+```dart
+class StreamRoutingTransport extends CustomTransport
+    implements RequestIdAwareTransport {
+  @override
+  Future<void> sendWithRequestId(
+    JsonRpcMessage message, {
+    RequestId? relatedRequestId,
+  }) async {
+    // Route with the full JSON-RPC request ID shape: String or int.
   }
 }
 ```
@@ -778,7 +804,7 @@ class CustomTransport extends Transport {
 Add logging, metrics, or filtering:
 
 ```dart
-class LoggingTransport extends Transport {
+class LoggingTransport extends Transport implements RequestIdAwareTransport {
   final Transport inner;
   final Logger logger;
 
@@ -789,26 +815,41 @@ class LoggingTransport extends Transport {
     logger.info('Starting transport');
     await inner.start();
 
-    inner.onMessage = (message) {
+    inner.onmessage = (message) {
       logger.debug('Received: $message');
-      onMessage?.call(message);
+      onmessage?.call(message);
     };
 
-    inner.onError = (error) {
+    inner.onerror = (error) {
       logger.warn('Error: $error');
-      onError?.call(error);
+      onerror?.call(error);
     };
 
-    inner.onClose = () {
+    inner.onclose = () {
       logger.info('Closed');
-      onClose?.call();
+      onclose?.call();
     };
   }
 
   @override
-  Future<void> send(JsonRpcMessage message) async {
+  Future<void> send(
+    JsonRpcMessage message, {
+    int? relatedRequestId,
+  }) async {
     logger.debug('Sending: $message');
-    await inner.send(message);
+    await inner.send(message, relatedRequestId: relatedRequestId);
+  }
+
+  @override
+  Future<void> sendWithRequestId(
+    JsonRpcMessage message, {
+    RequestId? relatedRequestId,
+  }) async {
+    logger.debug('Sending: $message');
+    await inner.sendPreservingRequestId(
+      message,
+      relatedRequestId: relatedRequestId,
+    );
   }
 
   @override
@@ -816,6 +857,9 @@ class LoggingTransport extends Transport {
     logger.info('Closing transport');
     await inner.close();
   }
+
+  @override
+  String? get sessionId => inner.sessionId;
 }
 
 // Usage

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -133,7 +133,8 @@ class StreamableHTTPServerTransportOptions {
 /// In stateless mode:
 /// - Session ID is only included in initialization responses
 /// - No session validation is performed
-class StreamableHTTPServerTransport implements Transport {
+class StreamableHTTPServerTransport
+    implements Transport, RequestIdAwareTransport {
   // when sessionId is not set (null), it means the transport is in stateless mode
   final String? Function()? _sessionIdGenerator;
   bool _started = false;
@@ -840,7 +841,15 @@ class StreamableHTTPServerTransport implements Transport {
   }
 
   @override
-  Future<void> send(JsonRpcMessage message, {dynamic relatedRequestId}) async {
+  Future<void> send(JsonRpcMessage message, {dynamic relatedRequestId}) {
+    return sendWithRequestId(message, relatedRequestId: relatedRequestId);
+  }
+
+  @override
+  Future<void> sendWithRequestId(
+    JsonRpcMessage message, {
+    RequestId? relatedRequestId,
+  }) async {
     dynamic requestId = relatedRequestId;
     if (_isJsonRpcResponse(message) || _isJsonRpcError(message)) {
       // If the message is a response, use the request ID from the message

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -646,7 +646,8 @@ abstract class Protocol {
           : null,
       taskRequestedTtl:
           (request.params?['task'] as Map<String, dynamic>?)?['ttl'] as int?,
-      sendNotification: (notification, {relatedTask}) => this.notification(
+      sendNotification: (notification, {relatedTask}) =>
+          _notificationWithRequestId(
         notification,
         relatedTask: relatedTask,
         relatedRequestId: request.id,
@@ -668,11 +669,11 @@ abstract class Protocol {
                   ? RelatedTaskMetadata(taskId: relatedTaskId)
                   : null),
         );
-        return this.request<T>(
+        return _requestWithRequestId<T>(
           req,
           resultFactory,
           newOptions,
-          request.id is int ? request.id as int : null,
+          request.id,
         );
       },
     );
@@ -928,6 +929,20 @@ abstract class Protocol {
     RequestOptions? options,
     int? relatedRequestId,
   ]) {
+    return _requestWithRequestId(
+      requestData,
+      resultFactory,
+      options,
+      relatedRequestId,
+    );
+  }
+
+  Future<T> _requestWithRequestId<T extends BaseResultData>(
+    JsonRpcRequest requestData,
+    T Function(Map<String, dynamic> resultJson) resultFactory, [
+    RequestOptions? options,
+    RequestId? relatedRequestId,
+  ]) {
     if (_transport == null) {
       return Future.error(StateError("Not connected to a transport."));
     }
@@ -1007,7 +1022,12 @@ abstract class Protocol {
       // Spec doesn't strictly say, but usually cancellations go via same channel.
       // For now assume standard transport for cancellations unless queued.
 
-      _transport?.send(notification).catchError((e) {
+      _transport
+          ?.sendPreservingRequestId(
+        notification,
+        relatedRequestId: relatedRequestId,
+      )
+          .catchError((e) {
         _onerror(
           StateError("Failed to send cancellation for request $messageId: $e"),
         );
@@ -1085,7 +1105,10 @@ abstract class Protocol {
     } else {
       // Normal transport
       _transport!
-          .send(jsonrpcRequest, relatedRequestId: relatedRequestId)
+          .sendPreservingRequestId(
+        jsonrpcRequest,
+        relatedRequestId: relatedRequestId,
+      )
           .catchError((error) {
         _cleanupTimeout(messageId);
         if (!completer.isCompleted) {
@@ -1122,6 +1145,18 @@ abstract class Protocol {
     JsonRpcNotification notificationData, {
     RelatedTaskMetadata? relatedTask,
     int? relatedRequestId,
+  }) {
+    return _notificationWithRequestId(
+      notificationData,
+      relatedTask: relatedTask,
+      relatedRequestId: relatedRequestId,
+    );
+  }
+
+  Future<void> _notificationWithRequestId(
+    JsonRpcNotification notificationData, {
+    RelatedTaskMetadata? relatedTask,
+    RequestId? relatedRequestId,
   }) async {
     if (_transport == null) {
       throw StateError("Not connected to a transport.");
@@ -1181,7 +1216,7 @@ abstract class Protocol {
         _pendingDebouncedNotifications.remove(notificationData.method);
         if (_transport == null) return;
         _transport!
-            .send(
+            .sendPreservingRequestId(
               jsonrpcNotification,
               relatedRequestId: relatedRequestId,
             )
@@ -1190,7 +1225,7 @@ abstract class Protocol {
       return;
     }
 
-    await _transport!.send(
+    await _transport!.sendPreservingRequestId(
       jsonrpcNotification,
       relatedRequestId: relatedRequestId,
     );

--- a/lib/src/shared/transport.dart
+++ b/lib/src/shared/transport.dart
@@ -26,6 +26,45 @@ abstract class Transport {
   String? get sessionId;
 }
 
+/// Optional capability for transports that can preserve JSON-RPC request IDs
+/// with their full MCP shape (string or integer) for request/stream correlation.
+///
+/// Existing custom transports can keep implementing [Transport.send] with
+/// `int? relatedRequestId`. Transports that need to route messages by string
+/// request IDs should also implement this interface.
+abstract class RequestIdAwareTransport {
+  /// Sends a JSON-RPC message while preserving a string-or-integer request ID.
+  Future<void> sendWithRequestId(
+    JsonRpcMessage message, {
+    RequestId? relatedRequestId,
+  });
+}
+
+extension RequestIdAwareTransportSend on Transport {
+  /// Sends [message] while preserving string request IDs when the transport
+  /// supports [RequestIdAwareTransport].
+  ///
+  /// Legacy transports receive only integer IDs, matching the existing public
+  /// [Transport.send] contract and keeping custom implementations source-compatible.
+  Future<void> sendPreservingRequestId(
+    JsonRpcMessage message, {
+    RequestId? relatedRequestId,
+  }) {
+    final transport = this;
+    if (transport is RequestIdAwareTransport) {
+      return (transport as RequestIdAwareTransport).sendWithRequestId(
+        message,
+        relatedRequestId: relatedRequestId,
+      );
+    }
+
+    return send(
+      message,
+      relatedRequestId: relatedRequestId is int ? relatedRequestId : null,
+    );
+  }
+}
+
 /// Optional capability for transports that can attach MCP protocol version
 /// headers to outbound requests.
 abstract class ProtocolVersionAwareTransport {

--- a/test/shared/protocol_test.dart
+++ b/test/shared/protocol_test.dart
@@ -6,8 +6,9 @@ import 'package:mcp_dart/src/types.dart';
 import 'package:test/test.dart';
 
 /// A mock transport implementation for testing the protocol layer
-class MockTransport implements Transport {
+class MockTransport implements Transport, RequestIdAwareTransport {
   final List<JsonRpcMessage> sentMessages = [];
+  final List<RequestId?> relatedRequestIds = [];
   final StreamController<JsonRpcMessage> _incomingMessages =
       StreamController<JsonRpcMessage>.broadcast();
   bool _started = false;
@@ -35,6 +36,7 @@ class MockTransport implements Transport {
   /// Clears the list of sent messages - useful between tests
   void clearSentMessages() {
     sentMessages.clear();
+    relatedRequestIds.clear();
   }
 
   /// Simulates receiving a message from the remote end
@@ -80,11 +82,20 @@ class MockTransport implements Transport {
   }
 
   @override
-  Future<void> send(JsonRpcMessage message, {int? relatedRequestId}) async {
+  Future<void> send(JsonRpcMessage message, {int? relatedRequestId}) {
+    return sendWithRequestId(message, relatedRequestId: relatedRequestId);
+  }
+
+  @override
+  Future<void> sendWithRequestId(
+    JsonRpcMessage message, {
+    RequestId? relatedRequestId,
+  }) async {
     if (_closed) {
       throw StateError('Transport is closed');
     }
     sentMessages.add(message);
+    relatedRequestIds.add(relatedRequestId);
   }
 
   @override
@@ -106,6 +117,24 @@ class MockTransport implements Transport {
   /// Creates a shutdown error to test error handling
   void simulateError(Error error) {
     onerror?.call(error);
+  }
+}
+
+Future<void> waitForSentMessages(
+  MockTransport transport,
+  int count, {
+  Duration timeout = const Duration(seconds: 1),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (transport.sentMessages.length < count &&
+      DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  if (transport.sentMessages.length < count) {
+    fail(
+      'Timed out waiting for $count sent messages; '
+      'only saw ${transport.sentMessages.length}.',
+    );
   }
 }
 
@@ -270,6 +299,130 @@ void main() {
       final result = await requestFuture;
       expect(result, isA<TestResult>());
       expect(result.value, equals('response-data'));
+    });
+
+    test('routes handler notifications for string request IDs', () async {
+      await protocol.connect(transport);
+
+      protocol.setRequestHandler<JsonRpcRequest>(
+        'test/string-id',
+        (request, extra) async {
+          await extra.sendNotification(
+            const JsonRpcNotification(method: 'test/notification'),
+          );
+          return TestResult(value: 'ok');
+        },
+        (id, params, meta) => JsonRpcRequest(
+          id: id,
+          method: 'test/string-id',
+          params: params,
+          meta: meta,
+        ),
+      );
+
+      transport.receiveMessage(
+        const JsonRpcRequest(id: 'client-req-1', method: 'test/string-id'),
+      );
+
+      await waitForSentMessages(transport, 2);
+
+      expect(transport.sentMessages, hasLength(2));
+      expect(transport.sentMessages[0], isA<JsonRpcNotification>());
+      expect(transport.relatedRequestIds[0], 'client-req-1');
+      expect(transport.sentMessages[1], isA<JsonRpcResponse>());
+      expect((transport.sentMessages[1] as JsonRpcResponse).id, 'client-req-1');
+    });
+
+    test('routes handler requests for string request IDs', () async {
+      await protocol.connect(transport);
+
+      protocol.setRequestHandler<JsonRpcRequest>(
+        'test/string-id/request',
+        (request, extra) async {
+          final nestedResult = await extra.sendRequest<TestResult>(
+            const JsonRpcRequest(id: 0, method: 'test/method'),
+            (json) => TestResult(value: json['value'] as String),
+            const RequestOptions(timeout: Duration(seconds: 1)),
+          );
+          return TestResult(value: nestedResult.value);
+        },
+        (id, params, meta) => JsonRpcRequest(
+          id: id,
+          method: 'test/string-id/request',
+          params: params,
+          meta: meta,
+        ),
+      );
+
+      transport.receiveMessage(
+        const JsonRpcRequest(
+          id: 'client-req-2',
+          method: 'test/string-id/request',
+        ),
+      );
+
+      await waitForSentMessages(transport, 1);
+
+      expect(transport.sentMessages[0], isA<JsonRpcRequest>());
+      expect(transport.relatedRequestIds[0], 'client-req-2');
+
+      final nestedRequest = transport.sentMessages[0] as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: nestedRequest.id,
+          result: {'value': 'nested-ok'},
+        ),
+      );
+
+      await waitForSentMessages(transport, 2);
+
+      expect(transport.sentMessages[1], isA<JsonRpcResponse>());
+      final response = transport.sentMessages[1] as JsonRpcResponse;
+      expect(response.id, 'client-req-2');
+      expect(response.result['value'], 'nested-ok');
+    });
+
+    test('routes nested cancellation notifications for string request IDs',
+        () async {
+      await protocol.connect(transport);
+
+      final controller = BasicAbortController();
+      protocol.setRequestHandler<JsonRpcRequest>(
+        'test/cancel-nested',
+        (request, extra) async {
+          final result = await extra
+              .sendRequest<TestResult>(
+                const JsonRpcRequest(id: 0, method: 'test/nested-cancel'),
+                (json) => TestResult(value: json['value'] as String),
+                RequestOptions(signal: controller.signal),
+              )
+              .catchError((_) => TestResult(value: 'cancelled'));
+          return result;
+        },
+        (id, params, meta) => JsonRpcRequest(
+          id: id,
+          method: 'test/cancel-nested',
+          params: params,
+          meta: meta,
+        ),
+      );
+
+      transport.receiveMessage(
+        const JsonRpcRequest(id: 'client-req-3', method: 'test/cancel-nested'),
+      );
+
+      await waitForSentMessages(transport, 1);
+      controller.abort('User cancelled');
+
+      await waitForSentMessages(transport, 2);
+      final cancellationIndex = transport.sentMessages.indexWhere(
+        (message) =>
+            message is JsonRpcNotification &&
+            message.method == 'notifications/cancelled',
+      );
+
+      expect(cancellationIndex, isNot(-1));
+      expect(transport.relatedRequestIds[cancellationIndex], 'client-req-3');
     });
 
     test('handles outgoing request errors', () async {

--- a/test/shared/transport_api_compatibility_test.dart
+++ b/test/shared/transport_api_compatibility_test.dart
@@ -1,0 +1,76 @@
+import 'package:mcp_dart/mcp_dart.dart';
+import 'package:test/test.dart';
+
+class LegacyTransport implements Transport {
+  JsonRpcMessage? lastMessage;
+  int? lastRelatedRequestId;
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  void Function()? onclose;
+
+  @override
+  void Function(Error error)? onerror;
+
+  @override
+  void Function(JsonRpcMessage message)? onmessage;
+
+  @override
+  Future<void> send(JsonRpcMessage message, {int? relatedRequestId}) async {
+    lastMessage = message;
+    lastRelatedRequestId = relatedRequestId;
+  }
+
+  @override
+  String? get sessionId => null;
+
+  @override
+  Future<void> start() async {}
+}
+
+class StringAwareTransport extends LegacyTransport
+    implements RequestIdAwareTransport {
+  RequestId? lastRequestIdAwareRelatedRequestId;
+
+  @override
+  Future<void> sendWithRequestId(
+    JsonRpcMessage message, {
+    RequestId? relatedRequestId,
+  }) async {
+    lastMessage = message;
+    lastRequestIdAwareRelatedRequestId = relatedRequestId;
+  }
+}
+
+void main() {
+  group('Transport request ID compatibility', () {
+    test('legacy transports keep compiling with int relatedRequestId',
+        () async {
+      final transport = LegacyTransport();
+
+      await transport.sendPreservingRequestId(
+        const JsonRpcNotification(method: 'test/notification'),
+        relatedRequestId: 'client-req-1',
+      );
+
+      expect(transport.lastMessage, isA<JsonRpcNotification>());
+      expect(transport.lastRelatedRequestId, isNull);
+    });
+
+    test('request-id-aware transports preserve string relatedRequestId',
+        () async {
+      final transport = StringAwareTransport();
+
+      await transport.sendPreservingRequestId(
+        const JsonRpcNotification(method: 'test/notification'),
+        relatedRequestId: 'client-req-1',
+      );
+
+      expect(transport.lastMessage, isA<JsonRpcNotification>());
+      expect(transport.lastRelatedRequestId, isNull);
+      expect(transport.lastRequestIdAwareRelatedRequestId, 'client-req-1');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Preserve JSON-RPC string request IDs when request handlers send nested requests, notifications, or cancellation notifications.
- Keep the existing `Transport.send(... {int? relatedRequestId})` public API source-compatible for custom transports.
- Preserve `StreamableHTTPServerTransport.send(... {dynamic relatedRequestId})` concrete API compatibility while routing through the request-ID-aware path.
- Add optional `RequestIdAwareTransport.sendWithRequestId(... {RequestId? relatedRequestId})` plus `sendPreservingRequestId(...)` so transports that need full MCP/JSON-RPC request IDs can opt in without breaking legacy implementations.
- Update Streamable HTTP server transport to opt into the request-ID-aware path.
- Update transport docs/changelog with the non-breaking migration path.

Closes #110.

Follow-up hardening remains tracked separately in #111.

## Public API compatibility

This PR no longer changes the existing `Transport.send` signature. Existing third-party custom transports that implement:

```dart
Future<void> send(JsonRpcMessage message, {int? relatedRequestId})
```

continue to compile and run unchanged.

The existing concrete Streamable HTTP server send API also remains compatible with its previous wider parameter:

```dart
Future<void> send(JsonRpcMessage message, {dynamic relatedRequestId})
```

For transports/middleware that route by JSON-RPC request ID and need string IDs, the additive opt-in API is:

```dart
abstract class RequestIdAwareTransport {
  Future<void> sendWithRequestId(
    JsonRpcMessage message, {
    RequestId? relatedRequestId,
  });
}
```

Protocol internals call `sendPreservingRequestId(...)`, which preserves string IDs for `RequestIdAwareTransport` implementations and falls back to the legacy integer-only path for existing transports.

## Tests / verification

- `dart analyze`
- `dart analyze lib/api_check.dart` from an external scratch package importing `package:mcp_dart/mcp_dart.dart`, proving a legacy custom `Transport.send(... int? relatedRequestId)` still compiles
- `dart test test/shared/protocol_test.dart test/shared/transport_api_compatibility_test.dart`
- `dart test`
- `git diff --check`
- Static scan over the diff for hardcoded secrets, dangerous exec, raw URL logging, and debug prints

## Review notes

- Regression coverage includes nested handler notifications, nested handler requests, and nested cancellation notifications under incoming string request IDs.
- Added explicit public API compatibility coverage in `test/shared/transport_api_compatibility_test.dart`.
- Independent review found no blockers after the compatibility refactor.
