### PR TITLE
fix(completion): support context arguments and prompt titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+### Spec Alignment
+
+- Added MCP `completion/complete` wire support for
+  `context.arguments` and `PromptReference.title`, including context-aware
+  server completion callbacks for prompt and resource-template completions.
+
 ### Compatibility Notes
 
 - **Custom transports remain source-compatible while string request routing is available**:

--- a/doc/client-guide.md
+++ b/doc/client-guide.md
@@ -432,13 +432,15 @@ Get argument completion suggestions:
 // Complete resource template variable
 final result = await client.complete(
   CompleteRequest(
-    ref: CompletionReference(
-      type: CompletionReferenceType.resourceRef,
-      uri: 'users://{userId}/profile',
+    ref: const ResourceReference(
+      uri: 'users://{organization}/{userId}/profile',
     ),
-    argument: CompletionArgument(
+    argument: const ArgumentCompletionInfo(
       name: 'userId',
       value: 'ali',  // Partial value
+    ),
+    context: const CompletionContext(
+      arguments: {'organization': 'engineering'},
     ),
   ),
 );
@@ -457,13 +459,16 @@ if (result.completion.hasMore == true) {
 // Complete prompt argument
 final result = await client.complete(
   CompleteRequest(
-    ref: CompletionReference(
-      type: CompletionReferenceType.promptRef,
+    ref: const PromptReference(
       name: 'translate',
+      title: 'Translate text',
     ),
-    argument: CompletionArgument(
+    argument: const ArgumentCompletionInfo(
       name: 'target_language',
       value: 'Spa',  // Partial value
+    ),
+    context: const CompletionContext(
+      arguments: {'source_language': 'English'},
     ),
   ),
 );

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -467,13 +467,15 @@ final response = await makeAuthenticatedRequest(
 // Argument completion
 final result = await client.complete(
   CompleteRequest(
-    ref: CompletionReference(
-      type: CompletionReferenceType.resourceRef,
-      uri: 'users://{userId}/profile',
+    ref: const ResourceReference(
+      uri: 'users://{organization}/{userId}/profile',
     ),
-    argument: CompletionArgument(
+    argument: const ArgumentCompletionInfo(
       name: 'userId',
       value: 'ali',  // Partial input
+    ),
+    context: const CompletionContext(
+      arguments: {'organization': 'engineering'},
     ),
   ),
 );

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -748,13 +748,15 @@ await client.unsubscribeResource(UnsubscribeRequest(
 
 ```dart
 final result = await client.complete(CompleteRequest(
-  ref: CompletionReference(
-    type: CompletionReferenceType.resourceRef,
-    uri: 'users://{userId}/profile',
+  ref: const ResourceReference(
+    uri: 'users://{organization}/{userId}/profile',
   ),
-  argument: CompletionArgument(
+  argument: const ArgumentCompletionInfo(
     name: 'userId',
     value: 'al',  // Partial
+  ),
+  context: const CompletionContext(
+    arguments: {'organization': 'engineering'},
   ),
 ));
 
@@ -767,13 +769,16 @@ for (final value in result.completion.values) {
 
 ```dart
 final result = await client.complete(CompleteRequest(
-  ref: CompletionReference(
-    type: CompletionReferenceType.promptRef,
+  ref: const PromptReference(
     name: 'translate',
+    title: 'Translate text',
   ),
-  argument: CompletionArgument(
+  argument: const ArgumentCompletionInfo(
     name: 'language',
     value: 'Spa',
+  ),
+  context: const CompletionContext(
+    arguments: {'source_language': 'English'},
   ),
 ));
 ```

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -16,6 +16,12 @@ final _logger = Logger("mcp_dart.server.mcp");
 /// Callback capable of providing completions for a partial value.
 typedef CompleteCallback = FutureOr<List<String>> Function(String value);
 
+/// Callback capable of providing completions with request context.
+typedef CompleteWithContextCallback = FutureOr<List<String>> Function(
+  String value,
+  CompletionContext? context,
+);
+
 IconTheme? _iconThemeFromString(String? theme) {
   return switch (theme) {
     'light' => IconTheme.light,
@@ -43,7 +49,24 @@ class CompletableDef {
   /// The callback to invoke to get completion suggestions.
   final CompleteCallback complete;
 
-  const CompletableDef({required this.complete});
+  /// Optional callback that also receives `completion/complete` context.
+  final CompleteWithContextCallback? completeWithContext;
+
+  const CompletableDef({
+    required this.complete,
+    this.completeWithContext,
+  });
+
+  FutureOr<List<String>> completeValue(
+    String value,
+    CompletionContext? context,
+  ) {
+    final completeWithContext = this.completeWithContext;
+    if (completeWithContext != null) {
+      return completeWithContext(value, context);
+    }
+    return complete(value);
+  }
 }
 
 /// A field that supports auto-completion.
@@ -141,6 +164,13 @@ typedef CompleteResourceTemplateCallback = FutureOr<List<String>> Function(
   String currentValue,
 );
 
+/// Callback to complete a value within a resource template with request context.
+typedef CompleteResourceTemplateWithContextCallback = FutureOr<List<String>>
+    Function(
+  String currentValue,
+  CompletionContext? context,
+);
+
 /// Callback to list available tasks.
 typedef ListTasksCallback = FutureOr<ListTasksResult> Function(
   RequestHandlerExtra extra,
@@ -175,15 +205,34 @@ class ResourceTemplateRegistration {
   /// Callbacks to complete variables within the template.
   final Map<String, CompleteResourceTemplateCallback>? completeCallbacks;
 
+  /// Context-aware callbacks to complete variables within the template.
+  final Map<String, CompleteResourceTemplateWithContextCallback>?
+      completeCallbacksWithContext;
+
   ResourceTemplateRegistration(
     String templateString, {
     required this.listCallback,
     this.completeCallbacks,
+    this.completeCallbacksWithContext,
   }) : uriTemplate = UriTemplateExpander(templateString);
 
   /// Gets the completion callback for a specific variable.
   CompleteResourceTemplateCallback? getCompletionCallback(String variableName) {
     return completeCallbacks?[variableName];
+  }
+
+  FutureOr<List<String>>? completeVariable(
+    String variableName,
+    String currentValue,
+    CompletionContext? context,
+  ) {
+    final completeWithContext = completeCallbacksWithContext?[variableName];
+    if (completeWithContext != null) {
+      return completeWithContext(currentValue, context);
+    }
+    final complete = completeCallbacks?[variableName];
+    if (complete == null) return null;
+    return complete(currentValue);
   }
 }
 
@@ -1155,10 +1204,12 @@ class McpServer {
         final ResourceReference r => _handleResourceCompletion(
             r,
             request.completeParams.argument,
+            request.completeParams.context,
           ),
         final PromptReference p => _handlePromptCompletion(
             p,
             request.completeParams.argument,
+            request.completeParams.context,
           ),
       },
       (id, params, meta) => JsonRpcCompleteRequest.fromJson({
@@ -1173,15 +1224,18 @@ class McpServer {
   Future<CompleteResult> _handlePromptCompletion(
     PromptReference ref,
     ArgumentCompletionInfo argInfo,
+    CompletionContext? context,
   ) async {
     final prompt = _registeredPrompts[ref.name];
     if (prompt == null || !prompt.enabled) return _emptyCompletionResult();
 
     final argDef = prompt.argsSchemaDefinition?[argInfo.name];
-    final completer = argDef?.completable?.def.complete;
+    final completer = argDef?.completable?.def;
     if (completer == null) return _emptyCompletionResult();
     try {
-      return _createCompletionResult(await completer(argInfo.value));
+      return _createCompletionResult(
+        await completer.completeValue(argInfo.value, context),
+      );
     } catch (e) {
       _logger.warn(
         "Error during prompt argument completion for '${ref.name}.${argInfo.name}': $e",
@@ -1193,6 +1247,7 @@ class McpServer {
   Future<CompleteResult> _handleResourceCompletion(
     ResourceReference ref,
     ArgumentCompletionInfo argInfo,
+    CompletionContext? context,
   ) async {
     final templateEntry = _registeredResourceTemplates.entries.firstWhere(
       (e) => e.value.resourceTemplate.uriTemplate.toString() == ref.uri,
@@ -1203,11 +1258,14 @@ class McpServer {
     );
     if (!templateEntry.value.enabled) return _emptyCompletionResult();
 
-    final completer = templateEntry.value.resourceTemplate
-        .getCompletionCallback(argInfo.name);
-    if (completer == null) return _emptyCompletionResult();
+    final completions = templateEntry.value.resourceTemplate.completeVariable(
+      argInfo.name,
+      argInfo.value,
+      context,
+    );
+    if (completions == null) return _emptyCompletionResult();
     try {
-      return _createCompletionResult(await completer(argInfo.value));
+      return _createCompletionResult(await completions);
     } catch (e) {
       _logger.warn(
         "Error during resource template completion for '${ref.uri}' variable '${argInfo.name}': $e",

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -1258,13 +1258,13 @@ class McpServer {
     );
     if (!templateEntry.value.enabled) return _emptyCompletionResult();
 
-    final completions = templateEntry.value.resourceTemplate.completeVariable(
-      argInfo.name,
-      argInfo.value,
-      context,
-    );
-    if (completions == null) return _emptyCompletionResult();
     try {
+      final completions = templateEntry.value.resourceTemplate.completeVariable(
+        argInfo.name,
+        argInfo.value,
+        context,
+      );
+      if (completions == null) return _emptyCompletionResult();
       return _createCompletionResult(await completions);
     } catch (e) {
       _logger.warn(

--- a/lib/src/types/completion.dart
+++ b/lib/src/types/completion.dart
@@ -22,7 +22,10 @@ sealed class Reference {
         'type': type,
         ...switch (this) {
           final ResourceReference r => {'uri': r.uri},
-          final PromptReference p => {'name': p.name},
+          final PromptReference p => {
+              'name': p.name,
+              if (p.title != null) 'title': p.title,
+            },
         },
       };
 }
@@ -44,11 +47,18 @@ class ResourceReference extends Reference {
 class PromptReference extends Reference {
   final String name;
 
-  const PromptReference({required this.name}) : super(type: 'ref/prompt');
+  /// A human-readable title of the prompt.
+  final String? title;
+
+  const PromptReference({
+    required this.name,
+    this.title,
+  }) : super(type: 'ref/prompt');
 
   factory PromptReference.fromJson(Map<String, dynamic> json) {
     return PromptReference(
       name: json['name'] as String,
+      title: json['title'] as String?,
     );
   }
 }
@@ -79,6 +89,26 @@ class ArgumentCompletionInfo {
       };
 }
 
+/// Additional context for completion requests.
+class CompletionContext {
+  /// Previously-resolved variables in a URI template or prompt.
+  final Map<String, String>? arguments;
+
+  const CompletionContext({this.arguments});
+
+  factory CompletionContext.fromJson(Map<String, dynamic> json) {
+    return CompletionContext(
+      arguments: (json['arguments'] as Map<String, dynamic>?)?.map(
+        (key, value) => MapEntry(key, value as String),
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        if (arguments != null) 'arguments': arguments,
+      };
+}
+
 /// Parameters for the `completion/complete` request.
 class CompleteRequest {
   /// The reference identifying the completion target (prompt or resource).
@@ -87,7 +117,14 @@ class CompleteRequest {
   /// Information about the argument being completed.
   final ArgumentCompletionInfo argument;
 
-  const CompleteRequest({required this.ref, required this.argument});
+  /// Additional context for resolving completions.
+  final CompletionContext? context;
+
+  const CompleteRequest({
+    required this.ref,
+    required this.argument,
+    this.context,
+  });
 
   factory CompleteRequest.fromJson(Map<String, dynamic> json) =>
       CompleteRequest(
@@ -95,11 +132,17 @@ class CompleteRequest {
         argument: ArgumentCompletionInfo.fromJson(
           json['argument'] as Map<String, dynamic>,
         ),
+        context: json['context'] == null
+            ? null
+            : CompletionContext.fromJson(
+                json['context'] as Map<String, dynamic>,
+              ),
       );
 
   Map<String, dynamic> toJson() => {
         'ref': ref.toJson(),
         'argument': argument.toJson(),
+        if (context != null) 'context': context!.toJson(),
       };
 }
 

--- a/test/client/client_test.dart
+++ b/test/client/client_test.dart
@@ -281,17 +281,21 @@ void main() {
       transport.clearSentMessages();
 
       final params = const CompleteRequest(
-        ref: PromptReference(name: 'test-prompt'),
+        ref: PromptReference(name: 'test-prompt', title: 'Test Prompt'),
         argument: ArgumentCompletionInfo(name: 'arg1', value: 'val'),
+        context: CompletionContext(arguments: {'arg0': 'resolved'}),
       );
 
       await client.complete(params);
 
       // Verify a complete request was sent
       expect(transport.sentMessages.length, equals(1));
+      final request = transport.sentMessages.first as JsonRpcRequest;
+      expect(request.method, equals('completion/complete'));
+      expect(request.params?['ref']['title'], equals('Test Prompt'));
       expect(
-        (transport.sentMessages.first as JsonRpcRequest).method,
-        equals('completion/complete'),
+        request.params?['context']['arguments'],
+        equals({'arg0': 'resolved'}),
       );
     });
 

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -155,6 +155,64 @@ void main() {
       expect(deserializedPrompt.arguments?.single.title, 'Argument Title');
     });
 
+    test('CompleteRequest supports context arguments and prompt title', () {
+      final request = const CompleteRequest(
+        ref: PromptReference(
+          name: 'translate',
+          title: 'Translate prompt',
+        ),
+        argument: ArgumentCompletionInfo(
+          name: 'target_language',
+          value: 'Spa',
+        ),
+        context: CompletionContext(
+          arguments: {
+            'source_language': 'English',
+            'formality': 'formal',
+          },
+        ),
+      );
+
+      final json = request.toJson();
+      expect(json['ref']['type'], 'ref/prompt');
+      expect(json['ref']['name'], 'translate');
+      expect(json['ref']['title'], 'Translate prompt');
+      expect(json['context']['arguments']['source_language'], 'English');
+      expect(json['context']['arguments']['formality'], 'formal');
+
+      final deserialized = CompleteRequest.fromJson(json);
+      final ref = deserialized.ref as PromptReference;
+      expect(ref.name, 'translate');
+      expect(ref.title, 'Translate prompt');
+      expect(deserialized.context?.arguments, {
+        'source_language': 'English',
+        'formality': 'formal',
+      });
+
+      final message = JsonRpcMessage.fromJson({
+        'jsonrpc': '2.0',
+        'id': 1,
+        'method': 'completion/complete',
+        'params': json,
+      });
+      expect(message, isA<JsonRpcCompleteRequest>());
+
+      final completeRequest = message as JsonRpcCompleteRequest;
+      final promptRef = completeRequest.completeParams.ref as PromptReference;
+      expect(promptRef.title, 'Translate prompt');
+      expect(completeRequest.completeParams.context?.arguments, {
+        'source_language': 'English',
+        'formality': 'formal',
+      });
+      expect(
+        completeRequest.toJson()['params']['context']['arguments'],
+        {
+          'source_language': 'English',
+          'formality': 'formal',
+        },
+      );
+    });
+
     test('Elicitation with URL', () {
       final params = const ElicitRequestParams(
         message: 'test',

--- a/test/server/mcp_test.dart
+++ b/test/server/mcp_test.dart
@@ -980,6 +980,62 @@ void main() {
       expect(completion['values'], equals(['eng/alice', 'eng/alex']));
     });
 
+    test('resource template completion handles synchronous callback errors',
+        () async {
+      mcpServer.resourceTemplate(
+        'failing_template',
+        ResourceTemplateRegistration(
+          'failing://{path}',
+          listCallback: (extra) async =>
+              const ListResourcesResult(resources: []),
+          completeCallbacks: {
+            'path': (currentValue) {
+              throw StateError('completion exploded');
+            },
+          },
+        ),
+        (uri, variables, extra) async {
+          return ReadResourceResult(
+            contents: [
+              TextResourceContents(uri: uri.toString(), text: 'content'),
+            ],
+          );
+        },
+      );
+
+      await mcpServer.connect(transport);
+
+      final initRequest = JsonRpcInitializeRequest(
+        id: 1,
+        initParams: const InitializeRequestParams(
+          protocolVersion: latestProtocolVersion,
+          capabilities: ClientCapabilities(),
+          clientInfo: Implementation(name: 'TestClient', version: '1.0.0'),
+        ),
+      );
+      transport.receiveMessage(initRequest);
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final completeRequest = JsonRpcCompleteRequest(
+        id: 2,
+        completeParams: const CompleteRequestParams(
+          ref: ResourceReference(
+            uri: 'failing://{path}',
+          ),
+          argument: ArgumentCompletionInfo(name: 'path', value: 'docs'),
+        ),
+      );
+      transport.receiveMessage(completeRequest);
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final error = transport.sentMessages
+          .whereType<JsonRpcError>()
+          .where((r) => r.id == 2)
+          .first;
+      expect(error.error.code, equals(ErrorCode.internalError.value));
+      expect(error.error.message, equals('Completion failed'));
+    });
+
     test('prompt completion receives context arguments', () async {
       CompletionContext? receivedContext;
 

--- a/test/server/mcp_test.dart
+++ b/test/server/mcp_test.dart
@@ -904,7 +904,148 @@ void main() {
       transport.receiveMessage(completeRequest);
       await Future.delayed(const Duration(milliseconds: 10));
 
-      expect(transport.sentMessages.isNotEmpty, isTrue);
+      final response = transport.sentMessages
+          .whereType<JsonRpcResponse>()
+          .where((r) => r.id == 2)
+          .first;
+      final completion = response.result['completion'] as Map<String, dynamic>;
+      expect(
+        completion['values'],
+        equals(['documents/file1.txt', 'documents/file2.txt']),
+      );
+    });
+
+    test('resource template completion receives context arguments', () async {
+      CompletionContext? receivedContext;
+
+      mcpServer.resourceTemplate(
+        'context_template',
+        ResourceTemplateRegistration(
+          'users://{organization}/{userId}',
+          listCallback: (extra) async =>
+              const ListResourcesResult(resources: []),
+          completeCallbacksWithContext: {
+            'userId': (currentValue, context) async {
+              receivedContext = context;
+              final organization = context?.arguments?['organization'];
+              return ['alice', 'alex', 'bob']
+                  .where((user) => user.startsWith(currentValue))
+                  .map((user) => '$organization/$user')
+                  .toList();
+            },
+          },
+        ),
+        (uri, variables, extra) async {
+          return ReadResourceResult(
+            contents: [
+              TextResourceContents(uri: uri.toString(), text: 'content'),
+            ],
+          );
+        },
+      );
+
+      await mcpServer.connect(transport);
+
+      final initRequest = JsonRpcInitializeRequest(
+        id: 1,
+        initParams: const InitializeRequestParams(
+          protocolVersion: latestProtocolVersion,
+          capabilities: ClientCapabilities(),
+          clientInfo: Implementation(name: 'TestClient', version: '1.0.0'),
+        ),
+      );
+      transport.receiveMessage(initRequest);
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final completeRequest = JsonRpcCompleteRequest(
+        id: 2,
+        completeParams: const CompleteRequestParams(
+          ref: ResourceReference(
+            uri: 'users://{organization}/{userId}',
+          ),
+          argument: ArgumentCompletionInfo(name: 'userId', value: 'al'),
+          context: CompletionContext(arguments: {'organization': 'eng'}),
+        ),
+      );
+      transport.receiveMessage(completeRequest);
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      expect(receivedContext?.arguments, equals({'organization': 'eng'}));
+
+      final response = transport.sentMessages
+          .whereType<JsonRpcResponse>()
+          .where((r) => r.id == 2)
+          .first;
+      final completion = response.result['completion'] as Map<String, dynamic>;
+      expect(completion['values'], equals(['eng/alice', 'eng/alex']));
+    });
+
+    test('prompt completion receives context arguments', () async {
+      CompletionContext? receivedContext;
+
+      mcpServer.prompt(
+        'context_prompt',
+        argsSchema: {
+          'city': PromptArgumentDefinition(
+            completable: CompletableField(
+              def: CompletableDef(
+                complete: (value) async => [],
+                completeWithContext: (value, context) async {
+                  receivedContext = context;
+                  final country = context?.arguments?['country'];
+                  return ['$country/$value'];
+                },
+              ),
+            ),
+          ),
+        },
+        callback: (args, extra) async {
+          return const GetPromptResult(
+            messages: [
+              PromptMessage(
+                role: PromptMessageRole.user,
+                content: TextContent(text: 'ok'),
+              ),
+            ],
+          );
+        },
+      );
+
+      await mcpServer.connect(transport);
+
+      final initRequest = JsonRpcInitializeRequest(
+        id: 1,
+        initParams: const InitializeRequestParams(
+          protocolVersion: latestProtocolVersion,
+          capabilities: ClientCapabilities(),
+          clientInfo: Implementation(name: 'TestClient', version: '1.0.0'),
+        ),
+      );
+      transport.receiveMessage(initRequest);
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final completeRequest = JsonRpcCompleteRequest(
+        id: 2,
+        completeParams: const CompleteRequestParams(
+          ref: PromptReference(
+            name: 'context_prompt',
+            title: 'Context Prompt',
+          ),
+          argument: ArgumentCompletionInfo(name: 'city', value: 'Seoul'),
+          context: CompletionContext(arguments: {'country': 'KR'}),
+        ),
+      );
+      transport.receiveMessage(completeRequest);
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      expect(receivedContext?.arguments, equals({'country': 'KR'}));
+
+      final response = transport.sentMessages
+          .whereType<JsonRpcResponse>()
+          .where((r) => r.id == 2)
+          .first;
+      final completion = response.result['completion'] as Map<String, dynamic>;
+      expect(completion['values'], equals(['KR/Seoul']));
     });
 
     test('completion limits results to 100 items', () async {


### PR DESCRIPTION
## Summary

- Add `completion/complete` request support for `context.arguments` and preserve `PromptReference.title` during wire serialization/deserialization.
- Add `CompletionContext` to completion request types and ensure client-sent JSON-RPC requests round-trip the new fields.
- Add context-aware server completion callback paths for prompt arguments and resource template variables while preserving existing callback APIs as fallback.
- Update completion docs, examples, quick reference, and changelog for the new stable-spec fields.

## MCP version and sources consulted

- Target MCP stable version: 2025-11-25.
- Official source consulted: `modelcontextprotocol/schema/2025-11-25/schema.ts`, especially `CompleteRequestParams.context.arguments`, `PromptReference`, and `BaseMetadata.title`.
- Existing mcp_dart completion types, client completion request flow, server prompt/resource-template completion flow, docs, examples, and completion tests.

## Changed files

- `lib/src/types/completion.dart`
- `lib/src/server/mcp_server.dart`
- `test/client/client_test.dart`
- `test/server/mcp_test.dart`
- `test/mcp_2025_11_25_test.dart`
- `doc/client-guide.md`
- `doc/quick-reference.md`
- `doc/examples.md`
- `CHANGELOG.md`

## Behavior/spec alignment

- `CompleteRequest` now accepts optional `CompletionContext` and serializes/deserializes `context.arguments` as the stable schema's string map.
- `PromptReference` now carries optional `title` via the stable schema's `BaseMetadata` shape and preserves it through `toJson`, `fromJson`, and JSON-RPC parsing.
- `Client.complete` can send prompt reference titles and completion context arguments on the wire.
- Server prompt completion can receive request context through `CompletableDef.completeWithContext`.
- Server resource template completion can receive request context through `ResourceTemplateRegistration.completeCallbacksWithContext`.
- Existing non-context completion callbacks remain supported and are used when no context-aware callback is supplied.

## Compatibility impact

- Existing `PromptReference(name: ...)` and `CompleteRequest(ref: ..., argument: ...)` usages continue to work because the new fields are optional.
- Existing `CompleteCallback` and resource template `completeCallbacks` continue to work unchanged.
- Context-aware callbacks are opt-in and take precedence only when explicitly provided.
- Wire output remains limited to stable MCP fields for this feature area.

## Tests/checks run

- `dart format .`
- `dart analyze lib test`
- Targeted completion/client/server/spec tests
- `TMPDIR=/workspace/tmp dart test --concurrency=1`

## Notes

- No dependency or manifest changes were made.
- No local path dependency workaround was used.
- GitHub push/PR creation still requires credentials outside this execution environment.
