### PR TITLE
fix: honor progress timeout caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ### Reliability
 
+- Honored `RequestOptions.resetTimeoutOnProgress` and `maxTotalTimeout` together
+  so progress notifications can reset inactivity timers without bypassing the
+  absolute total timeout cap.
 - Supported string progress tokens end-to-end for outgoing requests that supply
   a custom `progressToken`, while preserving generated integer tokens for the
   default `RequestOptions.onprogress` path.

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -489,8 +489,13 @@ abstract class Protocol {
     bool resetOnProgress,
     void Function() onTimeout,
   ) {
+    var initialTimeout = timeout;
+    if (maxTotalTimeout != null && maxTotalTimeout < initialTimeout) {
+      initialTimeout = maxTotalTimeout;
+    }
+
     final info = _TimeoutInfo(
-      timeoutTimer: Timer(timeout, onTimeout),
+      timeoutTimer: Timer(initialTimeout, onTimeout),
       startTime: DateTime.now(),
       timeoutDuration: timeout,
       maxTotalTimeoutDuration: maxTotalTimeout,

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -489,6 +489,7 @@ abstract class Protocol {
     bool resetOnProgress,
     void Function() onTimeout,
   ) {
+    final startTime = DateTime.now();
     var initialTimeout = timeout;
     if (maxTotalTimeout != null && maxTotalTimeout < initialTimeout) {
       initialTimeout = maxTotalTimeout;
@@ -496,7 +497,7 @@ abstract class Protocol {
 
     final info = _TimeoutInfo(
       timeoutTimer: Timer(initialTimeout, onTimeout),
-      startTime: DateTime.now(),
+      startTime: startTime,
       timeoutDuration: timeout,
       maxTotalTimeoutDuration: maxTotalTimeout,
       resetOnProgress: resetOnProgress,

--- a/test/shared/protocol_test.dart
+++ b/test/shared/protocol_test.dart
@@ -566,6 +566,258 @@ void main() {
       expect(result.value, 'response-data');
     });
 
+    test('progress notifications keep request alive when reset is enabled',
+        () async {
+      await protocol.connect(transport);
+
+      final progressUpdates = <Progress>[];
+      final requestFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'keep-alive-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(
+              onprogress: progressUpdates.add,
+              timeout: const Duration(milliseconds: 60),
+              resetTimeoutOnProgress: true,
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      expect(transport.sentMessages, hasLength(1));
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+
+      for (final progress in [25.0, 50.0, 75.0]) {
+        await Future<void>.delayed(const Duration(milliseconds: 40));
+        transport.receiveMessage(
+          JsonRpcProgressNotification(
+            progressParams: ProgressNotification(
+              progressToken: 'keep-alive-token',
+              progress: progress,
+            ),
+          ),
+        );
+      }
+
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {'value': 'completed-after-progress'},
+        ),
+      );
+
+      final result = await requestFuture;
+      expect(result.value, 'completed-after-progress');
+      expect(
+        progressUpdates.map((progress) => progress.progress),
+        [25, 50, 75],
+      );
+    });
+
+    test('progress notifications do not reset timeout when disabled', () async {
+      await protocol.connect(transport);
+
+      final requestFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'no-reset-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(
+              onprogress: (_) {},
+              timeout: const Duration(milliseconds: 80),
+              resetTimeoutOnProgress: false,
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      transport.receiveMessage(
+        JsonRpcProgressNotification(
+          progressParams: const ProgressNotification(
+            progressToken: 'no-reset-token',
+            progress: 50,
+          ),
+        ),
+      );
+
+      await expectLater(
+        requestFuture,
+        throwsA(
+          isA<McpError>()
+              .having(
+                (error) => error.code,
+                'code',
+                ErrorCode.requestTimeout.value,
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                contains('timed out'),
+              ),
+        ),
+      );
+    });
+
+    test('maxTotalTimeout aborts despite progress notifications', () async {
+      await protocol.connect(transport);
+
+      final progressTimer = Timer.periodic(
+        const Duration(milliseconds: 30),
+        (_) {
+          transport.receiveMessage(
+            JsonRpcProgressNotification(
+              progressParams: const ProgressNotification(
+                progressToken: 'max-total-token',
+                progress: 1,
+              ),
+            ),
+          );
+        },
+      );
+      addTearDown(progressTimer.cancel);
+
+      final requestFuture = protocol.request<TestResult>(
+        const JsonRpcRequest(
+          id: 0,
+          method: 'test/method',
+          meta: {'progressToken': 'max-total-token'},
+        ),
+        (json) => TestResult(value: json['value'] as String),
+        RequestOptions(
+          onprogress: (_) {},
+          timeout: const Duration(seconds: 1),
+          resetTimeoutOnProgress: false,
+          maxTotalTimeout: const Duration(milliseconds: 120),
+        ),
+      );
+
+      await expectLater(
+        requestFuture.timeout(const Duration(milliseconds: 500)),
+        throwsA(
+          isA<McpError>()
+              .having(
+                (error) => error.code,
+                'code',
+                ErrorCode.requestTimeout.value,
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                contains('timed out'),
+              ),
+        ),
+      );
+    });
+
+    test('maxTotalTimeout caps progress-based timeout resets', () async {
+      await protocol.connect(transport);
+
+      final progressUpdates = <Progress>[];
+      final requestFuture = protocol.request<TestResult>(
+        const JsonRpcRequest(
+          id: 0,
+          method: 'test/method',
+          meta: {'progressToken': 'capped-reset-token'},
+        ),
+        (json) => TestResult(value: json['value'] as String),
+        RequestOptions(
+          onprogress: progressUpdates.add,
+          timeout: const Duration(seconds: 1),
+          resetTimeoutOnProgress: true,
+          maxTotalTimeout: const Duration(milliseconds: 120),
+        ),
+      );
+
+      final progressTimer = Timer.periodic(
+        const Duration(milliseconds: 30),
+        (_) {
+          transport.receiveMessage(
+            JsonRpcProgressNotification(
+              progressParams: const ProgressNotification(
+                progressToken: 'capped-reset-token',
+                progress: 1,
+              ),
+            ),
+          );
+        },
+      );
+      addTearDown(progressTimer.cancel);
+
+      await expectLater(
+        requestFuture.timeout(const Duration(milliseconds: 500)),
+        throwsA(
+          isA<McpError>()
+              .having(
+                (error) => error.code,
+                'code',
+                ErrorCode.requestTimeout.value,
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                contains('timed out'),
+              ),
+        ),
+      );
+      expect(progressUpdates, isNotEmpty);
+    });
+
+    test('custom progress token can be reused after timeout cleanup', () async {
+      await protocol.connect(transport);
+
+      final firstFuture = protocol.request<TestResult>(
+        const JsonRpcRequest(
+          id: 0,
+          method: 'test/method',
+          meta: {'progressToken': 'reusable-after-timeout'},
+        ),
+        (json) => TestResult(value: json['value'] as String),
+        RequestOptions(
+          onprogress: (_) {},
+          timeout: const Duration(milliseconds: 50),
+        ),
+      );
+
+      await expectLater(
+        firstFuture.timeout(const Duration(seconds: 5)),
+        throwsA(isA<McpError>()),
+      );
+
+      final secondFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'reusable-after-timeout'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(
+              onprogress: (_) {},
+              timeout: const Duration(seconds: 1),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final sentRequests = transport.sentMessages.whereType<JsonRpcRequest>();
+      expect(sentRequests, hasLength(2));
+      final secondRequest = sentRequests.last;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: secondRequest.id,
+          result: {'value': 'reused'},
+        ),
+      );
+
+      expect((await secondFuture).value, 'reused');
+    });
+
     test('rejects duplicate progress tokens for in-flight requests', () async {
       await protocol.connect(transport);
 


### PR DESCRIPTION
## Bug Description

`RequestOptions.maxTotalTimeout` could be bypassed when the initial inactivity timeout was longer than the absolute cap, and the intended interaction with `resetTimeoutOnProgress` was not fully covered by regression tests.

Closes #106

## Root Cause

The initial request timeout timer was always scheduled with the inactivity `timeout` duration. Progress-based resets already capped subsequent timers to the remaining `maxTotalTimeout`, but a request whose initial `timeout` exceeded `maxTotalTimeout` would not fire at the absolute cap unless progress reset the timer first.

## Fix

- Schedule the initial request timeout for the shorter of `timeout` and `maxTotalTimeout`.
- Preserve existing progress reset behavior, including respecting `resetTimeoutOnProgress` and capping resets to the remaining total timeout.
- Add regression coverage for:
  - progress keeping a request alive when reset is enabled
  - progress not extending a request when reset is disabled
  - `maxTotalTimeout` aborting despite progress notifications
  - `maxTotalTimeout` capping progress-based resets
  - custom progress token cleanup/reuse after timeout
- Add an Unreleased changelog note.

## How to Verify

1. Run the protocol test suite.
2. Confirm the new progress/timeout tests pass.
3. Confirm analyzer and full tests pass.

## Test Plan

- [x] `dart format --output=none --set-exit-if-changed lib/src/shared/protocol.dart test/shared/protocol_test.dart`
- [x] `dart analyze`
- [x] `dart test test/shared/protocol_test.dart`
- [x] `dart test`
- [x] `git diff --check`
- [x] Independent review completed; initial coverage blocker fixed and re-review approved.

## Risk Assessment

Low — the implementation change is limited to initial timer scheduling in the shared protocol layer, with focused regression tests covering enabled/disabled progress resets, the absolute max-total cap, and timeout cleanup behavior. No public API changes.
