### PR TITLE
fix: support string progress tokens end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ### Reliability
 
+- Supported string progress tokens end-to-end for outgoing requests that supply
+  a custom `progressToken`, while preserving generated integer tokens for the
+  default `RequestOptions.onprogress` path.
 - Preserved string JSON-RPC request IDs when handler code sends nested requests,
   notifications, or cancellation notifications, keeping related-request routing
   compatible with clients that use string IDs.

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -8,6 +8,8 @@ import 'transport.dart';
 
 final _logger = Logger("mcp_dart.shared.protocol");
 
+bool _isProgressToken(Object? token) => token is int || token is String;
+
 /// Callback for progress notifications.
 typedef ProgressCallback = void Function(Progress progress);
 
@@ -49,6 +51,10 @@ const Duration defaultRequestTimeout = Duration(milliseconds: 60000);
 /// Options that can be given per request.
 class RequestOptions {
   /// Callback for progress notifications from the remote end.
+  ///
+  /// When set, the protocol adds an integer progress token to outgoing request
+  /// metadata unless the request already carries an `int` or `String`
+  /// `progressToken`, which is preserved for callers that need a custom token.
   final ProgressCallback? onprogress;
 
   /// Signal to cancel an in-flight request.
@@ -238,8 +244,11 @@ abstract class Protocol {
   /// Error handlers for outgoing requests, mapped by request ID.
   final Map<int, void Function(Error error)> _responseErrorHandlers = {};
 
-  /// Progress callbacks for outgoing requests, mapped by request ID.
-  final Map<int, ProgressCallback> _progressHandlers = {};
+  /// Progress callbacks for outgoing requests, mapped by progress token.
+  final Map<Object, ProgressCallback> _progressHandlers = {};
+
+  /// Progress tokens selected for outgoing requests, mapped by request ID.
+  final Map<int, Object> _requestProgressTokens = {};
 
   /// Timeout state for outgoing requests, mapped by request ID.
   final Map<int, _TimeoutInfo> _timeoutInfo = {};
@@ -254,7 +263,7 @@ abstract class Protocol {
   final TaskMessageQueue? _taskMessageQueue;
 
   /// Maps task IDs to progress tokens to keep handlers alive.
-  final Map<String, int> _taskProgressTokens = {};
+  final Map<String, Object> _taskProgressTokens = {};
 
   /// Set of notification methods currently pending debounce.
   final Set<String> _pendingDebouncedNotifications = {};
@@ -490,6 +499,14 @@ abstract class Protocol {
     _timeoutInfo.remove(messageId)?.timeoutTimer.cancel();
   }
 
+  /// Removes progress bookkeeping for an outgoing request.
+  void _cleanupProgressHandler(int messageId) {
+    final progressToken = _requestProgressTokens.remove(messageId);
+    if (progressToken != null) {
+      _progressHandlers.remove(progressToken);
+    }
+  }
+
   /// Sends a JSON-RPC error response for a given request ID.
   Future<void> _sendErrorResponse(
     RequestId id,
@@ -534,6 +551,7 @@ abstract class Protocol {
     _responseCompleters.clear();
     _responseErrorHandlers.clear();
     _progressHandlers.clear();
+    _requestProgressTokens.clear();
     _timeoutInfo.clear();
     _requestHandlerAbortControllers.clear();
     _taskProgressTokens.clear();
@@ -776,20 +794,22 @@ abstract class Protocol {
     final params = notification.progressParams;
     final progressToken = params.progressToken;
 
-    if (progressToken is! int) {
+    if (!_isProgressToken(progressToken)) {
       _onerror(
-        ArgumentError("Received non-integer progressToken: $progressToken"),
+        ArgumentError(
+          "Received invalid progressToken: $progressToken. Expected int or String.",
+        ),
       );
       return;
     }
-    final messageId = progressToken;
 
-    final progressHandler = _progressHandlers[messageId];
+    final progressHandler = _progressHandlers[progressToken];
     if (progressHandler == null) {
       return;
     }
 
-    final timeoutInfo = _timeoutInfo[messageId];
+    final timeoutInfo =
+        progressToken is int ? _timeoutInfo[progressToken] : null;
     if (timeoutInfo != null) {
       // Determine if we should reset
       // We don't have easy access to RequestOptions here without storing them,
@@ -811,7 +831,7 @@ abstract class Protocol {
       progressHandler(progressData);
     } catch (e) {
       _onerror(
-        StateError("Error in progress handler for request $messageId: $e"),
+        StateError("Error in progress handler for token $progressToken: $e"),
       );
     }
   }
@@ -863,13 +883,14 @@ abstract class Protocol {
         final task = result['task'] as Map<String, dynamic>;
         if (task['taskId'] is String) {
           isTaskResponse = true;
-          _taskProgressTokens[task['taskId'] as String] = messageId;
+          _taskProgressTokens[task['taskId'] as String] =
+              _requestProgressTokens[messageId] ?? messageId;
         }
       }
     }
 
     if (!isTaskResponse) {
-      _progressHandlers.remove(messageId);
+      _cleanupProgressHandler(messageId);
     }
 
     if (completer == null || completer.isCompleted) {
@@ -967,14 +988,30 @@ abstract class Protocol {
     final messageId = _requestMessageId++;
     final completer = Completer<JsonRpcResponse>();
     Error? capturedError;
+    Object? progressToken;
 
     Map<String, dynamic>? finalMeta = requestData.meta;
     Map<String, dynamic>? finalParams = requestData.params;
 
     if (options?.onprogress != null) {
-      _progressHandlers[messageId] = options!.onprogress!;
       final currentMeta = Map<String, dynamic>.from(finalMeta ?? {});
-      currentMeta['progressToken'] = messageId;
+      final requestedProgressToken = currentMeta['progressToken'];
+      if (requestedProgressToken != null) {
+        if (!_isProgressToken(requestedProgressToken)) {
+          return Future.error(
+            ArgumentError(
+              'progressToken must be an int or String when onprogress is set.',
+            ),
+          );
+        }
+        progressToken = requestedProgressToken;
+      } else {
+        progressToken = messageId;
+        currentMeta['progressToken'] = progressToken;
+      }
+      final token = progressToken!;
+      _progressHandlers[token] = options!.onprogress!;
+      _requestProgressTokens[messageId] = token;
       finalMeta = currentMeta;
     }
 
@@ -1007,7 +1044,7 @@ abstract class Protocol {
 
       _responseCompleters.remove(messageId);
       _responseErrorHandlers.remove(messageId);
-      _progressHandlers.remove(messageId);
+      _cleanupProgressHandler(messageId);
       _cleanupTimeout(messageId);
 
       final cancelReason = reason?.toString() ?? 'Request cancelled';
@@ -1098,6 +1135,7 @@ abstract class Protocol {
         _transport?.sessionId,
       ).catchError((e) {
         _cleanupTimeout(messageId);
+        _cleanupProgressHandler(messageId);
         if (!completer.isCompleted) {
           completer.completeError(e);
         }
@@ -1111,6 +1149,7 @@ abstract class Protocol {
       )
           .catchError((error) {
         _cleanupTimeout(messageId);
+        _cleanupProgressHandler(messageId);
         if (!completer.isCompleted) {
           completer.completeError(error);
         }
@@ -1134,7 +1173,7 @@ abstract class Protocol {
       abortSubscription?.cancel();
       _responseCompleters.remove(messageId);
       _responseErrorHandlers.remove(messageId);
-      _progressHandlers.remove(messageId);
+      _cleanupProgressHandler(messageId);
     }).catchError((error) {
       throw capturedError ?? error;
     });

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -250,6 +250,9 @@ abstract class Protocol {
   /// Progress tokens selected for outgoing requests, mapped by request ID.
   final Map<int, Object> _requestProgressTokens = {};
 
+  /// Request IDs for active progress tokens, mapped by progress token.
+  final Map<Object, int> _progressTokenRequestIds = {};
+
   /// Timeout state for outgoing requests, mapped by request ID.
   final Map<int, _TimeoutInfo> _timeoutInfo = {};
 
@@ -261,9 +264,6 @@ abstract class Protocol {
 
   /// Task message queue implementation.
   final TaskMessageQueue? _taskMessageQueue;
-
-  /// Maps task IDs to progress tokens to keep handlers alive.
-  final Map<String, Object> _taskProgressTokens = {};
 
   /// Set of notification methods currently pending debounce.
   final Set<String> _pendingDebouncedNotifications = {};
@@ -504,7 +504,16 @@ abstract class Protocol {
     final progressToken = _requestProgressTokens.remove(messageId);
     if (progressToken != null) {
       _progressHandlers.remove(progressToken);
+      _progressTokenRequestIds.remove(progressToken);
     }
+  }
+
+  Object _nextAvailableProgressToken(int preferredToken) {
+    var token = preferredToken;
+    while (_progressHandlers.containsKey(token)) {
+      token++;
+    }
+    return token;
   }
 
   /// Sends a JSON-RPC error response for a given request ID.
@@ -552,9 +561,9 @@ abstract class Protocol {
     _responseErrorHandlers.clear();
     _progressHandlers.clear();
     _requestProgressTokens.clear();
+    _progressTokenRequestIds.clear();
     _timeoutInfo.clear();
     _requestHandlerAbortControllers.clear();
-    _taskProgressTokens.clear();
     _pendingDebouncedNotifications.clear();
     _requestResolvers.clear();
     _transport = null;
@@ -808,8 +817,8 @@ abstract class Protocol {
       return;
     }
 
-    final timeoutInfo =
-        progressToken is int ? _timeoutInfo[progressToken] : null;
+    final requestId = _progressTokenRequestIds[progressToken];
+    final timeoutInfo = requestId != null ? _timeoutInfo[requestId] : null;
     if (timeoutInfo != null) {
       // Determine if we should reset
       // We don't have easy access to RequestOptions here without storing them,
@@ -875,23 +884,7 @@ abstract class Protocol {
     final errorHandler = _responseErrorHandlers.remove(messageId);
     _cleanupTimeout(messageId);
 
-    // Keep progress handler if it's a task response
-    bool isTaskResponse = false;
-    if (responseMessage is JsonRpcResponse) {
-      final result = responseMessage.result;
-      if (result['task'] is Map) {
-        final task = result['task'] as Map<String, dynamic>;
-        if (task['taskId'] is String) {
-          isTaskResponse = true;
-          _taskProgressTokens[task['taskId'] as String] =
-              _requestProgressTokens[messageId] ?? messageId;
-        }
-      }
-    }
-
-    if (!isTaskResponse) {
-      _cleanupProgressHandler(messageId);
-    }
+    _cleanupProgressHandler(messageId);
 
     if (completer == null || completer.isCompleted) {
       return;
@@ -1006,12 +999,18 @@ abstract class Protocol {
         }
         progressToken = requestedProgressToken;
       } else {
-        progressToken = messageId;
+        progressToken = _nextAvailableProgressToken(messageId);
         currentMeta['progressToken'] = progressToken;
       }
       final token = progressToken!;
+      if (_progressHandlers.containsKey(token)) {
+        return Future.error(
+          ArgumentError('progressToken is already in use by another request.'),
+        );
+      }
       _progressHandlers[token] = options!.onprogress!;
       _requestProgressTokens[messageId] = token;
+      _progressTokenRequestIds[token] = messageId;
       finalMeta = currentMeta;
     }
 

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -201,6 +201,9 @@ class _TimeoutInfo {
   /// Maximum total duration allowed, regardless of resets.
   final Duration? maxTotalTimeoutDuration;
 
+  /// Whether progress notifications reset the request timeout timer.
+  final bool resetOnProgress;
+
   /// Callback to execute when the timeout occurs.
   final void Function() onTimeout;
 
@@ -210,6 +213,7 @@ class _TimeoutInfo {
     required this.startTime,
     required this.timeoutDuration,
     this.maxTotalTimeoutDuration,
+    this.resetOnProgress = false,
     required this.onTimeout,
   });
 }
@@ -482,6 +486,7 @@ abstract class Protocol {
     int messageId,
     Duration timeout,
     Duration? maxTotalTimeout,
+    bool resetOnProgress,
     void Function() onTimeout,
   ) {
     final info = _TimeoutInfo(
@@ -489,9 +494,32 @@ abstract class Protocol {
       startTime: DateTime.now(),
       timeoutDuration: timeout,
       maxTotalTimeoutDuration: maxTotalTimeout,
+      resetOnProgress: resetOnProgress,
       onTimeout: onTimeout,
     );
     _timeoutInfo[messageId] = info;
+  }
+
+  void _resetTimeoutOnProgress(_TimeoutInfo timeoutInfo) {
+    if (!timeoutInfo.resetOnProgress) return;
+
+    var nextTimeout = timeoutInfo.timeoutDuration;
+    final maxTotalTimeout = timeoutInfo.maxTotalTimeoutDuration;
+    if (maxTotalTimeout != null) {
+      final elapsed = DateTime.now().difference(timeoutInfo.startTime);
+      final remaining = maxTotalTimeout - elapsed;
+      if (remaining <= Duration.zero) {
+        timeoutInfo.timeoutTimer.cancel();
+        timeoutInfo.onTimeout();
+        return;
+      }
+      if (remaining < nextTimeout) {
+        nextTimeout = remaining;
+      }
+    }
+
+    timeoutInfo.timeoutTimer.cancel();
+    timeoutInfo.timeoutTimer = Timer(nextTimeout, timeoutInfo.onTimeout);
   }
 
   /// Cleans up the timeout state associated with a request ID.
@@ -820,16 +848,8 @@ abstract class Protocol {
     final requestId = _progressTokenRequestIds[progressToken];
     final timeoutInfo = requestId != null ? _timeoutInfo[requestId] : null;
     if (timeoutInfo != null) {
-      // Determine if we should reset
-      // We don't have easy access to RequestOptions here without storing them,
-      // but in the original code we check `resetTimeoutOnProgress`
-      // For now, assume false unless we enhance `_TimeoutInfo` or lookup.
-      // The original code had `_getRequestOptionsFromTimeoutInfo` which returned null.
-      // If we want to support resetTimeoutOnProgress, we need to store it in `_TimeoutInfo` or a map.
+      _resetTimeoutOnProgress(timeoutInfo);
     }
-
-    // In strict TS implementation, `resetTimeoutOnProgress` is stored in `TimeoutInfo`.
-    // I will check `_resetTimeout` logic. It uses `_timeoutInfo`.
 
     try {
       final progressData = Progress(
@@ -1112,6 +1132,7 @@ abstract class Protocol {
       messageId,
       timeoutDuration,
       maxTotalTimeoutDuration,
+      options?.resetTimeoutOnProgress ?? false,
       timeoutHandler,
     );
 

--- a/test/shared/protocol_advanced_scenarios_test.dart
+++ b/test/shared/protocol_advanced_scenarios_test.dart
@@ -101,11 +101,11 @@ void main() {
       final errors = <Error>[];
       protocol.onerror = (error) => errors.add(error);
 
-      // Send progress notification with string progressToken (should be int)
+      // Send progress notification with an invalid progressToken type.
       transport.receiveMessage(
         JsonRpcProgressNotification(
           progressParams: const ProgressNotificationParams(
-            progressToken: 'invalid-token' as dynamic,
+            progressToken: false,
             progress: 50,
             total: 100,
           ),

--- a/test/shared/protocol_test.dart
+++ b/test/shared/protocol_test.dart
@@ -425,6 +425,185 @@ void main() {
       expect(transport.relatedRequestIds[cancellationIndex], 'client-req-3');
     });
 
+    test('dispatches generated integer progress tokens', () async {
+      await protocol.connect(transport);
+
+      final progressUpdates = <Progress>[];
+      final requestFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(id: 0, method: 'test/method'),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(
+              onprogress: progressUpdates.add,
+              timeout: const Duration(seconds: 1),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      expect(transport.sentMessages, hasLength(1));
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      final progressToken = sentRequest.meta?['progressToken'];
+      expect(progressToken, isA<int>());
+
+      transport.receiveMessage(
+        JsonRpcProgressNotification(
+          progressParams: ProgressNotification(
+            progressToken: progressToken,
+            progress: 25,
+          ),
+        ),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(progressUpdates, hasLength(1));
+      expect(progressUpdates.single.progress, 25);
+
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {'value': 'response-data'},
+        ),
+      );
+
+      final result = await requestFuture;
+      expect(result.value, 'response-data');
+    });
+
+    test('dispatches string progress tokens from request metadata', () async {
+      await protocol.connect(transport);
+
+      final progressUpdates = <Progress>[];
+      final requestFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'progress-token-1'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(
+              onprogress: progressUpdates.add,
+              timeout: const Duration(seconds: 1),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      expect(transport.sentMessages, hasLength(1));
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      expect(sentRequest.meta?['progressToken'], 'progress-token-1');
+
+      transport.receiveMessage(
+        JsonRpcProgressNotification(
+          progressParams: const ProgressNotification(
+            progressToken: 'progress-token-1',
+            progress: 50,
+            total: 100,
+            message: 'halfway',
+          ),
+        ),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(progressUpdates, hasLength(1));
+      expect(progressUpdates.single.progress, 50);
+      expect(progressUpdates.single.total, 100);
+      expect(progressUpdates.single.message, 'halfway');
+
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {'value': 'response-data'},
+        ),
+      );
+
+      final result = await requestFuture;
+      expect(result.value, 'response-data');
+    });
+
+    test('custom integer progress tokens survive unrelated request cleanup',
+        () async {
+      await protocol.connect(transport);
+
+      final unrelatedRequestFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(id: 0, method: 'test/method'),
+            (json) => TestResult(value: json['value'] as String),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final progressUpdates = <Progress>[];
+      final progressRequestFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 0},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: progressUpdates.add),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      expect(transport.sentMessages, hasLength(2));
+      final unrelatedRequest = transport.sentMessages[0] as JsonRpcRequest;
+      final progressRequest = transport.sentMessages[1] as JsonRpcRequest;
+      expect(unrelatedRequest.id, 0);
+      expect(progressRequest.id, 1);
+      expect(progressRequest.meta?['progressToken'], 0);
+
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: unrelatedRequest.id,
+          result: {'value': 'unrelated'},
+        ),
+      );
+      expect((await unrelatedRequestFuture).value, 'unrelated');
+
+      transport.receiveMessage(
+        JsonRpcProgressNotification(
+          progressParams: const ProgressNotification(
+            progressToken: 0,
+            progress: 75,
+          ),
+        ),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(progressUpdates, hasLength(1));
+      expect(progressUpdates.single.progress, 75);
+
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: progressRequest.id,
+          result: {'value': 'with-progress'},
+        ),
+      );
+      expect((await progressRequestFuture).value, 'with-progress');
+    });
+
+    test('rejects invalid request progress tokens when progress handler is set',
+        () async {
+      await protocol.connect(transport);
+
+      await expectLater(
+        protocol.request<TestResult>(
+          const JsonRpcRequest(
+            id: 0,
+            method: 'test/method',
+            meta: {'progressToken': false},
+          ),
+          (json) => TestResult(value: json['value'] as String),
+          RequestOptions(onprogress: (_) {}),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      expect(transport.sentMessages, isEmpty);
+    });
+
     test('handles outgoing request errors', () async {
       await protocol.connect(transport);
 

--- a/test/shared/protocol_test.dart
+++ b/test/shared/protocol_test.dart
@@ -522,6 +522,50 @@ void main() {
       expect(result.value, 'response-data');
     });
 
+    test('progress notifications reset timeout for custom tokens', () async {
+      await protocol.connect(transport);
+
+      final requestFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'reset-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(
+              onprogress: (_) {},
+              timeout: const Duration(milliseconds: 80),
+              resetTimeoutOnProgress: true,
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      expect(transport.sentMessages, hasLength(1));
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      transport.receiveMessage(
+        JsonRpcProgressNotification(
+          progressParams: const ProgressNotification(
+            progressToken: 'reset-token',
+            progress: 50,
+          ),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {'value': 'response-data'},
+        ),
+      );
+
+      final result = await requestFuture;
+      expect(result.value, 'response-data');
+    });
+
     test('rejects duplicate progress tokens for in-flight requests', () async {
       await protocol.connect(transport);
 

--- a/test/shared/protocol_test.dart
+++ b/test/shared/protocol_test.dart
@@ -522,6 +522,115 @@ void main() {
       expect(result.value, 'response-data');
     });
 
+    test('rejects duplicate progress tokens for in-flight requests', () async {
+      await protocol.connect(transport);
+
+      final firstFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'shared-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      await expectLater(
+        protocol.request<TestResult>(
+          const JsonRpcRequest(
+            id: 0,
+            method: 'test/method',
+            meta: {'progressToken': 'shared-token'},
+          ),
+          (json) => TestResult(value: json['value'] as String),
+          RequestOptions(onprogress: (_) {}),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      expect(transport.sentMessages, hasLength(1));
+      final firstRequest = transport.sentMessages.single as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: firstRequest.id,
+          result: {'value': 'response-data'},
+        ),
+      );
+      expect((await firstFuture).value, 'response-data');
+    });
+
+    test('generated progress tokens avoid active custom integer tokens',
+        () async {
+      await protocol.connect(transport);
+
+      final customProgressUpdates = <Progress>[];
+      final generatedProgressUpdates = <Progress>[];
+      final customFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 1},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: customProgressUpdates.add),
+          )
+          .timeout(const Duration(seconds: 5));
+      final generatedFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(id: 0, method: 'test/method'),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: generatedProgressUpdates.add),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      expect(transport.sentMessages, hasLength(2));
+      final customRequest = transport.sentMessages[0] as JsonRpcRequest;
+      final generatedRequest = transport.sentMessages[1] as JsonRpcRequest;
+      expect(customRequest.id, 0);
+      expect(customRequest.meta?['progressToken'], 1);
+      expect(generatedRequest.id, 1);
+      expect(generatedRequest.meta?['progressToken'], 2);
+
+      transport.receiveMessage(
+        JsonRpcProgressNotification(
+          progressParams: const ProgressNotification(
+            progressToken: 1,
+            progress: 25,
+          ),
+        ),
+      );
+      transport.receiveMessage(
+        JsonRpcProgressNotification(
+          progressParams: const ProgressNotification(
+            progressToken: 2,
+            progress: 50,
+          ),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(customProgressUpdates.single.progress, 25);
+      expect(generatedProgressUpdates.single.progress, 50);
+
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: customRequest.id,
+          result: {'value': 'custom'},
+        ),
+      );
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: generatedRequest.id,
+          result: {'value': 'generated'},
+        ),
+      );
+      expect((await customFuture).value, 'custom');
+      expect((await generatedFuture).value, 'generated');
+    });
+
     test('custom integer progress tokens survive unrelated request cleanup',
         () async {
       await protocol.connect(transport);


### PR DESCRIPTION
## Summary
- preserve caller-supplied `int` or `String` `progressToken` values when `RequestOptions.onprogress` is set
- dispatch incoming progress notifications by the actual progress token instead of assuming request-id integers
- keep generated integer progress tokens for the default path and reject invalid token types
- add regression coverage for string tokens, generated integer tokens, custom integer cleanup isolation, and invalid token handling

Closes #107

## Test Plan
- [x] `dart test test/shared/protocol_test.dart --name "progress tokens"`
- [x] `dart test test/shared/protocol_test.dart --name "rejects invalid request progress tokens"`
- [x] `dart analyze`
- [x] `dart test`

## Review Notes
- Independent review found a cleanup edge case for custom integer tokens; fixed with a regression test before PR creation.
