### PR TITLE
fix(json-schema): support const, enum-only schemas, and union type arrays (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Preserved string JSON-RPC request IDs when handler code sends nested requests,
   notifications, or cancellation notifications, keeping related-request routing
   compatible with clients that use string IDs.
+- Improved JSON Schema parsing and validation for `const`, enum-only schemas,
+  titled enum `const` entries, and simple `type` array unions such as nullable
+  schemas.
 
 ## 2.1.1
 

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -28,6 +28,8 @@ server.registerTool(
 
 ## JSON Schema Validation
 
+mcp_dart implements a pragmatic JSON Schema subset for MCP tool input/output and elicitation schemas; it is not a complete JSON Schema 2020-12 validator.
+
 ### Basic Types
 
 ```dart
@@ -124,6 +126,28 @@ String enum schemas serialize as standard JSON Schema:
 
 `JsonEnum` uses the same standard output. When enum values include display titles, it emits `enumNames` for compatibility with clients that understand title metadata; mixed primitive enums without titles emit an `enum` array without a `type`. Legacy serialized input using `type: 'enum'` / `values` is still accepted by parsers.
 
+### Const Values
+
+Use `JsonSchema.constValue(...)` when a property must equal exactly one JSON value:
+
+```dart
+'confirmation': JsonSchema.constValue('DELETE')
+```
+
+This emits standard JSON Schema `const` and validates only the constant value.
+
+### Nullable and Type Unions
+
+`JsonSchema.fromJson(...)` also accepts simple JSON Schema `type` arrays, such as nullable string schemas:
+
+```json
+{
+  "type": ["string", "null"]
+}
+```
+
+These are parsed as a union of the listed primitive schema types and validate only values matching one of those types.
+
 ## Tool Annotations
 
 Provide behavioral hints to clients:
@@ -157,7 +181,7 @@ server.registerTool(
   ),
   inputSchema: ToolInputSchema(
     properties: {
-      'confirmation': JsonSchema.string(constValue: 'DELETE'),
+      'confirmation': JsonSchema.constValue('DELETE'),
     },
     required: ['confirmation'],
   ),

--- a/lib/src/shared/json_schema/json_schema.dart
+++ b/lib/src/shared/json_schema/json_schema.dart
@@ -46,6 +46,9 @@ sealed class JsonSchema {
 
     final type = json['type'];
     if (type is List) {
+      if (!_isValidJsonTypeArray(type)) {
+        return JsonAny.fromJson(json);
+      }
       return JsonUnion.fromJson(json);
     }
     if (type is String) {
@@ -91,15 +94,13 @@ sealed class JsonSchema {
       return null;
     }
 
-    return JsonAllOf(
-      [
-        _fromJson(_schemaWithKeys(json, primaryKeys)),
-        _fromJson(_schemaWithoutKeys(json, primaryKeys)),
-      ],
-      title: json['title'] as String?,
-      description: json['description'] as String?,
-      defaultValue: json['default'],
-    );
+    // JSON Schema keywords are conjunctive: a schema such as
+    // `{type: ['string', 'null'], enum: ['auto', null]}` means both the
+    // type-array assertion and the enum assertion apply. Preserve the official
+    // wire shape instead of rewriting it into allOf or a typed convenience
+    // schema; JsonAny preserves the keywords and the validator enforces the
+    // supported assertions.
+    return JsonAny.fromJson(json);
   }
 
   static Set<String>? _primaryKeysForConjunctiveSplit(
@@ -111,6 +112,14 @@ sealed class JsonSchema {
 
     if (json['type'] is List) {
       return {'type'};
+    }
+
+    final type = json['type'];
+    if (type is String && json['enum'] is List) {
+      final enumValues = json['enum'] as List;
+      if (type != 'string' || !enumValues.every((value) => value is String)) {
+        return {'type'};
+      }
     }
 
     for (final keyword in const ['allOf', 'anyOf', 'oneOf', 'not']) {
@@ -138,27 +147,30 @@ sealed class JsonSchema {
     return null;
   }
 
-  static Map<String, dynamic> _schemaWithKeys(
-    Map<String, dynamic> json,
-    Set<String> keys,
-  ) {
-    return {
-      for (final key in keys)
-        if (json.containsKey(key)) key: json[key],
-    };
+  static bool _isValidJsonTypeArray(List<dynamic> types) {
+    if (types.isEmpty) {
+      return false;
+    }
+    final seen = <String>{};
+    for (final type in types) {
+      if (type is! String ||
+          !_knownJsonTypes.contains(type) ||
+          !seen.add(type)) {
+        return false;
+      }
+    }
+    return true;
   }
 
-  static Map<String, dynamic> _schemaWithoutKeys(
-    Map<String, dynamic> json,
-    Set<String> keys,
-  ) {
-    return {
-      for (final entry in json.entries)
-        if (!keys.contains(entry.key) &&
-            !_jsonSchemaAnnotationKeys.contains(entry.key))
-          entry.key: entry.value,
-    };
-  }
+  static const Set<String> _knownJsonTypes = {
+    'string',
+    'number',
+    'integer',
+    'boolean',
+    'null',
+    'array',
+    'object',
+  };
 
   static bool _hasOnlyAnnotationAnd(
     Map<String, dynamic> json,
@@ -404,6 +416,7 @@ sealed class JsonSchema {
 
 /// A schema for string values.
 class JsonString extends JsonSchema {
+  final bool _hasDefault;
   final int? minLength;
   final int? maxLength;
   final String? pattern;
@@ -424,13 +437,26 @@ class JsonString extends JsonSchema {
     super.title,
     super.description,
     this.defaultValue,
-  });
+  }) : _hasDefault = defaultValue != null;
+
+  const JsonString._({
+    this.minLength,
+    this.maxLength,
+    this.pattern,
+    this.format,
+    this.enumValues,
+    this.enumNames,
+    super.title,
+    super.description,
+    this.defaultValue,
+    required bool hasDefault,
+  }) : _hasDefault = hasDefault;
 
   @override
   final String? defaultValue;
 
   factory JsonString.fromJson(Map<String, dynamic> json) {
-    return JsonString(
+    return JsonString._(
       minLength: json['minLength'] as int?,
       maxLength: json['maxLength'] as int?,
       pattern: json['pattern'] as String?,
@@ -441,6 +467,7 @@ class JsonString extends JsonSchema {
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'] as String?,
+      hasDefault: json.containsKey('default'),
     );
   }
 
@@ -449,7 +476,7 @@ class JsonString extends JsonSchema {
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
       'type': 'string',
       if (minLength != null) 'minLength': minLength,
       if (maxLength != null) 'maxLength': maxLength,
@@ -463,6 +490,7 @@ class JsonString extends JsonSchema {
 
 /// A schema for number values.
 class JsonNumber extends JsonSchema {
+  final bool _hasDefault;
   final num? minimum;
   final num? maximum;
   final num? exclusiveMinimum;
@@ -478,13 +506,25 @@ class JsonNumber extends JsonSchema {
     this.defaultValue,
     super.title,
     super.description,
-  });
+  }) : _hasDefault = defaultValue != null;
+
+  const JsonNumber._({
+    this.minimum,
+    this.maximum,
+    this.exclusiveMinimum,
+    this.exclusiveMaximum,
+    this.multipleOf,
+    this.defaultValue,
+    super.title,
+    super.description,
+    required bool hasDefault,
+  }) : _hasDefault = hasDefault;
 
   @override
   final num? defaultValue;
 
   factory JsonNumber.fromJson(Map<String, dynamic> json) {
-    return JsonNumber(
+    return JsonNumber._(
       minimum: json['minimum'] as num?,
       maximum: json['maximum'] as num?,
       exclusiveMinimum: json['exclusiveMinimum'] as num?,
@@ -493,6 +533,7 @@ class JsonNumber extends JsonSchema {
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'] as num?,
+      hasDefault: json.containsKey('default'),
     );
   }
 
@@ -501,7 +542,7 @@ class JsonNumber extends JsonSchema {
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
       'type': 'number',
       if (minimum != null) 'minimum': minimum,
       if (maximum != null) 'maximum': maximum,
@@ -514,6 +555,7 @@ class JsonNumber extends JsonSchema {
 
 /// A schema for integer values.
 class JsonInteger extends JsonSchema {
+  final bool _hasDefault;
   final int? minimum;
   final int? maximum;
   final int? exclusiveMinimum;
@@ -529,13 +571,25 @@ class JsonInteger extends JsonSchema {
     this.defaultValue,
     super.title,
     super.description,
-  });
+  }) : _hasDefault = defaultValue != null;
+
+  const JsonInteger._({
+    this.minimum,
+    this.maximum,
+    this.exclusiveMinimum,
+    this.exclusiveMaximum,
+    this.multipleOf,
+    this.defaultValue,
+    super.title,
+    super.description,
+    required bool hasDefault,
+  }) : _hasDefault = hasDefault;
 
   @override
   final int? defaultValue;
 
   factory JsonInteger.fromJson(Map<String, dynamic> json) {
-    return JsonInteger(
+    return JsonInteger._(
       minimum: json['minimum'] as int?,
       maximum: json['maximum'] as int?,
       exclusiveMinimum: json['exclusiveMinimum'] as int?,
@@ -544,6 +598,7 @@ class JsonInteger extends JsonSchema {
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'] as int?,
+      hasDefault: json.containsKey('default'),
     );
   }
 
@@ -552,7 +607,7 @@ class JsonInteger extends JsonSchema {
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
       'type': 'integer',
       if (minimum != null) 'minimum': minimum,
       if (maximum != null) 'maximum': maximum,
@@ -565,20 +620,30 @@ class JsonInteger extends JsonSchema {
 
 /// A schema for boolean values.
 class JsonBoolean extends JsonSchema {
+  final bool _hasDefault;
+
   const JsonBoolean({
     this.defaultValue,
     super.title,
     super.description,
-  });
+  }) : _hasDefault = defaultValue != null;
+
+  const JsonBoolean._({
+    this.defaultValue,
+    super.title,
+    super.description,
+    required bool hasDefault,
+  }) : _hasDefault = hasDefault;
 
   @override
   final bool? defaultValue;
 
   factory JsonBoolean.fromJson(Map<String, dynamic> json) {
-    return JsonBoolean(
+    return JsonBoolean._(
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'] as bool?,
+      hasDefault: json.containsKey('default'),
     );
   }
 
@@ -587,7 +652,7 @@ class JsonBoolean extends JsonSchema {
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
       'type': 'boolean',
     };
   }
@@ -595,20 +660,30 @@ class JsonBoolean extends JsonSchema {
 
 /// A schema for null values.
 class JsonNull extends JsonSchema {
+  final bool _hasDefault;
+
   const JsonNull({
     this.defaultValue,
     super.title,
     super.description,
-  });
+  }) : _hasDefault = defaultValue != null;
+
+  const JsonNull._({
+    this.defaultValue,
+    super.title,
+    super.description,
+    required bool hasDefault,
+  }) : _hasDefault = hasDefault;
 
   @override
   final dynamic defaultValue;
 
   factory JsonNull.fromJson(Map<String, dynamic> json) {
-    return JsonNull(
+    return JsonNull._(
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'],
+      hasDefault: json.containsKey('default'),
     );
   }
 
@@ -617,7 +692,7 @@ class JsonNull extends JsonSchema {
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
       'type': 'null',
     };
   }
@@ -625,6 +700,7 @@ class JsonNull extends JsonSchema {
 
 /// A schema for array values.
 class JsonArray extends JsonSchema {
+  final bool _hasDefault;
   final JsonSchema? items;
   final int? minItems;
   final int? maxItems;
@@ -638,13 +714,24 @@ class JsonArray extends JsonSchema {
     this.defaultValue,
     super.title,
     super.description,
-  });
+  }) : _hasDefault = defaultValue != null;
+
+  const JsonArray._({
+    this.items,
+    this.minItems,
+    this.maxItems,
+    this.uniqueItems,
+    this.defaultValue,
+    super.title,
+    super.description,
+    required bool hasDefault,
+  }) : _hasDefault = hasDefault;
 
   @override
   final List<dynamic>? defaultValue;
 
   factory JsonArray.fromJson(Map<String, dynamic> json) {
-    return JsonArray(
+    return JsonArray._(
       items: json['items'] != null
           ? JsonSchema.fromJson(json['items'] as Map<String, dynamic>)
           : null,
@@ -654,6 +741,7 @@ class JsonArray extends JsonSchema {
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'] as List<dynamic>?,
+      hasDefault: json.containsKey('default'),
     );
   }
 
@@ -662,7 +750,7 @@ class JsonArray extends JsonSchema {
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
       'type': 'array',
       if (items != null) 'items': items!.toJson(),
       if (minItems != null) 'minItems': minItems,
@@ -674,6 +762,7 @@ class JsonArray extends JsonSchema {
 
 /// A schema for object values.
 class JsonObject extends JsonSchema {
+  final bool _hasDefault;
   final Map<String, JsonSchema>? properties;
   final List<String>? required;
 
@@ -689,7 +778,18 @@ class JsonObject extends JsonSchema {
     this.defaultValue,
     super.title,
     super.description,
-  });
+  }) : _hasDefault = defaultValue != null;
+
+  const JsonObject._({
+    this.properties,
+    this.required,
+    this.additionalProperties,
+    this.dependentRequired,
+    this.defaultValue,
+    super.title,
+    super.description,
+    required bool hasDefault,
+  }) : _hasDefault = hasDefault;
 
   @override
   final Map<String, dynamic>? defaultValue;
@@ -705,7 +805,7 @@ class JsonObject extends JsonSchema {
       );
     }
 
-    return JsonObject(
+    return JsonObject._(
       properties: (json['properties'] as Map<String, dynamic>?)?.map(
         (key, value) =>
             MapEntry(key, JsonSchema.fromJson(value as Map<String, dynamic>)),
@@ -717,6 +817,7 @@ class JsonObject extends JsonSchema {
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'] as Map<String, dynamic>?,
+      hasDefault: json.containsKey('default'),
     );
   }
 
@@ -725,7 +826,7 @@ class JsonObject extends JsonSchema {
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
       'type': 'object',
       if (properties != null)
         'properties': properties!.map((k, v) => MapEntry(k, v.toJson())),
@@ -742,13 +843,24 @@ class JsonObject extends JsonSchema {
 /// A schema that accepts any value, potentially with additional constraints not captured by other types.
 class JsonAny extends JsonSchema {
   final Map<String, dynamic> properties;
+  final bool _hasDefault;
 
   const JsonAny([
     this.properties = const {},
     String? title,
     String? description,
     this.defaultValue,
-  ]) : super(title: title, description: description);
+  ])  : _hasDefault = defaultValue != null,
+        super(title: title, description: description);
+
+  const JsonAny._(
+    this.properties,
+    String? title,
+    String? description,
+    this.defaultValue, {
+    required bool hasDefault,
+  })  : _hasDefault = hasDefault,
+        super(title: title, description: description);
 
   @override
   final dynamic defaultValue;
@@ -772,11 +884,12 @@ class JsonAny extends JsonSchema {
       }
     }
 
-    return JsonAny(
+    return JsonAny._(
       Map.unmodifiable(properties),
       title,
       description,
       defaultValue,
+      hasDefault: json.containsKey('default'),
     );
   }
 
@@ -785,7 +898,7 @@ class JsonAny extends JsonSchema {
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
       ...properties,
     };
   }
@@ -793,6 +906,7 @@ class JsonAny extends JsonSchema {
 
 /// A schema that accepts exactly one JSON value.
 class JsonConst extends JsonSchema {
+  final bool _hasDefault;
   final dynamic value;
 
   const JsonConst(
@@ -800,17 +914,26 @@ class JsonConst extends JsonSchema {
     this.defaultValue,
     super.title,
     super.description,
-  });
+  }) : _hasDefault = defaultValue != null;
+
+  const JsonConst._(
+    this.value, {
+    this.defaultValue,
+    super.title,
+    super.description,
+    required bool hasDefault,
+  }) : _hasDefault = hasDefault;
 
   @override
   final dynamic defaultValue;
 
   factory JsonConst.fromJson(Map<String, dynamic> json) {
-    return JsonConst(
+    return JsonConst._(
       json['const'],
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'],
+      hasDefault: json.containsKey('default'),
     );
   }
 
@@ -819,7 +942,7 @@ class JsonConst extends JsonSchema {
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
       'const': value,
     };
   }
@@ -827,6 +950,7 @@ class JsonConst extends JsonSchema {
 
 /// A schema that validates against any one of the given schemas.
 class JsonUnion extends JsonSchema {
+  final bool _hasDefault;
   final List<JsonSchema> schemas;
 
   const JsonUnion(
@@ -834,7 +958,15 @@ class JsonUnion extends JsonSchema {
     this.defaultValue,
     super.title,
     super.description,
-  });
+  }) : _hasDefault = defaultValue != null;
+
+  const JsonUnion._(
+    this.schemas, {
+    this.defaultValue,
+    super.title,
+    super.description,
+    required bool hasDefault,
+  }) : _hasDefault = hasDefault;
 
   @override
   final dynamic defaultValue;
@@ -845,7 +977,7 @@ class JsonUnion extends JsonSchema {
     final schemaProperties = Map<String, dynamic>.from(json)
       ..removeWhere((key, value) => commonKeys.contains(key));
 
-    return JsonUnion(
+    return JsonUnion._(
       types.whereType<String>().map((type) {
         return JsonSchema.fromJson({
           ...schemaProperties,
@@ -855,6 +987,7 @@ class JsonUnion extends JsonSchema {
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'],
+      hasDefault: json.containsKey('default'),
     );
   }
 
@@ -865,7 +998,7 @@ class JsonUnion extends JsonSchema {
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
       if (typeNames != null)
         'type': typeNames
       else
@@ -941,6 +1074,7 @@ class JsonUnion extends JsonSchema {
 
 /// A schema that validates against all of the given schemas.
 class JsonAllOf extends JsonSchema {
+  final bool _hasDefault;
   final List<JsonSchema> schemas;
 
   const JsonAllOf(
@@ -948,19 +1082,28 @@ class JsonAllOf extends JsonSchema {
     this.defaultValue,
     super.title,
     super.description,
-  });
+  }) : _hasDefault = defaultValue != null;
+
+  const JsonAllOf._(
+    this.schemas, {
+    this.defaultValue,
+    super.title,
+    super.description,
+    required bool hasDefault,
+  }) : _hasDefault = hasDefault;
 
   @override
   final dynamic defaultValue;
 
   factory JsonAllOf.fromJson(Map<String, dynamic> json) {
-    return JsonAllOf(
+    return JsonAllOf._(
       (json['allOf'] as List)
           .map((e) => JsonSchema.fromJson(e as Map<String, dynamic>))
           .toList(),
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'],
+      hasDefault: json.containsKey('default'),
     );
   }
 
@@ -969,7 +1112,7 @@ class JsonAllOf extends JsonSchema {
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
       'allOf': schemas.map((s) => s.toJson()).toList(),
     };
   }
@@ -977,6 +1120,7 @@ class JsonAllOf extends JsonSchema {
 
 /// A schema that validates against any of the given schemas.
 class JsonAnyOf extends JsonSchema {
+  final bool _hasDefault;
   final List<JsonSchema> schemas;
 
   const JsonAnyOf(
@@ -984,19 +1128,28 @@ class JsonAnyOf extends JsonSchema {
     this.defaultValue,
     super.title,
     super.description,
-  });
+  }) : _hasDefault = defaultValue != null;
+
+  const JsonAnyOf._(
+    this.schemas, {
+    this.defaultValue,
+    super.title,
+    super.description,
+    required bool hasDefault,
+  }) : _hasDefault = hasDefault;
 
   @override
   final dynamic defaultValue;
 
   factory JsonAnyOf.fromJson(Map<String, dynamic> json) {
-    return JsonAnyOf(
+    return JsonAnyOf._(
       (json['anyOf'] as List)
           .map((e) => JsonSchema.fromJson(e as Map<String, dynamic>))
           .toList(),
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'],
+      hasDefault: json.containsKey('default'),
     );
   }
 
@@ -1005,7 +1158,7 @@ class JsonAnyOf extends JsonSchema {
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
       'anyOf': schemas.map((s) => s.toJson()).toList(),
     };
   }
@@ -1013,6 +1166,7 @@ class JsonAnyOf extends JsonSchema {
 
 /// A schema that validates against exactly one of the given schemas.
 class JsonOneOf extends JsonSchema {
+  final bool _hasDefault;
   final List<JsonSchema> schemas;
 
   const JsonOneOf(
@@ -1020,19 +1174,28 @@ class JsonOneOf extends JsonSchema {
     this.defaultValue,
     super.title,
     super.description,
-  });
+  }) : _hasDefault = defaultValue != null;
+
+  const JsonOneOf._(
+    this.schemas, {
+    this.defaultValue,
+    super.title,
+    super.description,
+    required bool hasDefault,
+  }) : _hasDefault = hasDefault;
 
   @override
   final dynamic defaultValue;
 
   factory JsonOneOf.fromJson(Map<String, dynamic> json) {
-    return JsonOneOf(
+    return JsonOneOf._(
       (json['oneOf'] as List)
           .map((e) => JsonSchema.fromJson(e as Map<String, dynamic>))
           .toList(),
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'],
+      hasDefault: json.containsKey('default'),
     );
   }
 
@@ -1041,7 +1204,7 @@ class JsonOneOf extends JsonSchema {
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
       'oneOf': schemas.map((s) => s.toJson()).toList(),
     };
   }
@@ -1049,6 +1212,7 @@ class JsonOneOf extends JsonSchema {
 
 /// A schema that validates against none of the given schemas.
 class JsonNot extends JsonSchema {
+  final bool _hasDefault;
   final JsonSchema schema;
 
   const JsonNot(
@@ -1056,17 +1220,26 @@ class JsonNot extends JsonSchema {
     this.defaultValue,
     super.title,
     super.description,
-  });
+  }) : _hasDefault = defaultValue != null;
+
+  const JsonNot._(
+    this.schema, {
+    this.defaultValue,
+    super.title,
+    super.description,
+    required bool hasDefault,
+  }) : _hasDefault = hasDefault;
 
   @override
   final dynamic defaultValue;
 
   factory JsonNot.fromJson(Map<String, dynamic> json) {
-    return JsonNot(
+    return JsonNot._(
       JsonSchema.fromJson(json['not'] as Map<String, dynamic>),
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'],
+      hasDefault: json.containsKey('default'),
     );
   }
 
@@ -1075,7 +1248,7 @@ class JsonNot extends JsonSchema {
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
       'not': schema.toJson(),
     };
   }
@@ -1083,14 +1256,39 @@ class JsonNot extends JsonSchema {
 
 /// A schema for enum values.
 class JsonEnum extends JsonSchema {
+  final bool _hasDefault;
   final List<dynamic> values;
+  final String? _constListKeyword;
+  final String? _constListType;
+  final String? _enumValuesKeyword;
+  final dynamic _enumTypeKeyword;
 
   const JsonEnum(
     this.values, {
     this.defaultValue,
     super.title,
     super.description,
-  });
+  })  : _hasDefault = defaultValue != null,
+        _constListKeyword = null,
+        _constListType = null,
+        _enumValuesKeyword = null,
+        _enumTypeKeyword = null;
+
+  const JsonEnum._(
+    this.values, {
+    this.defaultValue,
+    super.title,
+    super.description,
+    String? constListKeyword,
+    String? constListType,
+    String? enumValuesKeyword,
+    dynamic enumTypeKeyword,
+    required bool hasDefault,
+  })  : _hasDefault = hasDefault,
+        _constListKeyword = constListKeyword,
+        _constListType = constListType,
+        _enumValuesKeyword = enumValuesKeyword,
+        _enumTypeKeyword = enumTypeKeyword;
 
   @override
   final dynamic defaultValue;
@@ -1120,17 +1318,35 @@ class JsonEnum extends JsonSchema {
           !_constSchemaListValuesAreStrings(json[constListKey])) {
         return false;
       }
+      if (constListKey == 'oneOf' &&
+          !_constSchemaListValuesAreUnique(json[constListKey])) {
+        return false;
+      }
       return true;
     }
     return false;
   }
 
   factory JsonEnum.fromJson(Map<String, dynamic> json) {
-    return JsonEnum(
+    final constListKey = _constSchemaListKey(json);
+    final enumValuesKeyword = json['values'] is List
+        ? 'values'
+        : json['enum'] is List
+            ? 'enum'
+            : null;
+
+    return JsonEnum._(
       _parseValues(json),
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'],
+      hasDefault: json.containsKey('default'),
+      constListKeyword: constListKey,
+      constListType: constListKey != null ? json['type'] as String? : null,
+      enumValuesKeyword: enumValuesKeyword,
+      enumTypeKeyword: enumValuesKeyword != null && json.containsKey('type')
+          ? json['type']
+          : null,
     );
   }
 
@@ -1143,10 +1359,46 @@ class JsonEnum extends JsonSchema {
       (entry) => entry.value is String,
     );
 
-    return {
+    final annotations = {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
-      if (defaultValue != null) 'default': defaultValue,
+      if (_hasDefault) 'default': defaultValue,
+    };
+
+    final constListKeyword = _constListKeyword;
+    if (constListKeyword != null) {
+      return {
+        ...annotations,
+        if (_constListType != null) 'type': _constListType,
+        constListKeyword: normalizedEntries
+            .map(
+              (entry) => {
+                'const': entry.value,
+                if (entry.title != null) 'title': entry.title,
+                if (entry.description != null) 'description': entry.description,
+                if (entry.hasDefault) 'default': entry.defaultValue,
+              },
+            )
+            .toList(),
+      };
+    }
+
+    final enumValuesKeyword = _enumValuesKeyword;
+    if (enumValuesKeyword != null) {
+      return {
+        ...annotations,
+        if (_enumTypeKeyword != null) 'type': _enumTypeKeyword,
+        enumValuesKeyword:
+            normalizedEntries.map((entry) => entry.value).toList(),
+        if (hasTitles)
+          'enumNames': normalizedEntries
+              .map((entry) => entry.title ?? '${entry.value}')
+              .toList(),
+      };
+    }
+
+    return {
+      ...annotations,
       if (allStrings) 'type': 'string',
       if (allStrings)
         'enum': normalizedEntries.map((entry) => entry.value as String).toList()
@@ -1158,6 +1410,8 @@ class JsonEnum extends JsonSchema {
               (entry) => {
                 'const': entry.value,
                 if (entry.title != null) 'title': entry.title,
+                if (entry.description != null) 'description': entry.description,
+                if (entry.hasDefault) 'default': entry.defaultValue,
               },
             )
             .toList(),
@@ -1197,8 +1451,16 @@ class JsonEnum extends JsonSchema {
         if (entry is Map && entry.containsKey('const')) {
           final value = entry['const'];
           final title = entry['title'];
-          if (title is String && title != '$value') {
-            return {'value': value, 'title': title};
+          final description = entry['description'];
+          if (title is String ||
+              description is String ||
+              entry.containsKey('default')) {
+            return {
+              'value': value,
+              if (title is String) 'title': title,
+              if (description is String) 'description': description,
+              if (entry.containsKey('default')) 'default': entry['default'],
+            };
           }
           return value;
         }
@@ -1239,15 +1501,80 @@ class JsonEnum extends JsonSchema {
         schemaList.every((entry) => entry is Map && entry['const'] is String);
   }
 
-  static ({dynamic value, String? title}) _normalizeEntry(dynamic entry) {
+  static bool _constSchemaListValuesAreUnique(dynamic schemaList) {
+    if (schemaList is! List) {
+      return false;
+    }
+    for (var i = 0; i < schemaList.length; i++) {
+      final left = schemaList[i];
+      if (left is! Map) {
+        return false;
+      }
+      for (var j = i + 1; j < schemaList.length; j++) {
+        final right = schemaList[j];
+        if (right is! Map) {
+          return false;
+        }
+        if (_jsonValuesEqual(left['const'], right['const'])) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  static bool _jsonValuesEqual(dynamic left, dynamic right) {
+    if (left is List && right is List) {
+      if (left.length != right.length) {
+        return false;
+      }
+      for (var i = 0; i < left.length; i++) {
+        if (!_jsonValuesEqual(left[i], right[i])) {
+          return false;
+        }
+      }
+      return true;
+    }
+    if (left is Map && right is Map) {
+      if (left.length != right.length) {
+        return false;
+      }
+      for (final key in left.keys) {
+        if (!right.containsKey(key) ||
+            !_jsonValuesEqual(left[key], right[key])) {
+          return false;
+        }
+      }
+      return true;
+    }
+    return left == right;
+  }
+
+  static ({
+    dynamic value,
+    String? title,
+    String? description,
+    bool hasDefault,
+    dynamic defaultValue,
+  }) _normalizeEntry(dynamic entry) {
     if (entry is Map && entry.containsKey('value')) {
       final title = entry['title'];
+      final description = entry['description'];
       return (
         value: entry['value'],
         title: title is String ? title : null,
+        description: description is String ? description : null,
+        hasDefault: entry.containsKey('default'),
+        defaultValue: entry['default'],
       );
     }
 
-    return (value: entry, title: null);
+    return (
+      value: entry,
+      title: null,
+      description: null,
+      hasDefault: false,
+      defaultValue: null,
+    );
   }
 }

--- a/lib/src/shared/json_schema/json_schema.dart
+++ b/lib/src/shared/json_schema/json_schema.dart
@@ -1,3 +1,5 @@
+const _jsonSchemaAnnotationKeys = {'title', 'description', 'default'};
+
 /// A builder for creating JSON Schemas in a type-safe way.
 sealed class JsonSchema {
   final String? title;
@@ -13,9 +15,19 @@ sealed class JsonSchema {
 
   /// Creates a [JsonSchema] from a JSON map.
   factory JsonSchema.fromJson(Map<String, dynamic> json) {
+    return _fromJson(json);
+  }
+
+  static JsonSchema _fromJson(Map<String, dynamic> json) {
     if (JsonEnum._canParse(json)) {
       return JsonEnum.fromJson(json);
     }
+
+    final conjunctiveSchema = _splitConjunctiveSchema(json);
+    if (conjunctiveSchema != null) {
+      return conjunctiveSchema;
+    }
+
     if (json.containsKey('const')) {
       return JsonConst.fromJson(json);
     }
@@ -60,6 +72,101 @@ sealed class JsonSchema {
     // Fallback for schemas without an explicit type, or unknown types.
     // This handles empty schemas {} which validate everything (JsonAny).
     return JsonAny.fromJson(json);
+  }
+
+  static JsonSchema? _splitConjunctiveSchema(Map<String, dynamic> json) {
+    final primaryKeys = _primaryKeysForConjunctiveSplit(json);
+    if (primaryKeys == null) {
+      return null;
+    }
+
+    final siblingKeys = json.keys
+        .where(
+          (key) =>
+              !primaryKeys.contains(key) &&
+              !_jsonSchemaAnnotationKeys.contains(key),
+        )
+        .toSet();
+    if (siblingKeys.isEmpty) {
+      return null;
+    }
+
+    return JsonAllOf(
+      [
+        _fromJson(_schemaWithKeys(json, primaryKeys)),
+        _fromJson(_schemaWithoutKeys(json, primaryKeys)),
+      ],
+      title: json['title'] as String?,
+      description: json['description'] as String?,
+      defaultValue: json['default'],
+    );
+  }
+
+  static Set<String>? _primaryKeysForConjunctiveSplit(
+    Map<String, dynamic> json,
+  ) {
+    if (json.containsKey('const')) {
+      return {'const'};
+    }
+
+    if (json['type'] is List) {
+      return {'type'};
+    }
+
+    for (final keyword in const ['allOf', 'anyOf', 'oneOf', 'not']) {
+      if (json.containsKey(keyword)) {
+        return {keyword};
+      }
+    }
+
+    if (json['type'] == null) {
+      final enumKeys = <String>{};
+      if (json['enum'] is List) {
+        enumKeys.add('enum');
+      }
+      if (json['values'] is List) {
+        enumKeys.add('values');
+      }
+      if (enumKeys.isNotEmpty) {
+        if (json['enumNames'] is List) {
+          enumKeys.add('enumNames');
+        }
+        return enumKeys;
+      }
+    }
+
+    return null;
+  }
+
+  static Map<String, dynamic> _schemaWithKeys(
+    Map<String, dynamic> json,
+    Set<String> keys,
+  ) {
+    return {
+      for (final key in keys)
+        if (json.containsKey(key)) key: json[key],
+    };
+  }
+
+  static Map<String, dynamic> _schemaWithoutKeys(
+    Map<String, dynamic> json,
+    Set<String> keys,
+  ) {
+    return {
+      for (final entry in json.entries)
+        if (!keys.contains(entry.key) &&
+            !_jsonSchemaAnnotationKeys.contains(entry.key))
+          entry.key: entry.value,
+    };
+  }
+
+  static bool _hasOnlyAnnotationAnd(
+    Map<String, dynamic> json,
+    Set<String> keys,
+  ) {
+    return json.keys.every(
+      (key) => keys.contains(key) || _jsonSchemaAnnotationKeys.contains(key),
+    );
   }
 
   /// Converts the schema to a JSON map.
@@ -998,11 +1105,21 @@ class JsonEnum extends JsonSchema {
       return true;
     }
     if (type == null && (json['enum'] is List || json['values'] is List)) {
-      return true;
+      return JsonSchema._hasOnlyAnnotationAnd(
+        json,
+        {'enum', 'values', 'enumNames'},
+      );
     }
-    if ((type == null || type == 'string') &&
-        (_isConstSchemaList(json['oneOf']) ||
-            _isConstSchemaList(json['anyOf']))) {
+
+    final constListKey = _constSchemaListKey(json);
+    if ((type == null || type == 'string') && constListKey != null) {
+      if (!JsonSchema._hasOnlyAnnotationAnd(json, {'type', constListKey})) {
+        return false;
+      }
+      if (type == 'string' &&
+          !_constSchemaListValuesAreStrings(json[constListKey])) {
+        return false;
+      }
       return true;
     }
     return false;
@@ -1093,10 +1210,33 @@ class JsonEnum extends JsonSchema {
     return const [];
   }
 
+  static String? _constSchemaListKey(Map<String, dynamic> json) {
+    final hasOneOf = _isConstSchemaList(json['oneOf']);
+    final hasAnyOf = _isConstSchemaList(json['anyOf']);
+    if (hasOneOf == hasAnyOf) {
+      return null;
+    }
+    return hasOneOf ? 'oneOf' : 'anyOf';
+  }
+
   static bool _isConstSchemaList(dynamic schemaList) {
     return schemaList is List &&
         schemaList.isNotEmpty &&
-        schemaList.every((entry) => entry is Map && entry.containsKey('const'));
+        schemaList.every(
+          (entry) =>
+              entry is Map &&
+              entry.containsKey('const') &&
+              entry.keys.every(
+                (key) =>
+                    key is String &&
+                    (key == 'const' || _jsonSchemaAnnotationKeys.contains(key)),
+              ),
+        );
+  }
+
+  static bool _constSchemaListValuesAreStrings(dynamic schemaList) {
+    return schemaList is List &&
+        schemaList.every((entry) => entry is Map && entry['const'] is String);
   }
 
   static ({dynamic value, String? title}) _normalizeEntry(dynamic entry) {

--- a/lib/src/shared/json_schema/json_schema.dart
+++ b/lib/src/shared/json_schema/json_schema.dart
@@ -13,6 +13,12 @@ sealed class JsonSchema {
 
   /// Creates a [JsonSchema] from a JSON map.
   factory JsonSchema.fromJson(Map<String, dynamic> json) {
+    if (JsonEnum._canParse(json)) {
+      return JsonEnum.fromJson(json);
+    }
+    if (json.containsKey('const')) {
+      return JsonConst.fromJson(json);
+    }
     if (json.containsKey('allOf')) {
       return JsonAllOf.fromJson(json);
     }
@@ -27,6 +33,9 @@ sealed class JsonSchema {
     }
 
     final type = json['type'];
+    if (type is List) {
+      return JsonUnion.fromJson(json);
+    }
     if (type is String) {
       switch (type) {
         case 'string':
@@ -249,6 +258,36 @@ sealed class JsonSchema {
   }) {
     return JsonNot(
       schema,
+      title: title,
+      description: description,
+      defaultValue: defaultValue,
+    );
+  }
+
+  /// Creates a const schema that accepts exactly [value].
+  static JsonConst constValue(
+    dynamic value, {
+    String? title,
+    String? description,
+    dynamic defaultValue,
+  }) {
+    return JsonConst(
+      value,
+      title: title,
+      description: description,
+      defaultValue: defaultValue,
+    );
+  }
+
+  /// Creates a union schema that accepts any one of [schemas].
+  static JsonUnion union(
+    List<JsonSchema> schemas, {
+    String? title,
+    String? description,
+    dynamic defaultValue,
+  }) {
+    return JsonUnion(
+      schemas,
       title: title,
       description: description,
       defaultValue: defaultValue,
@@ -561,20 +600,13 @@ class JsonObject extends JsonSchema {
 
     return JsonObject(
       properties: (json['properties'] as Map<String, dynamic>?)?.map(
-        (key, value) => MapEntry(
-          key,
-          JsonSchema.fromJson(value as Map<String, dynamic>),
-        ),
+        (key, value) =>
+            MapEntry(key, JsonSchema.fromJson(value as Map<String, dynamic>)),
       ),
       required: (json['required'] as List?)?.cast<String>(),
       additionalProperties: parsedAdditionalProps,
-      dependentRequired:
-          (json['dependentRequired'] as Map<String, dynamic>?)?.map(
-        (key, value) => MapEntry(
-          key,
-          (value as List).cast<String>(),
-        ),
-      ),
+      dependentRequired: (json['dependentRequired'] as Map<String, dynamic>?)
+          ?.map((key, value) => MapEntry(key, (value as List).cast<String>())),
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'] as Map<String, dynamic>?,
@@ -609,10 +641,7 @@ class JsonAny extends JsonSchema {
     String? title,
     String? description,
     this.defaultValue,
-  ]) : super(
-          title: title,
-          description: description,
-        );
+  ]) : super(title: title, description: description);
 
   @override
   final dynamic defaultValue;
@@ -651,6 +680,154 @@ class JsonAny extends JsonSchema {
       if (description != null) 'description': description,
       if (defaultValue != null) 'default': defaultValue,
       ...properties,
+    };
+  }
+}
+
+/// A schema that accepts exactly one JSON value.
+class JsonConst extends JsonSchema {
+  final dynamic value;
+
+  const JsonConst(
+    this.value, {
+    this.defaultValue,
+    super.title,
+    super.description,
+  });
+
+  @override
+  final dynamic defaultValue;
+
+  factory JsonConst.fromJson(Map<String, dynamic> json) {
+    return JsonConst(
+      json['const'],
+      title: json['title'] as String?,
+      description: json['description'] as String?,
+      defaultValue: json['default'],
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (title != null) 'title': title,
+      if (description != null) 'description': description,
+      if (defaultValue != null) 'default': defaultValue,
+      'const': value,
+    };
+  }
+}
+
+/// A schema that validates against any one of the given schemas.
+class JsonUnion extends JsonSchema {
+  final List<JsonSchema> schemas;
+
+  const JsonUnion(
+    this.schemas, {
+    this.defaultValue,
+    super.title,
+    super.description,
+  });
+
+  @override
+  final dynamic defaultValue;
+
+  factory JsonUnion.fromJson(Map<String, dynamic> json) {
+    final types = json['type'] as List;
+    final commonKeys = {'type', 'title', 'description', 'default'};
+    final schemaProperties = Map<String, dynamic>.from(json)
+      ..removeWhere((key, value) => commonKeys.contains(key));
+
+    return JsonUnion(
+      types.whereType<String>().map((type) {
+        return JsonSchema.fromJson({
+          ...schemaProperties,
+          'type': type,
+        });
+      }).toList(),
+      title: json['title'] as String?,
+      description: json['description'] as String?,
+      defaultValue: json['default'],
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    final typeNames = _typeNamesForTypeOnlySchemas();
+
+    return {
+      if (title != null) 'title': title,
+      if (description != null) 'description': description,
+      if (defaultValue != null) 'default': defaultValue,
+      if (typeNames != null)
+        'type': typeNames
+      else
+        'anyOf': schemas.map((schema) => schema.toJson()).toList(),
+    };
+  }
+
+  List<String>? _typeNamesForTypeOnlySchemas() {
+    final typeNames = <String>[];
+    for (final schema in schemas) {
+      final typeName = _typeNameForTypeOnlySchema(schema);
+      if (typeName == null) {
+        return null;
+      }
+      typeNames.add(typeName);
+    }
+    return typeNames;
+  }
+
+  String? _typeNameForTypeOnlySchema(JsonSchema schema) {
+    if (schema.title != null ||
+        schema.description != null ||
+        schema.defaultValue != null) {
+      return null;
+    }
+
+    return switch (schema) {
+      JsonString(
+        minLength: null,
+        maxLength: null,
+        pattern: null,
+        format: null,
+        enumValues: null,
+        enumNames: null,
+      ) =>
+        'string',
+      JsonNumber(
+        minimum: null,
+        maximum: null,
+        exclusiveMinimum: null,
+        exclusiveMaximum: null,
+        multipleOf: null,
+      ) =>
+        'number',
+      JsonInteger(
+        minimum: null,
+        maximum: null,
+        exclusiveMinimum: null,
+        exclusiveMaximum: null,
+        multipleOf: null,
+      ) =>
+        'integer',
+      JsonBoolean _ => 'boolean',
+      JsonNull _ => 'null',
+      JsonArray(
+        items: null,
+        minItems: null,
+        maxItems: null,
+        uniqueItems: null,
+      ) =>
+        'array',
+      JsonObject(
+        properties: null,
+        required: null,
+        additionalProperties: null,
+        dependentRequired: null,
+      ) =>
+        'object',
+      _ => null,
     };
   }
 }
@@ -815,6 +992,22 @@ class JsonEnum extends JsonSchema {
   List<dynamic> get normalizedValues =>
       values.map((value) => _normalizeEntry(value).value).toList();
 
+  static bool _canParse(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type == 'enum') {
+      return true;
+    }
+    if (type == null && (json['enum'] is List || json['values'] is List)) {
+      return true;
+    }
+    if ((type == null || type == 'string') &&
+        (_isConstSchemaList(json['oneOf']) ||
+            _isConstSchemaList(json['anyOf']))) {
+      return true;
+    }
+    return false;
+  }
+
   factory JsonEnum.fromJson(Map<String, dynamic> json) {
     return JsonEnum(
       _parseValues(json),
@@ -829,8 +1022,9 @@ class JsonEnum extends JsonSchema {
     final normalizedEntries =
         values.map((value) => _normalizeEntry(value)).toList(growable: false);
     final hasTitles = normalizedEntries.any((entry) => entry.title != null);
-    final allStrings =
-        normalizedEntries.every((entry) => entry.value is String);
+    final allStrings = normalizedEntries.every(
+      (entry) => entry.value is String,
+    );
 
     return {
       if (title != null) 'title': title,
@@ -880,9 +1074,9 @@ class JsonEnum extends JsonSchema {
       return List<dynamic>.from(enumValues);
     }
 
-    final oneOfValues = json['oneOf'];
-    if (oneOfValues is List) {
-      return oneOfValues.map((entry) {
+    final constValues = json['oneOf'] ?? json['anyOf'];
+    if (constValues is List) {
+      return constValues.map((entry) {
         if (entry is Map && entry.containsKey('const')) {
           final value = entry['const'];
           final title = entry['title'];
@@ -897,6 +1091,12 @@ class JsonEnum extends JsonSchema {
     }
 
     return const [];
+  }
+
+  static bool _isConstSchemaList(dynamic schemaList) {
+    return schemaList is List &&
+        schemaList.isNotEmpty &&
+        schemaList.every((entry) => entry is Map && entry.containsKey('const'));
   }
 
   static ({dynamic value, String? title}) _normalizeEntry(dynamic entry) {

--- a/lib/src/shared/json_schema/json_schema_validator.dart
+++ b/lib/src/shared/json_schema/json_schema_validator.dart
@@ -54,10 +54,8 @@ extension JsonSchemaValidation on JsonSchema {
         _validateOneOf(one, data, path);
       case final JsonNot not:
         _validateNot(not, data, path);
-      case JsonAny _:
-        // JsonAny validates everything, but might check for specific properties if any
-        // The implementation has 'properties' map, but it's unstructured.
-        break;
+      case final JsonAny any:
+        _validateAny(any, data, path);
     }
   }
 
@@ -350,6 +348,253 @@ extension JsonSchemaValidation on JsonSchema {
       'Value does not match any union type',
       path,
     );
+  }
+
+  void _validateAny(JsonAny schema, dynamic data, List<String> path) {
+    final keywords = schema.properties;
+
+    _validateTypeKeyword(keywords['type'], data, path);
+
+    if (keywords.containsKey('const')) {
+      _validateConstValue(keywords['const'], data, path);
+    }
+
+    final enumValues = keywords['enum'] ?? keywords['values'];
+    if (enumValues is List) {
+      _validateEnumValues(enumValues, data, path);
+    }
+
+    if (data is String) {
+      _validateString(
+        JsonString.fromJson(
+          _schemaForKeywords(
+            keywords,
+            'string',
+            const ['minLength', 'maxLength', 'pattern', 'format'],
+          ),
+        ),
+        data,
+        path,
+      );
+    }
+    if (data is num) {
+      _validateNumber(
+        JsonNumber.fromJson(
+          _schemaForKeywords(
+            keywords,
+            'number',
+            const [
+              'minimum',
+              'maximum',
+              'exclusiveMinimum',
+              'exclusiveMaximum',
+              'multipleOf',
+            ],
+          ),
+        ),
+        data,
+        path,
+      );
+    }
+    if (data is List) {
+      _validateArray(
+        JsonArray.fromJson(
+          _schemaForKeywords(
+            keywords,
+            'array',
+            const ['items', 'minItems', 'maxItems', 'uniqueItems'],
+          ),
+        ),
+        data,
+        path,
+      );
+    }
+    if (data is Map) {
+      _validateObject(
+        JsonObject.fromJson(
+          _schemaForKeywords(
+            keywords,
+            'object',
+            const [
+              'properties',
+              'required',
+              'additionalProperties',
+              'dependentRequired',
+            ],
+          ),
+        ),
+        data,
+        path,
+      );
+    }
+
+    _validateCompositionKeywords(keywords, data, path);
+  }
+
+  Map<String, dynamic> _schemaForKeywords(
+    Map<String, dynamic> keywords,
+    String type,
+    Iterable<String> keys,
+  ) {
+    return {
+      'type': type,
+      for (final key in keys)
+        if (keywords.containsKey(key)) key: keywords[key],
+    };
+  }
+
+  void _validateTypeKeyword(
+    dynamic typeKeyword,
+    dynamic data,
+    List<String> path,
+  ) {
+    if (typeKeyword is String) {
+      if (_isKnownJsonType(typeKeyword) &&
+          !_matchesJsonType(typeKeyword, data)) {
+        throw JsonSchemaValidationException(
+          'Expected $typeKeyword, got ${data.runtimeType}',
+          path,
+        );
+      }
+      return;
+    }
+
+    if (typeKeyword is List) {
+      final types = typeKeyword.whereType<String>().where(_isKnownJsonType);
+      if (types.isNotEmpty &&
+          !types.any((type) => _matchesJsonType(type, data))) {
+        throw JsonSchemaValidationException(
+          'Value does not match any allowed type',
+          path,
+        );
+      }
+    }
+  }
+
+  bool _isKnownJsonType(String type) {
+    return const {
+      'string',
+      'number',
+      'integer',
+      'boolean',
+      'null',
+      'array',
+      'object',
+    }.contains(type);
+  }
+
+  bool _matchesJsonType(String type, dynamic data) {
+    return switch (type) {
+      'string' => data is String,
+      'number' => data is num,
+      'integer' => data is int,
+      'boolean' => data is bool,
+      'null' => data == null,
+      'array' => data is List,
+      'object' => data is Map,
+      _ => true,
+    };
+  }
+
+  void _validateConstValue(
+    dynamic expected,
+    dynamic data,
+    List<String> path,
+  ) {
+    if (!_deepEquals(expected, data)) {
+      throw JsonSchemaValidationException(
+        'Value must equal $expected',
+        path,
+      );
+    }
+  }
+
+  void _validateEnumValues(
+    List<dynamic> values,
+    dynamic data,
+    List<String> path,
+  ) {
+    if (!values.any((value) => _deepEquals(value, data))) {
+      throw JsonSchemaValidationException(
+        'Value must be one of $values',
+        path,
+      );
+    }
+  }
+
+  void _validateCompositionKeywords(
+    Map<String, dynamic> keywords,
+    dynamic data,
+    List<String> path,
+  ) {
+    final allOf = keywords['allOf'];
+    if (allOf is List) {
+      for (final entry in allOf.whereType<Map>()) {
+        _validate(
+          JsonSchema.fromJson(Map<String, dynamic>.from(entry)),
+          data,
+          path,
+        );
+      }
+    }
+
+    final anyOf = keywords['anyOf'];
+    if (anyOf is List) {
+      final matches = anyOf.whereType<Map>().any((entry) {
+        try {
+          _validate(
+            JsonSchema.fromJson(Map<String, dynamic>.from(entry)),
+            data,
+            path,
+          );
+          return true;
+        } catch (_) {
+          return false;
+        }
+      });
+      if (!matches) {
+        throw JsonSchemaValidationException(
+          'Value does not match anyOf schemas',
+          path,
+        );
+      }
+    }
+
+    final oneOf = keywords['oneOf'];
+    if (oneOf is List) {
+      final matches = oneOf.whereType<Map>().where((entry) {
+        try {
+          _validate(
+            JsonSchema.fromJson(Map<String, dynamic>.from(entry)),
+            data,
+            path,
+          );
+          return true;
+        } catch (_) {
+          return false;
+        }
+      }).length;
+      if (matches != 1) {
+        throw JsonSchemaValidationException(
+          'Value matches $matches schemas, expected exactly 1 for oneOf',
+          path,
+        );
+      }
+    }
+
+    final not = keywords['not'];
+    if (not is Map) {
+      try {
+        _validate(
+          JsonSchema.fromJson(Map<String, dynamic>.from(not)),
+          data,
+          path,
+        );
+      } catch (_) {
+        return;
+      }
+      throw JsonSchemaValidationException('Value matches not schema', path);
+    }
   }
 
   void _validateAllOf(JsonAllOf schema, dynamic data, List<String> path) {

--- a/lib/src/shared/json_schema/json_schema_validator.dart
+++ b/lib/src/shared/json_schema/json_schema_validator.dart
@@ -42,6 +42,10 @@ extension JsonSchemaValidation on JsonSchema {
         _validateObject(o, data, path);
       case final JsonEnum e:
         _validateEnum(e, data, path);
+      case final JsonConst c:
+        _validateConst(c, data, path);
+      case final JsonUnion u:
+        _validateUnion(u, data, path);
       case final JsonAllOf all:
         _validateAllOf(all, data, path);
       case final JsonAnyOf any:
@@ -326,6 +330,28 @@ extension JsonSchemaValidation on JsonSchema {
     }
   }
 
+  void _validateConst(JsonConst schema, dynamic data, List<String> path) {
+    if (!_deepEquals(schema.value, data)) {
+      throw JsonSchemaValidationException(
+        'Value must equal ${schema.value}',
+        path,
+      );
+    }
+  }
+
+  void _validateUnion(JsonUnion schema, dynamic data, List<String> path) {
+    for (final subSchema in schema.schemas) {
+      try {
+        _validate(subSchema, data, path);
+        return;
+      } catch (_) {}
+    }
+    throw JsonSchemaValidationException(
+      'Value does not match any union type',
+      path,
+    );
+  }
+
   void _validateAllOf(JsonAllOf schema, dynamic data, List<String> path) {
     for (final subSchema in schema.schemas) {
       _validate(subSchema, data, path);
@@ -371,10 +397,7 @@ extension JsonSchemaValidation on JsonSchema {
     } catch (_) {
       return;
     }
-    throw JsonSchemaValidationException(
-      'Value matches not schema',
-      path,
-    );
+    throw JsonSchemaValidationException('Value matches not schema', path);
   }
 
   bool _hasUniqueItems(List data) {

--- a/lib/src/shared/json_schema/json_schema_validator.dart
+++ b/lib/src/shared/json_schema/json_schema_validator.dart
@@ -342,7 +342,9 @@ extension JsonSchemaValidation on JsonSchema {
       try {
         _validate(subSchema, data, path);
         return;
-      } catch (_) {}
+      } on JsonSchemaValidationException {
+        // This branch did not match; keep checking the remaining branches.
+      }
     }
     throw JsonSchemaValidationException(
       'Value does not match any union type',
@@ -460,9 +462,22 @@ extension JsonSchemaValidation on JsonSchema {
     }
 
     if (typeKeyword is List) {
-      final types = typeKeyword.whereType<String>().where(_isKnownJsonType);
-      if (types.isNotEmpty &&
-          !types.any((type) => _matchesJsonType(type, data))) {
+      final types = typeKeyword.map((type) {
+        if (type is! String || !_isKnownJsonType(type)) {
+          throw JsonSchemaValidationException(
+            'type array entries must be known JSON types',
+            path,
+          );
+        }
+        return type;
+      }).toList();
+      if (types.isEmpty || types.toSet().length != types.length) {
+        throw JsonSchemaValidationException(
+          'type array must contain unique known JSON types',
+          path,
+        );
+      }
+      if (!types.any((type) => _matchesJsonType(type, data))) {
         throw JsonSchemaValidationException(
           'Value does not match any allowed type',
           path,
@@ -528,10 +543,10 @@ extension JsonSchemaValidation on JsonSchema {
     List<String> path,
   ) {
     final allOf = keywords['allOf'];
-    if (allOf is List) {
-      for (final entry in allOf.whereType<Map>()) {
+    if (keywords.containsKey('allOf')) {
+      for (final entry in _compositionSchemaList('allOf', allOf, path)) {
         _validate(
-          JsonSchema.fromJson(Map<String, dynamic>.from(entry)),
+          JsonSchema.fromJson(entry),
           data,
           path,
         );
@@ -539,16 +554,16 @@ extension JsonSchemaValidation on JsonSchema {
     }
 
     final anyOf = keywords['anyOf'];
-    if (anyOf is List) {
-      final matches = anyOf.whereType<Map>().any((entry) {
+    if (keywords.containsKey('anyOf')) {
+      final matches = _compositionSchemaList('anyOf', anyOf, path).any((entry) {
         try {
           _validate(
-            JsonSchema.fromJson(Map<String, dynamic>.from(entry)),
+            JsonSchema.fromJson(entry),
             data,
             path,
           );
           return true;
-        } catch (_) {
+        } on JsonSchemaValidationException {
           return false;
         }
       });
@@ -561,16 +576,17 @@ extension JsonSchemaValidation on JsonSchema {
     }
 
     final oneOf = keywords['oneOf'];
-    if (oneOf is List) {
-      final matches = oneOf.whereType<Map>().where((entry) {
+    if (keywords.containsKey('oneOf')) {
+      final matches =
+          _compositionSchemaList('oneOf', oneOf, path).where((entry) {
         try {
           _validate(
-            JsonSchema.fromJson(Map<String, dynamic>.from(entry)),
+            JsonSchema.fromJson(entry),
             data,
             path,
           );
           return true;
-        } catch (_) {
+        } on JsonSchemaValidationException {
           return false;
         }
       }).length;
@@ -583,18 +599,43 @@ extension JsonSchemaValidation on JsonSchema {
     }
 
     final not = keywords['not'];
-    if (not is Map) {
+    if (keywords.containsKey('not')) {
+      if (not is! Map) {
+        throw JsonSchemaValidationException(
+          'not must be a schema object',
+          path,
+        );
+      }
       try {
         _validate(
           JsonSchema.fromJson(Map<String, dynamic>.from(not)),
           data,
           path,
         );
-      } catch (_) {
+      } on JsonSchemaValidationException {
         return;
       }
       throw JsonSchemaValidationException('Value matches not schema', path);
     }
+  }
+
+  List<Map<String, dynamic>> _compositionSchemaList(
+    String keyword,
+    dynamic value,
+    List<String> path,
+  ) {
+    if (value is! List) {
+      throw JsonSchemaValidationException('$keyword must be a list', path);
+    }
+    return value.map((entry) {
+      if (entry is! Map) {
+        throw JsonSchemaValidationException(
+          '$keyword entries must be schema objects',
+          path,
+        );
+      }
+      return Map<String, dynamic>.from(entry);
+    }).toList();
   }
 
   void _validateAllOf(JsonAllOf schema, dynamic data, List<String> path) {
@@ -610,7 +651,9 @@ extension JsonSchemaValidation on JsonSchema {
         _validate(subSchema, data, path);
         isValid = true;
         break;
-      } catch (_) {}
+      } on JsonSchemaValidationException {
+        // This branch did not match; keep checking the remaining branches.
+      }
     }
     if (!isValid) {
       throw JsonSchemaValidationException(
@@ -626,7 +669,9 @@ extension JsonSchemaValidation on JsonSchema {
       try {
         _validate(subSchema, data, path);
         validCount++;
-      } catch (_) {}
+      } on JsonSchemaValidationException {
+        // This branch did not match; keep checking the remaining branches.
+      }
     }
     if (validCount != 1) {
       throw JsonSchemaValidationException(
@@ -639,7 +684,7 @@ extension JsonSchemaValidation on JsonSchema {
   void _validateNot(JsonNot schema, dynamic data, List<String> path) {
     try {
       _validate(schema.schema, data, path);
-    } catch (_) {
+    } on JsonSchemaValidationException {
       return;
     }
     throw JsonSchemaValidationException('Value matches not schema', path);

--- a/test/shared/json_schema_from_json_test.dart
+++ b/test/shared/json_schema_from_json_test.dart
@@ -22,6 +22,16 @@ void main() {
       expect(s.enumValues, ['a', 'b']);
     });
 
+    test('preserves mixed typed enum schemas conjunctively', () {
+      final json = {
+        'type': 'string',
+        'enum': ['a', null],
+      };
+      final schema = JsonSchema.fromJson(json);
+      expect(schema, isA<JsonAny>());
+      expect(schema.toJson(), json);
+    });
+
     test('parses legacy enum schema', () {
       final json = {
         'type': 'enum',
@@ -41,6 +51,7 @@ void main() {
       expect(schema, isA<JsonEnum>());
       final s = schema as JsonEnum;
       expect(s.values, [1, 'a', null]);
+      expect(s.toJson(), json);
     });
 
     test('parses const schema', () {
@@ -80,14 +91,19 @@ void main() {
       final json = {
         'type': 'string',
         'oneOf': [
-          {'const': 'red', 'title': 'Red'},
-          {'const': 'blue', 'title': 'Blue'},
+          {
+            'const': 'red',
+            'title': 'Red',
+            'description': 'Primary red option',
+          },
+          {'const': 'blue', 'title': 'Blue', 'default': 'blue'},
         ],
       };
       final schema = JsonSchema.fromJson(json);
       expect(schema, isA<JsonEnum>());
       final s = schema as JsonEnum;
       expect(s.normalizedValues, ['red', 'blue']);
+      expect(s.toJson(), json);
     });
 
     test('parses titled array enum items from MCP elicitation', () {
@@ -105,6 +121,7 @@ void main() {
       final array = schema as JsonArray;
       expect(array.items, isA<JsonEnum>());
       expect((array.items! as JsonEnum).normalizedValues, ['red', 'blue']);
+      expect(array.toJson(), json);
     });
 
     test('parses number schema', () {
@@ -354,6 +371,77 @@ void main() {
       ]);
       final json = original.toJson();
       final parsed = JsonSchema.fromJson(json);
+      expect(parsed.toJson(), json);
+    });
+
+    test('type array union with sibling constraints preserves wire shape', () {
+      final json = {
+        'title': 'Optional mode',
+        'description':
+            'Official JSON Schema allows assertions beside type arrays',
+        'type': ['string', 'null'],
+        'enum': ['auto', null],
+        'default': 'auto',
+      };
+
+      final parsed = JsonSchema.fromJson(json);
+
+      expect(parsed.toJson(), json);
+    });
+
+    test('explicit null defaults preserve parsed wire shape', () {
+      final schemas = [
+        {
+          'type': 'string',
+          'default': null,
+        },
+        {
+          'const': 'DELETE',
+          'default': null,
+        },
+        {
+          'type': ['string', 'null'],
+          'enum': ['auto', null],
+          'default': null,
+        },
+        {
+          'oneOf': [
+            {'const': 'short', 'title': 'Short'},
+            {'const': 'longer', 'title': 'Longer'},
+          ],
+          'default': null,
+        },
+      ];
+
+      for (final json in schemas) {
+        expect(JsonSchema.fromJson(json).toJson(), json);
+      }
+    });
+
+    test('composition schema with sibling assertions preserves wire shape', () {
+      final json = {
+        'type': 'string',
+        'oneOf': [
+          {'const': 'short', 'title': 'Short'},
+          {'const': 'longer', 'title': 'Longer'},
+        ],
+        'minLength': 5,
+      };
+
+      final parsed = JsonSchema.fromJson(json);
+
+      expect(parsed.toJson(), json);
+    });
+
+    test('const schema with sibling assertions preserves wire shape', () {
+      final json = {
+        'type': 'string',
+        'const': 'DELETE',
+        'minLength': 6,
+      };
+
+      final parsed = JsonSchema.fromJson(json);
+
       expect(parsed.toJson(), json);
     });
 

--- a/test/shared/json_schema_from_json_test.dart
+++ b/test/shared/json_schema_from_json_test.dart
@@ -33,6 +33,80 @@ void main() {
       expect(s.values, ['simple', 'complex']);
     });
 
+    test('parses enum-only schema', () {
+      final json = {
+        'enum': [1, 'a', null],
+      };
+      final schema = JsonSchema.fromJson(json);
+      expect(schema, isA<JsonEnum>());
+      final s = schema as JsonEnum;
+      expect(s.values, [1, 'a', null]);
+    });
+
+    test('parses const schema', () {
+      final json = {'const': 'DELETE'};
+      final schema = JsonSchema.fromJson(json);
+      expect(schema, isA<JsonConst>());
+      final s = schema as JsonConst;
+      expect(s.value, 'DELETE');
+      expect(s.toJson(), json);
+    });
+
+    test('parses type array union schema', () {
+      final json = {
+        'type': ['string', 'null'],
+      };
+      final schema = JsonSchema.fromJson(json);
+      expect(schema, isA<JsonUnion>());
+      final s = schema as JsonUnion;
+      expect(s.schemas[0], isA<JsonString>());
+      expect(s.schemas[1], isA<JsonNull>());
+      expect(s.toJson(), json);
+    });
+
+    test('parses titled enum const schemas', () {
+      final json = {
+        'oneOf': [
+          {'const': 1, 'title': 'One'},
+          {'const': true, 'title': 'Enabled'},
+        ],
+      };
+      final schema = JsonSchema.fromJson(json);
+      expect(schema, isA<JsonEnum>());
+      expect(schema.toJson(), json);
+    });
+
+    test('parses titled string enum const schemas from MCP elicitation', () {
+      final json = {
+        'type': 'string',
+        'oneOf': [
+          {'const': 'red', 'title': 'Red'},
+          {'const': 'blue', 'title': 'Blue'},
+        ],
+      };
+      final schema = JsonSchema.fromJson(json);
+      expect(schema, isA<JsonEnum>());
+      final s = schema as JsonEnum;
+      expect(s.normalizedValues, ['red', 'blue']);
+    });
+
+    test('parses titled array enum items from MCP elicitation', () {
+      final json = {
+        'type': 'array',
+        'items': {
+          'anyOf': [
+            {'const': 'red', 'title': 'Red'},
+            {'const': 'blue', 'title': 'Blue'},
+          ],
+        },
+      };
+      final schema = JsonSchema.fromJson(json);
+      expect(schema, isA<JsonArray>());
+      final array = schema as JsonArray;
+      expect(array.items, isA<JsonEnum>());
+      expect((array.items! as JsonEnum).normalizedValues, ['red', 'blue']);
+    });
+
     test('parses number schema', () {
       final json = {
         'type': 'number',
@@ -261,6 +335,33 @@ void main() {
         properties: {'name': JsonSchema.string()},
         additionalProperties: false,
       );
+      final json = original.toJson();
+      final parsed = JsonSchema.fromJson(json);
+      expect(parsed.toJson(), json);
+    });
+
+    test('const round trip', () {
+      final original = JsonSchema.constValue('DELETE');
+      final json = original.toJson();
+      final parsed = JsonSchema.fromJson(json);
+      expect(parsed.toJson(), json);
+    });
+
+    test('type array union round trip', () {
+      final original = JsonSchema.union([
+        JsonSchema.string(),
+        JsonSchema.nullValue(),
+      ]);
+      final json = original.toJson();
+      final parsed = JsonSchema.fromJson(json);
+      expect(parsed.toJson(), json);
+    });
+
+    test('titled non-string enum round trip', () {
+      const original = JsonEnum([
+        {'value': 1, 'title': 'One'},
+        {'value': true, 'title': 'Enabled'},
+      ]);
       final json = original.toJson();
       final parsed = JsonSchema.fromJson(json);
       expect(parsed.toJson(), json);

--- a/test/shared/json_schema_test.dart
+++ b/test/shared/json_schema_test.dart
@@ -164,6 +164,21 @@ void main() {
       });
     });
 
+    test('JsonConst serializes correctly', () {
+      final schema = JsonSchema.constValue('DELETE');
+      expect(schema.toJson(), {'const': 'DELETE'});
+    });
+
+    test('JsonUnion serializes simple type arrays correctly', () {
+      final schema = JsonSchema.union([
+        JsonSchema.string(),
+        JsonSchema.nullValue(),
+      ]);
+      expect(schema.toJson(), {
+        'type': ['string', 'null'],
+      });
+    });
+
     test('JsonEnum serializes titled string values compatibly', () {
       const schema = JsonEnum([
         'simple',

--- a/test/shared/json_schema_validator_test.dart
+++ b/test/shared/json_schema_validator_test.dart
@@ -633,6 +633,98 @@ void main() {
           throwsA(isA<JsonSchemaValidationException>()),
         );
       });
+
+      test('rejects malformed raw composition keywords', () {
+        final schemas = [
+          {
+            'type': 'string',
+            'allOf': ['not a schema'],
+            'minLength': 1,
+          },
+          {
+            'type': 'string',
+            'anyOf': ['not a schema'],
+            'minLength': 1,
+          },
+          {
+            'type': 'string',
+            'oneOf': ['not a schema'],
+            'minLength': 1,
+          },
+          {
+            'type': 'string',
+            'not': 'not a schema',
+            'minLength': 1,
+          },
+        ];
+
+        for (final json in schemas) {
+          final schema = JsonSchema.fromJson(json);
+          expect(
+            () => schema.validate('value'),
+            throwsA(isA<JsonSchemaValidationException>()),
+          );
+        }
+      });
+
+      test('rejects malformed raw type arrays', () {
+        final schemas = [
+          {
+            'type': ['string', 1],
+          },
+          {
+            'type': ['string', 'bogus'],
+          },
+          {'type': <String>[]},
+          {
+            'type': ['string', 'string'],
+          },
+          {
+            'type': ['string', 1],
+            'enum': ['value'],
+          },
+        ];
+
+        for (final json in schemas) {
+          final schema = JsonSchema.fromJson(json);
+          expect(schema.toJson(), json);
+          expect(
+            () => schema.validate('value'),
+            throwsA(isA<JsonSchemaValidationException>()),
+          );
+        }
+      });
+
+      test('validates mixed typed enum schemas conjunctively', () {
+        final schema = JsonSchema.fromJson({
+          'type': 'string',
+          'enum': ['a', null],
+        });
+
+        schema.validate('a');
+        expect(
+          () => schema.validate(null),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+        expect(
+          () => schema.validate('b'),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+      });
+
+      test('preserves exact oneOf semantics for duplicate const branches', () {
+        final schema = JsonSchema.fromJson({
+          'oneOf': [
+            {'const': 'duplicate'},
+            {'const': 'duplicate'},
+          ],
+        });
+
+        expect(
+          () => schema.validate('duplicate'),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+      });
     });
 
     group('JsonAny validation', () {

--- a/test/shared/json_schema_validator_test.dart
+++ b/test/shared/json_schema_validator_test.dart
@@ -417,6 +417,21 @@ void main() {
         );
       });
 
+      test('validates enum-only schema from map', () {
+        final schema = JsonSchema.fromJson({
+          'enum': [1, 'a', null],
+        });
+
+        schema.validate(1);
+        schema.validate('a');
+        schema.validate(null);
+
+        expect(
+          () => schema.validate('b'),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+      });
+
       test('validates titled enum values against canonical values', () {
         final schema = const JsonEnum([
           'simple',
@@ -428,6 +443,74 @@ void main() {
 
         expect(
           () => schema.validate('Complex Option'),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+      });
+
+      test('round-tripped titled non-string enum stays strict', () {
+        const original = JsonEnum([
+          {'value': 1, 'title': 'One'},
+          {'value': true, 'title': 'Enabled'},
+        ]);
+        final schema = JsonSchema.fromJson(original.toJson());
+
+        schema.validate(1);
+        schema.validate(true);
+
+        expect(
+          () => schema.validate('One'),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+        expect(
+          () => schema.validate(false),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+      });
+
+      test('validates titled anyOf enum items against canonical values', () {
+        final schema = JsonSchema.fromJson({
+          'type': 'array',
+          'items': {
+            'anyOf': [
+              {'const': 'red', 'title': 'Red'},
+              {'const': 'blue', 'title': 'Blue'},
+            ],
+          },
+        });
+
+        schema.validate(['red', 'blue']);
+
+        expect(
+          () => schema.validate(['Red']),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+      });
+    });
+
+    group('const validation', () {
+      test('validates only the constant value', () {
+        final schema = JsonSchema.fromJson({'const': 'DELETE'});
+
+        schema.validate('DELETE');
+
+        expect(
+          () => schema.validate('delete'),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+      });
+    });
+
+    group('union validation', () {
+      test('validates type array union schema', () {
+        final schema = JsonSchema.fromJson({
+          'type': ['string', 'null'],
+        });
+
+        schema.validate('value');
+        schema.validate(null);
+
+        expect(
+          () => schema.validate(1),
           throwsA(isA<JsonSchemaValidationException>()),
         );
       });

--- a/test/shared/json_schema_validator_test.dart
+++ b/test/shared/json_schema_validator_test.dart
@@ -498,6 +498,22 @@ void main() {
           throwsA(isA<JsonSchemaValidationException>()),
         );
       });
+
+      test('preserves sibling assertions when parsing const schemas', () {
+        final schema = JsonSchema.fromJson({
+          'type': 'string',
+          'const': 1,
+        });
+
+        expect(
+          () => schema.validate(1),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+        expect(
+          () => schema.validate('1'),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+      });
     });
 
     group('union validation', () {
@@ -511,6 +527,24 @@ void main() {
 
         expect(
           () => schema.validate(1),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+      });
+
+      test('preserves top-level constraints around type array unions', () {
+        final schema = JsonSchema.fromJson({
+          'type': ['string', 'null'],
+          'enum': ['a'],
+        });
+
+        schema.validate('a');
+
+        expect(
+          () => schema.validate(null),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+        expect(
+          () => schema.validate('b'),
           throwsA(isA<JsonSchemaValidationException>()),
         );
       });
@@ -578,6 +612,24 @@ void main() {
         schema.validate(true);
         expect(
           () => schema.validate("string"),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+      });
+
+      test('preserves sibling assertions around const composition lists', () {
+        final schema = JsonSchema.fromJson({
+          'type': 'string',
+          'oneOf': [
+            {'const': 'a'},
+            {'const': 'bb'},
+          ],
+          'minLength': 2,
+        });
+
+        schema.validate('bb');
+
+        expect(
+          () => schema.validate('a'),
           throwsA(isA<JsonSchemaValidationException>()),
         );
       });


### PR DESCRIPTION
## Summary

- Add JSON Schema parser support for const, enum-only schemas, and type array unions instead of falling back to permissive JsonAny.
- Add builder/validator support for constant values and union schemas, including nullable forms like `{ "type": ["string", "null"] }`.
- Preserve strict round-tripping/validation for standard enums, titled oneOf/anyOf const enums, and mixed primitive enum values.
- Update docs and changelog for the JSON Schema API/documentation mismatch.

Fixes #108.

## MCP version and sources consulted

- Target MCP stable version: 2025-11-25.
- Official source consulted: `modelcontextprotocol/schema/2025-11-25/schema.ts`, especially elicitation enum schema forms using enum, oneOf[].const, and items.anyOf[].const.
- Existing mcp_dart JSON Schema parser, builder, validator, tests, `doc/tools.md`, and issue #108 acceptance criteria.

## Changed files

- `lib/src/shared/json_schema/json_schema.dart`
- `lib/src/shared/json_schema/json_schema_validator.dart`
- `test/shared/json_schema_from_json_test.dart`
- `test/shared/json_schema_test.dart`
- `test/shared/json_schema_validator_test.dart`
- `doc/tools.md`
- `CHANGELOG.md`

## Behavior/spec alignment

- `{ "const": "DELETE" }` now parses to a strict schema and validates only the constant value.
- `{ "enum": [1, "a", null] }` now parses as an enum schema without non-standard `type: "enum"`.
- `{ "type": ["string", "null"] }` now parses and validates as a JSON Schema type union.
- Titled enum schemas emitted through oneOf/anyOf with const retain canonical values when parsed back, including non-string values.

## Compatibility impact

- Existing typed schemas and legacy enum-name behavior are preserved.
- Previously unsupported const, enum-only, and type-array schemas become stricter after parsing instead of validating as JsonAny.

## Tests/checks run

- `dart format --output=none --set-exit-if-changed` on changed Dart files
- `dart analyze lib test`
- `dart test test/shared/json_schema_from_json_test.dart test/shared/json_schema_test.dart test/shared/json_schema_validator_test.dart`
- `TMPDIR=/workspace/tmp dart test --concurrency=1`

## Notes

- No repository-level `CONTRIBUTING.md` or pull request template was found in this checkout.
- Local full-suite run skipped TS interop tests that require compiled fixtures; upstream CI builds those fixtures before running interop.
