### PR TITLE
Fix flutter_http_client widget smoke test

### DIFF
--- a/example/flutter_http_client/test/widget_test.dart
+++ b/example/flutter_http_client/test/widget_test.dart
@@ -1,30 +1,23 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_http_client/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('shows the MCP HTTP client UI', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Simple MCP Client'), findsOneWidget);
+    expect(find.widgetWithText(ElevatedButton, 'Connect'), findsOneWidget);
+    expect(find.widgetWithText(ElevatedButton, 'Disconnect'), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, 'Call Tool'), findsOneWidget);
+    expect(find.textContaining('Welcome to the MCP Client'), findsOneWidget);
+    expect(find.textContaining('Notifications (0):'), findsOneWidget);
+    expect(find.byIcon(Icons.add), findsNothing);
   });
 }

--- a/example/flutter_http_client/test/widget_test.dart
+++ b/example/flutter_http_client/test/widget_test.dart
@@ -11,6 +11,7 @@ void main() {
     addTearDown(tester.view.resetDevicePixelRatio);
 
     final errorWidgetBuilder = ErrorWidget.builder;
+    addTearDown(() => ErrorWidget.builder = errorWidgetBuilder);
     await tester.pumpWidget(const MyApp());
     ErrorWidget.builder = errorWidgetBuilder;
 

--- a/example/flutter_http_client/test/widget_test.dart
+++ b/example/flutter_http_client/test/widget_test.dart
@@ -10,9 +10,11 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
 
+    final errorWidgetBuilder = ErrorWidget.builder;
     await tester.pumpWidget(const MyApp());
+    ErrorWidget.builder = errorWidgetBuilder;
 
-    expect(find.text('Simple MCP Client'), findsOneWidget);
+    expect(find.text('MCP Client'), findsOneWidget);
     expect(find.widgetWithText(ElevatedButton, 'Connect'), findsOneWidget);
     expect(find.widgetWithText(ElevatedButton, 'Disconnect'), findsOneWidget);
     expect(find.widgetWithText(OutlinedButton, 'Call Tool'), findsOneWidget);

--- a/example/flutter_http_client/test/widget_test.dart
+++ b/example/flutter_http_client/test/widget_test.dart
@@ -11,9 +11,14 @@ void main() {
     addTearDown(tester.view.resetDevicePixelRatio);
 
     final errorWidgetBuilder = ErrorWidget.builder;
-    addTearDown(() => ErrorWidget.builder = errorWidgetBuilder);
-    await tester.pumpWidget(const MyApp());
-    ErrorWidget.builder = errorWidgetBuilder;
+    try {
+      await tester.pumpWidget(const MyApp());
+    } finally {
+      // MyApp installs a global ErrorWidget.builder. Restore it as soon as
+      // the first frame is built so Flutter's widget-test global state check
+      // sees the original value even if pumpWidget throws.
+      ErrorWidget.builder = errorWidgetBuilder;
+    }
 
     expect(find.text('MCP Client'), findsOneWidget);
     expect(find.widgetWithText(ElevatedButton, 'Connect'), findsOneWidget);


### PR DESCRIPTION
## Summary
- Replace the stale generated counter widget test with a smoke test for the MCP HTTP client UI
- Set a stable desktop widget-test viewport so the current example layout can render without the default small test surface overflow

Fixes #113

## Testing
- `git diff --check`
- Not run: `flutter test` (`flutter` is not available in my local PATH)