### PR TITLE
test(flutter_http_client): replace stale counter test with MCP client smoke tests

### DIFF
--- a/example/flutter_http_client/test/widget_test.dart
+++ b/example/flutter_http_client/test/widget_test.dart
@@ -1,30 +1,98 @@
-// This is a basic Flutter widget test.
+// Widget smoke tests for the MCP HTTP client example.
 //
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
+// These tests verify that the MCP client UI renders correctly in its initial
+// disconnected state, without requiring a live server.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mcp_dart/mcp_dart.dart';
 
 import 'package:flutter_http_client/main.dart';
+import 'package:flutter_http_client/screens/mcp_client_screen.dart';
+import 'package:flutter_http_client/services/streamable_mcp_service.dart';
+
+// ---------------------------------------------------------------------------
+// Minimal stub – overrides only what the widget reads in the disconnected state
+// ---------------------------------------------------------------------------
+class _FakeMcpService extends StreamableMcpService {
+  _FakeMcpService() : super(serverUrl: 'http://localhost:3000/mcp');
+
+  @override
+  bool get isConnected => false;
+
+  @override
+  String? get connectionError => null;
+
+  @override
+  List<Tool>? get availableTools => null;
+
+  @override
+  List<Prompt>? get availablePrompts => null;
+
+  @override
+  List<Resource>? get availableResources => null;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: pump MyApp inside a fixed-size surface to prevent overflow errors
+// ---------------------------------------------------------------------------
+Widget _testApp() {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 800,
+        height: 1024,
+        child: McpClientScreen(mcpService: _FakeMcpService()),
+      ),
+    ),
+  );
+}
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('MCP client screen renders AppBar title', (tester) async {
+    await tester.pumpWidget(_testApp());
+    expect(find.text('MCP Client'), findsOneWidget);
+  });
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+  testWidgets('Connect button is present and enabled when disconnected',
+      (tester) async {
+    await tester.pumpWidget(_testApp());
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+    // "Connect" must be visible (requiresConnection: false means it is enabled)
+    expect(find.text('Connect'), findsOneWidget);
+  });
 
-    // Verify that our counter has incremented.
+  testWidgets('Disconnect and Terminate Session buttons are present',
+      (tester) async {
+    await tester.pumpWidget(_testApp());
+    expect(find.text('Disconnect'), findsOneWidget);
+    expect(find.text('Terminate Session'), findsOneWidget);
+  });
+
+  testWidgets('Status chip shows Disconnected when not connected',
+      (tester) async {
+    await tester.pumpWidget(_testApp());
+    expect(find.text('Disconnected'), findsOneWidget);
+    expect(find.text('Connected'), findsNothing);
+  });
+
+  testWidgets('Settings icon button is present in AppBar', (tester) async {
+    await tester.pumpWidget(_testApp());
+    expect(find.byIcon(Icons.settings), findsOneWidget);
+  });
+
+  testWidgets('Response area shows welcome message on startup', (tester) async {
+    await tester.pumpWidget(_testApp());
+    // The initial _responseText set in initState
+    expect(find.textContaining('Welcome to the MCP Client'), findsOneWidget);
+  });
+
+  testWidgets('No counter widgets from default Flutter template exist',
+      (tester) async {
+    await tester.pumpWidget(_testApp());
+    expect(find.byIcon(Icons.add), findsNothing);
+    // The old template asserted '0' and '1' as counter values
     expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('1'), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary

Closes #113.

The current `example/flutter_http_client/test/widget_test.dart` is the
default Flutter counter template and no longer matches the MCP HTTP
client UI it is supposed to exercise — it asserts on counter widgets
that no longer exist, and triggers a `RenderFlex overflowed by 49
pixels` failure on default screen sizes.

This change replaces the stale 16-line counter template with a 96-line
smoke test suite that targets the real `McpClientScreen` widget tree.

## Change

- A minimal `_FakeMcpService` extends `StreamableMcpService` and
  overrides the five getters the screen reads in its disconnected
  state (`isConnected`, `connectionError`, `availableTools`,
  `availablePrompts`, `availableResources`), so the tests run with
  no live server.
- The widget is wrapped in `SizedBox(800 × 1024)` to eliminate the
  overflow reported in the issue.
- Seven test cases cover: AppBar title, Connect button, Disconnect /
  Terminate Session buttons, Disconnected status chip, Settings icon,
  the initial welcome message, and explicit absence of legacy counter
  widgets.

## Note

The test was authored without a local Flutter SDK; CI on this PR will
be the first runtime verification. Static analysis (correct imports,
return-type matching for all five overrides against
`StreamableMcpService`) was completed locally.

---

Prepared with AI assistance (Claude Sonnet 4.6 via Claude Code).