### PR TITLE
fix: return task from cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
   - `TaskClient.cancelTask` now expects a task-shaped result and will reject
     older non-compliant servers that still return `{}`.
   - `Task.fromJson()` requires MCP-required task fields (`createdAt`,
-    `lastUpdatedAt`, and `ttl`) and `Task.toJson()` requires timestamps before
-    emitting task-shaped protocol results.
+    `lastUpdatedAt`, and `ttl`), and the `Task` constructor now requires
+    `ttl`, `createdAt`, and `lastUpdatedAt` so serialization is non-throwing
+    for valid task instances.
   - `Task.toJson()` continues to serialize required `ttl` even when it is
     `null`, and now omits optional `pollInterval` when it is not set.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### Compatibility Notes
 
+- **Task cancellation now returns the final task state**:
+  - `tasks/cancel` responses now serialize the cancelled `Task` required by MCP
+    2025-11-25 instead of an empty result object.
+  - `CancelTaskCallback`, `ToolTaskHandler.cancelTask`, and
+    `TaskClient.cancelTask` return the cancelled `Task`, so server handlers
+    should return the post-cancellation task state.
+
 - **Custom transports remain source-compatible while string request routing is available**:
   - `Transport.send(... relatedRequestId: ...)` keeps the existing `int?`
     signature for third-party custom transports and middleware.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-### Compatibility Notes
+### Compatibility Notes (Potentially Breaking)
 
 - **Task cancellation now returns the final task state**:
   - `tasks/cancel` responses now serialize the cancelled `Task` required by MCP
@@ -8,6 +8,13 @@
   - `CancelTaskCallback`, `ToolTaskHandler.cancelTask`, and
     `TaskClient.cancelTask` return the cancelled `Task`, so server handlers
     should return the post-cancellation task state.
+  - `TaskClient.cancelTask` now expects a task-shaped result and will reject
+    older non-compliant servers that still return `{}`.
+  - `Task.fromJson()` requires MCP-required task fields (`createdAt`,
+    `lastUpdatedAt`, and `ttl`) and `Task.toJson()` requires timestamps before
+    emitting task-shaped protocol results.
+  - `Task.toJson()` continues to serialize required `ttl` even when it is
+    `null`, and now omits optional `pollInterval` when it is not set.
 
 - **Custom transports remain source-compatible while string request routing is available**:
   - `Transport.send(... relatedRequestId: ...)` keeps the existing `int?`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@
 - **Task cancellation now returns the final task state**:
   - `tasks/cancel` responses now serialize the cancelled `Task` required by MCP
     2025-11-25 instead of an empty result object.
-  - `CancelTaskCallback`, `ToolTaskHandler.cancelTask`, and
-    `TaskClient.cancelTask` return the cancelled `Task`, so server handlers
-    should return the post-cancellation task state.
-  - `TaskClient.cancelTask` now expects a task-shaped result and will reject
-    older non-compliant servers that still return `{}`.
+  - New spec-compliant APIs expose that result explicitly:
+    `onCancelTaskWithResult`, `CancelTaskCallback`,
+    `CancelTaskResultHandler.cancelTaskWithResult`, and
+    `TaskClient.cancelTaskWithResult` return the cancelled `Task`.
+  - Legacy APIs remain source-compatible for one compatibility window:
+    `onCancelTask`, `ToolTaskHandler.cancelTask`, and `TaskClient.cancelTask`
+    are deprecated shims. The server-side legacy shims still return a full
+    cancelled `Task` on the wire by resolving the post-cancel task through
+    `onGetTask`/`getTask`.
+  - `TaskClient.cancelTaskWithResult` expects a task-shaped result and will
+    reject older non-compliant servers that still return `{}`. Deprecated
+    `TaskClient.cancelTask` remains available when callers intentionally need
+    the legacy empty-result behavior.
   - `Task.fromJson()` requires MCP-required task fields (`createdAt`,
     `lastUpdatedAt`, and `ttl`), and the `Task` constructor now requires
     `ttl`, `createdAt`, and `lastUpdatedAt` so serialization is non-throwing

--- a/doc/migration_2025_11_25_compat.md
+++ b/doc/migration_2025_11_25_compat.md
@@ -12,7 +12,11 @@ This guide helps update existing code that used older sampling/tool-choice APIs.
   provide normalized list access.
 - `tasks/cancel` returns the final cancelled `Task` as its JSON-RPC result.
   `onCancelTask`, `ToolTaskHandler.cancelTask`, and `TaskClient.cancelTask`
-  now return that `Task` instead of an empty result.
+  now return that `Task` instead of an empty result. This is a source-breaking
+  change for cancellation handlers, and `TaskClient.cancelTask` now expects a
+  task-shaped result from MCP 2025-11-25-compatible servers.
+- Task serialization keeps the MCP-required `ttl` field even when it is `null`,
+  while omitting optional `pollInterval` when it is not set.
 - Streamable HTTP defaults are stricter for protocol-version headers, DNS
   rebinding protection, and batch request rejection.
 
@@ -120,7 +124,13 @@ After:
 
 ```dart
 server.experimental.onCancelTask((taskId, extra) async {
-  await store.cancelTask(taskId);
+  final cancelled = await store.cancelTask(taskId);
+  if (!cancelled) {
+    throw McpError(
+      ErrorCode.invalidParams.value,
+      'Cannot cancel task: not found or already terminal',
+    );
+  }
   final task = await store.getTask(taskId);
   if (task == null) {
     throw McpError(ErrorCode.invalidParams.value, 'Task not found');

--- a/doc/migration_2025_11_25_compat.md
+++ b/doc/migration_2025_11_25_compat.md
@@ -17,6 +17,8 @@ This guide helps update existing code that used older sampling/tool-choice APIs.
   task-shaped result from MCP 2025-11-25-compatible servers.
 - Task serialization keeps the MCP-required `ttl` field even when it is `null`,
   while omitting optional `pollInterval` when it is not set.
+- The `Task` constructor now requires `ttl`, `createdAt`, and `lastUpdatedAt`,
+  so valid task instances serialize without throwing.
 - Streamable HTTP defaults are stricter for protocol-version headers, DNS
   rebinding protection, and batch request rejection.
 

--- a/doc/migration_2025_11_25_compat.md
+++ b/doc/migration_2025_11_25_compat.md
@@ -10,6 +10,9 @@ This guide helps update existing code that used older sampling/tool-choice APIs.
   single block or a list of blocks.
 - `SamplingMessage.contentBlocks` and `CreateMessageResult.contentBlocks`
   provide normalized list access.
+- `tasks/cancel` returns the final cancelled `Task` as its JSON-RPC result.
+  `onCancelTask`, `ToolTaskHandler.cancelTask`, and `TaskClient.cancelTask`
+  now return that `Task` instead of an empty result.
 - Streamable HTTP defaults are stricter for protocol-version headers, DNS
   rebinding protection, and batch request rejection.
 
@@ -100,3 +103,34 @@ for (final block in result.contentBlocks) {
   // ...
 }
 ```
+
+### Task cancellation result
+
+Before:
+
+```dart
+server.experimental.onCancelTask((taskId, extra) async {
+  await store.cancelTask(taskId);
+});
+
+await taskClient.cancelTask(taskId);
+```
+
+After:
+
+```dart
+server.experimental.onCancelTask((taskId, extra) async {
+  await store.cancelTask(taskId);
+  final task = await store.getTask(taskId);
+  if (task == null) {
+    throw McpError(ErrorCode.invalidParams.value, 'Task not found');
+  }
+  return task;
+});
+
+final cancelledTask = await taskClient.cancelTask(taskId);
+```
+
+Returned cancelled tasks should include the MCP-required task fields:
+`taskId`, `status`, `createdAt`, `lastUpdatedAt`, and `ttl` (`null` is valid
+for `ttl`).

--- a/doc/migration_2025_11_25_compat.md
+++ b/doc/migration_2025_11_25_compat.md
@@ -11,10 +11,11 @@ This guide helps update existing code that used older sampling/tool-choice APIs.
 - `SamplingMessage.contentBlocks` and `CreateMessageResult.contentBlocks`
   provide normalized list access.
 - `tasks/cancel` returns the final cancelled `Task` as its JSON-RPC result.
-  `onCancelTask`, `ToolTaskHandler.cancelTask`, and `TaskClient.cancelTask`
-  now return that `Task` instead of an empty result. This is a source-breaking
-  change for cancellation handlers, and `TaskClient.cancelTask` now expects a
-  task-shaped result from MCP 2025-11-25-compatible servers.
+  Use `onCancelTaskWithResult`, `CancelTaskResultHandler.cancelTaskWithResult`,
+  and `TaskClient.cancelTaskWithResult` to access the result explicitly.
+  Legacy `onCancelTask`, `ToolTaskHandler.cancelTask`, and
+  `TaskClient.cancelTask` remain available as deprecated compatibility shims for
+  one release window.
 - Task serialization keeps the MCP-required `ttl` field even when it is `null`,
   while omitting optional `pollInterval` when it is not set.
 - The `Task` constructor now requires `ttl`, `createdAt`, and `lastUpdatedAt`,
@@ -122,10 +123,14 @@ server.experimental.onCancelTask((taskId, extra) async {
 await taskClient.cancelTask(taskId);
 ```
 
+The deprecated `onCancelTask` compatibility shim may still be used during the
+migration window, but it must be paired with `onGetTask` so the server can return
+the final cancelled task on the wire.
+
 After:
 
 ```dart
-server.experimental.onCancelTask((taskId, extra) async {
+server.experimental.onCancelTaskWithResult((taskId, extra) async {
   final cancelled = await store.cancelTask(taskId);
   if (!cancelled) {
     throw McpError(
@@ -140,7 +145,7 @@ server.experimental.onCancelTask((taskId, extra) async {
   return task;
 });
 
-final cancelledTask = await taskClient.cancelTask(taskId);
+final cancelledTask = await taskClient.cancelTaskWithResult(taskId);
 ```
 
 Returned cancelled tasks should include the MCP-required task fields:

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -217,7 +217,16 @@ server.registerPrompt(
 
 ```dart
 server.experimental.onListTasks((extra) async => ListTasksResult(tasks: []));
-server.experimental.onCancelTask((taskId, extra) async { /* cancel */ });
+server.experimental.onCancelTask((taskId, extra) async {
+  // Cancel the task and return its final cancelled state.
+  return Task(
+    taskId: taskId,
+    status: TaskStatus.cancelled,
+    createdAt: DateTime.now().toIso8601String(),
+    lastUpdatedAt: DateTime.now().toIso8601String(),
+    ttl: null,
+  );
+});
 server.experimental.onGetTask((taskId, extra) async { /* get */ });
 server.experimental.onTaskResult((taskId, extra) async { /* result */ });
 ```

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -217,7 +217,7 @@ server.registerPrompt(
 
 ```dart
 server.experimental.onListTasks((extra) async => ListTasksResult(tasks: []));
-server.experimental.onCancelTask((taskId, extra) async {
+server.experimental.onCancelTaskWithResult((taskId, extra) async {
   // Cancel the task and return its final cancelled state.
   final cancelled = await store.cancelTask(taskId);
   if (!cancelled) {

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -219,16 +219,29 @@ server.registerPrompt(
 server.experimental.onListTasks((extra) async => ListTasksResult(tasks: []));
 server.experimental.onCancelTask((taskId, extra) async {
   // Cancel the task and return its final cancelled state.
-  return Task(
-    taskId: taskId,
-    status: TaskStatus.cancelled,
-    createdAt: DateTime.now().toIso8601String(),
-    lastUpdatedAt: DateTime.now().toIso8601String(),
-    ttl: null,
-  );
+  final cancelled = await store.cancelTask(taskId);
+  if (!cancelled) {
+    throw McpError(
+      ErrorCode.invalidParams.value,
+      'Cannot cancel task: not found or already terminal',
+    );
+  }
+  final task = await store.getTask(taskId);
+  if (task == null) {
+    throw McpError(ErrorCode.invalidParams.value, 'Task not found');
+  }
+  return task;
 });
-server.experimental.onGetTask((taskId, extra) async { /* get */ });
-server.experimental.onTaskResult((taskId, extra) async { /* result */ });
+server.experimental.onGetTask((taskId, extra) async {
+  final task = await store.getTask(taskId);
+  if (task == null) {
+    throw McpError(ErrorCode.invalidParams.value, 'Task not found');
+  }
+  return task;
+});
+server.experimental.onTaskResult((taskId, extra) async {
+  return await store.getTaskResult(taskId);
+});
 ```
 
 ### Connect Transport

--- a/doc/server-guide.md
+++ b/doc/server-guide.md
@@ -729,9 +729,10 @@ server.experimental.onListTasks((extra) async {
       Task(
         taskId: 'task-1',
         status: TaskStatus.working,
+        statusMessage: 'Long operation is running',
+        ttl: null,
         createdAt: DateTime.now().toIso8601String(),
-        name: 'Long Operation',
-        description: 'A task that takes a long time',
+        lastUpdatedAt: DateTime.now().toIso8601String(),
       ),
     ],
   );
@@ -739,6 +740,14 @@ server.experimental.onListTasks((extra) async {
 
 server.experimental.onCancelTask((taskId, extra) async {
   // Logic to cancel the task
+  return Task(
+    taskId: taskId,
+    status: TaskStatus.cancelled,
+    statusMessage: 'Task cancelled',
+    ttl: null,
+    createdAt: DateTime.now().toIso8601String(),
+    lastUpdatedAt: DateTime.now().toIso8601String(),
+  );
 });
 
 server.experimental.onGetTask((taskId, extra) async {
@@ -746,7 +755,9 @@ server.experimental.onGetTask((taskId, extra) async {
   return Task(
     taskId: taskId,
     status: TaskStatus.working,
+    ttl: null,
     createdAt: DateTime.now().toIso8601String(),
+    lastUpdatedAt: DateTime.now().toIso8601String(),
   );
 });
 

--- a/doc/server-guide.md
+++ b/doc/server-guide.md
@@ -738,7 +738,7 @@ server.experimental.onListTasks((extra) async {
   );
 });
 
-server.experimental.onCancelTask((taskId, extra) async {
+server.experimental.onCancelTaskWithResult((taskId, extra) async {
   // Logic to cancel the task
   return Task(
     taskId: taskId,

--- a/example/jaspr-client/lib/components/tasks_panel.dart
+++ b/example/jaspr-client/lib/components/tasks_panel.dart
@@ -53,12 +53,11 @@ class TasksPanel extends StatelessComponent {
       ]),
       div([
         span(classes: 'tool-args', [Component.text('Status: ${task.status.name}')]),
-        if (task.createdAt != null)
-          span(
-            classes: 'tool-args',
-            attributes: {'style': 'margin-left: 0.5rem'},
-            [Component.text('Created: ${task.createdAt}')],
-          ),
+        span(
+          classes: 'tool-args',
+          attributes: {'style': 'margin-left: 0.5rem'},
+          [Component.text('Created: ${task.createdAt}')],
+        ),
       ]),
       if (task.statusMessage != null)
         p(

--- a/example/jaspr-client/lib/services/mcp_service.dart
+++ b/example/jaspr-client/lib/services/mcp_service.dart
@@ -467,8 +467,8 @@ class McpService {
   Future<void> cancelTask(String taskId) async {
     _ensureConnected();
     try {
-      await _taskClient!.cancelTask(taskId);
-      _emitLog(McpLogLevel.info, 'Cancelled task: $taskId');
+      final task = await _taskClient!.cancelTaskWithResult(taskId);
+      _emitLog(McpLogLevel.info, 'Cancelled task: ${task.taskId}');
     } catch (e) {
       _emitLog(McpLogLevel.error, 'Failed to cancel task: $e');
       rethrow;

--- a/example/simple_task_interactive_server.dart
+++ b/example/simple_task_interactive_server.dart
@@ -94,7 +94,7 @@ class InteractiveServer {
       return await handler.handle(taskId);
     });
 
-    server.experimental.onCancelTask((taskId, extra) async {
+    server.experimental.onCancelTaskWithResult((taskId, extra) async {
       print('[Server] tasks/cancel called for task $taskId');
       final cancelled = await store.cancelTask(taskId);
       if (!cancelled) {
@@ -339,7 +339,7 @@ class InteractiveServer {
   }
 }
 
-class SimpleToolTaskHandler implements ToolTaskHandler {
+class SimpleToolTaskHandler extends CancelTaskResultHandler {
   final SessionContext context;
   final String toolName;
   final Future<void> Function(SessionContext, String, Map<String, dynamic>)
@@ -376,7 +376,10 @@ class SimpleToolTaskHandler implements ToolTaskHandler {
   }
 
   @override
-  Future<Task> cancelTask(String taskId, RequestHandlerExtra? extra) async {
+  Future<Task> cancelTaskWithResult(
+    String taskId,
+    RequestHandlerExtra? extra,
+  ) async {
     final cancelled = await context.store.cancelTask(taskId);
     if (!cancelled) {
       throw McpError(

--- a/example/simple_task_interactive_server.dart
+++ b/example/simple_task_interactive_server.dart
@@ -103,6 +103,11 @@ class InteractiveServer {
           "Cannot cancel task: not found or already terminal",
         );
       }
+      final task = await store.getTask(taskId);
+      if (task == null) {
+        throw McpError(ErrorCode.invalidParams.value, "Task not found");
+      }
+      return task;
     });
 
     // Register Tools
@@ -371,8 +376,19 @@ class SimpleToolTaskHandler implements ToolTaskHandler {
   }
 
   @override
-  Future<void> cancelTask(String taskId, RequestHandlerExtra? extra) async {
-    await context.store.cancelTask(taskId);
+  Future<Task> cancelTask(String taskId, RequestHandlerExtra? extra) async {
+    final cancelled = await context.store.cancelTask(taskId);
+    if (!cancelled) {
+      throw McpError(
+        ErrorCode.invalidParams.value,
+        'Cannot cancel task: not found or already terminal',
+      );
+    }
+    final task = await context.store.getTask(taskId);
+    if (task == null) {
+      throw McpError(ErrorCode.invalidParams.value, 'Task not found');
+    }
+    return task;
   }
 
   @override

--- a/lib/src/client/task_client.dart
+++ b/lib/src/client/task_client.dart
@@ -175,8 +175,26 @@ class TaskClient {
     return result.tasks;
   }
 
+  /// Cancel a task by ID and ignore the returned final state.
+  ///
+  /// Prefer [cancelTaskWithResult] for MCP 2025-11-25-compatible clients.
+  @Deprecated(
+    'MCP 2025-11-25 tasks/cancel returns a Task. '
+    'Use cancelTaskWithResult instead.',
+  )
+  Future<void> cancelTask(String taskId) async {
+    final req = JsonRpcCancelTaskRequest(
+      id: -1,
+      cancelParams: CancelTaskRequest(taskId: taskId),
+    );
+    await client.request<EmptyResult>(
+      req,
+      (json) => const EmptyResult(),
+    );
+  }
+
   /// Cancel a task by ID and return its final cancelled state.
-  Future<Task> cancelTask(String taskId) async {
+  Future<Task> cancelTaskWithResult(String taskId) async {
     final req = JsonRpcCancelTaskRequest(
       id: -1,
       cancelParams: CancelTaskRequest(taskId: taskId),

--- a/lib/src/client/task_client.dart
+++ b/lib/src/client/task_client.dart
@@ -175,15 +175,15 @@ class TaskClient {
     return result.tasks;
   }
 
-  /// Cancel a task by ID
-  Future<void> cancelTask(String taskId) async {
+  /// Cancel a task by ID and return its final cancelled state.
+  Future<Task> cancelTask(String taskId) async {
     final req = JsonRpcCancelTaskRequest(
       id: -1,
       cancelParams: CancelTaskRequest(taskId: taskId),
     );
-    await client.request<EmptyResult>(
+    return client.request<Task>(
       req,
-      (json) => const EmptyResult(),
+      (json) => Task.fromJson(json),
     );
   }
 }

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -780,6 +780,10 @@ class ExperimentalMcpServerTasks {
   }
 
   /// Registers a callback for cancelling a task.
+  ///
+  /// The callback must cancel the task and return the final cancelled [Task]
+  /// used as the `tasks/cancel` result. Throw [McpError] if the task cannot
+  /// be cancelled, is missing, or is already terminal.
   void onCancelTask(CancelTaskCallback callback) {
     _server._cancelTaskCallback = callback;
     _server._ensureTaskHandlersInitialized();
@@ -956,6 +960,24 @@ class McpServer {
         final task = await Future.value(
           _cancelTaskCallback!(request.cancelParams.taskId, extra),
         );
+        if (task.taskId != request.cancelParams.taskId) {
+          throw McpError(
+            ErrorCode.invalidParams.value,
+            "Cancelled task result has mismatched taskId",
+          );
+        }
+        if (task.status != TaskStatus.cancelled) {
+          throw McpError(
+            ErrorCode.invalidParams.value,
+            "Task cancellation callback must return a cancelled task",
+          );
+        }
+        if (task.createdAt == null || task.lastUpdatedAt == null) {
+          throw McpError(
+            ErrorCode.invalidParams.value,
+            "Cancelled task result must include createdAt and lastUpdatedAt",
+          );
+        }
         return task;
       },
       (id, params, meta) => JsonRpcCancelTaskRequest.fromJson({

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -147,7 +147,9 @@ typedef ListTasksCallback = FutureOr<ListTasksResult> Function(
 );
 
 /// Callback to cancel a running task.
-typedef CancelTaskCallback = FutureOr<void> Function(
+///
+/// Must return the final cancelled task state for the `tasks/cancel` result.
+typedef CancelTaskCallback = FutureOr<Task> Function(
   String taskId,
   RequestHandlerExtra extra,
 );
@@ -951,10 +953,10 @@ class McpServer {
             "Task cancellation not supported",
           );
         }
-        await Future.value(
+        final task = await Future.value(
           _cancelTaskCallback!(request.cancelParams.taskId, extra),
         );
-        return const EmptyResult();
+        return task;
       },
       (id, params, meta) => JsonRpcCancelTaskRequest.fromJson({
         'id': id,

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -972,12 +972,6 @@ class McpServer {
             "Task cancellation callback must return a cancelled task",
           );
         }
-        if (task.createdAt == null || task.lastUpdatedAt == null) {
-          throw McpError(
-            ErrorCode.invalidParams.value,
-            "Cancelled task result must include createdAt and lastUpdatedAt",
-          );
-        }
         return task;
       },
       (id, params, meta) => JsonRpcCancelTaskRequest.fromJson({

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -146,6 +146,15 @@ typedef ListTasksCallback = FutureOr<ListTasksResult> Function(
   RequestHandlerExtra extra,
 );
 
+/// Legacy callback to cancel a running task without returning its final state.
+///
+/// Prefer [CancelTaskCallback] for MCP 2025-11-25-compatible `tasks/cancel`
+/// results.
+typedef LegacyCancelTaskCallback = FutureOr<void> Function(
+  String taskId,
+  RequestHandlerExtra extra,
+);
+
 /// Callback to cancel a running task.
 ///
 /// Must return the final cancelled task state for the `tasks/cancel` result.
@@ -779,12 +788,38 @@ class ExperimentalMcpServerTasks {
     _server._ensureTaskHandlersInitialized();
   }
 
-  /// Registers a callback for cancelling a task.
+  /// Registers a legacy callback for cancelling a task.
+  ///
+  /// This keeps pre-MCP-2025-11-25 code source-compatible. The callback should
+  /// cancel the task; the server then calls the registered `onGetTask` callback
+  /// to return the final cancelled [Task] required by `tasks/cancel`.
+  @Deprecated(
+    'MCP 2025-11-25 requires tasks/cancel to return a Task. '
+    'Use onCancelTaskWithResult instead. '
+    'This compatibility shim will be removed in the next major release.',
+  )
+  void onCancelTask(LegacyCancelTaskCallback callback) {
+    _server._cancelTaskCallback = (taskId, extra) async {
+      await Future.value(callback(taskId, extra));
+
+      final getTask = _server._getTaskCallback;
+      if (getTask == null) {
+        throw McpError(
+          ErrorCode.invalidParams.value,
+          'Legacy onCancelTask requires onGetTask to resolve the cancelled task',
+        );
+      }
+      return Future.value(getTask(taskId, extra));
+    };
+    _server._ensureTaskHandlersInitialized();
+  }
+
+  /// Registers a callback for cancelling a task and returning its final state.
   ///
   /// The callback must cancel the task and return the final cancelled [Task]
   /// used as the `tasks/cancel` result. Throw [McpError] if the task cannot
   /// be cancelled, is missing, or is already terminal.
-  void onCancelTask(CancelTaskCallback callback) {
+  void onCancelTaskWithResult(CancelTaskCallback callback) {
     _server._cancelTaskCallback = callback;
     _server._ensureTaskHandlersInitialized();
   }

--- a/lib/src/server/tasks/handler.dart
+++ b/lib/src/server/tasks/handler.dart
@@ -25,14 +25,41 @@ abstract class ToolTaskHandler {
   /// Retrieves the current status of a task.
   Future<Task> getTask(String taskId, RequestHandlerExtra? extra);
 
-  /// Cancels a running task and returns its final cancelled state.
-  Future<Task> cancelTask(String taskId, RequestHandlerExtra? extra);
+  /// Cancels a running task.
+  ///
+  /// Prefer implementing [CancelTaskResultHandler] so cancellations can return
+  /// the final task state required by MCP 2025-11-25.
+  @Deprecated(
+    'MCP 2025-11-25 requires cancellations to return the final Task. '
+    'Extend CancelTaskResultHandler and implement cancelTaskWithResult instead.',
+  )
+  Future<void> cancelTask(String taskId, RequestHandlerExtra? extra);
 
   /// Retrieves the final result of a completed task.
   Future<CallToolResult> getTaskResult(
     String taskId,
     RequestHandlerExtra? extra,
   );
+}
+
+/// MCP 2025-11-25-compliant task handler that returns the cancelled task.
+///
+/// Extend this when possible to keep the legacy [ToolTaskHandler.cancelTask]
+/// shim delegating to [cancelTaskWithResult]. If a handler already extends
+/// another base class, implement [ToolTaskHandler] directly and wire
+/// `cancelTaskWithResult` through the server-level `onCancelTaskWithResult`
+/// callback instead.
+abstract class CancelTaskResultHandler extends ToolTaskHandler {
+  /// Cancels a running task and returns its final cancelled state.
+  Future<Task> cancelTaskWithResult(String taskId, RequestHandlerExtra? extra);
+
+  @Deprecated(
+    'MCP 2025-11-25 requires cancellations to return the final Task. '
+    'Use cancelTaskWithResult instead.',
+  )
+  @override
+  Future<void> cancelTask(String taskId, RequestHandlerExtra? extra) =>
+      cancelTaskWithResult(taskId, extra);
 }
 
 /// Handles execution and result retrieval for tasks, managing the queue loop.

--- a/lib/src/server/tasks/handler.dart
+++ b/lib/src/server/tasks/handler.dart
@@ -25,8 +25,8 @@ abstract class ToolTaskHandler {
   /// Retrieves the current status of a task.
   Future<Task> getTask(String taskId, RequestHandlerExtra? extra);
 
-  /// Cancels a running task.
-  Future<void> cancelTask(String taskId, RequestHandlerExtra? extra);
+  /// Cancels a running task and returns its final cancelled state.
+  Future<Task> cancelTask(String taskId, RequestHandlerExtra? extra);
 
   /// Retrieves the final result of a completed task.
   Future<CallToolResult> getTaskResult(

--- a/lib/src/server/tasks/store.dart
+++ b/lib/src/server/tasks/store.dart
@@ -28,14 +28,13 @@ class InMemoryTaskStore implements TaskStore {
       for (final entry in _tasks.entries) {
         final task = entry.value;
         final ttl = task.ttl;
-        final createdAt = task.createdAt;
-        if (ttl == null || createdAt == null) {
+        if (ttl == null) {
           continue;
         }
 
         final DateTime created;
         try {
-          created = DateTime.parse(createdAt);
+          created = DateTime.parse(task.createdAt);
         } on FormatException {
           continue;
         }

--- a/lib/src/types/tasks.dart
+++ b/lib/src/types/tasks.dart
@@ -110,7 +110,7 @@ class Task implements BaseResultData {
         'status': status.name,
         if (statusMessage != null) 'statusMessage': statusMessage,
         'ttl': ttl,
-        'pollInterval': pollInterval,
+        if (pollInterval != null) 'pollInterval': pollInterval,
         if (createdAt != null) 'createdAt': createdAt,
         if (lastUpdatedAt != null) 'lastUpdatedAt': lastUpdatedAt,
         if (meta != null) '_meta': meta,

--- a/lib/src/types/tasks.dart
+++ b/lib/src/types/tasks.dart
@@ -64,16 +64,19 @@ class Task implements BaseResultData {
   final String? statusMessage;
 
   /// Time in milliseconds from creation before task may be deleted.
+  ///
+  /// Required by the MCP schema. A null value is serialized explicitly as
+  /// `"ttl": null` when the task has no expiry.
   final int? ttl;
 
   /// Suggested time in milliseconds between status checks.
   final int? pollInterval;
 
   /// ISO 8601 timestamp when the task was created.
-  final String? createdAt;
+  final String createdAt;
 
   /// ISO 8601 timestamp when the task status was last updated.
-  final String? lastUpdatedAt;
+  final String lastUpdatedAt;
 
   /// Optional metadata.
   @override
@@ -82,11 +85,11 @@ class Task implements BaseResultData {
   const Task({
     required this.taskId,
     required this.status,
+    required this.ttl,
+    required this.createdAt,
+    required this.lastUpdatedAt,
     this.statusMessage,
-    this.ttl,
     this.pollInterval,
-    this.createdAt,
-    this.lastUpdatedAt,
     this.meta,
   });
 
@@ -117,27 +120,16 @@ class Task implements BaseResultData {
   }
 
   @override
-  Map<String, dynamic> toJson() {
-    final createdAt = this.createdAt;
-    if (createdAt == null) {
-      throw const FormatException('Task.createdAt is required');
-    }
-    final lastUpdatedAt = this.lastUpdatedAt;
-    if (lastUpdatedAt == null) {
-      throw const FormatException('Task.lastUpdatedAt is required');
-    }
-
-    return {
-      'taskId': taskId,
-      'status': status.name,
-      if (statusMessage != null) 'statusMessage': statusMessage,
-      'ttl': ttl,
-      if (pollInterval != null) 'pollInterval': pollInterval,
-      'createdAt': createdAt,
-      'lastUpdatedAt': lastUpdatedAt,
-      if (meta != null) '_meta': meta,
-    };
-  }
+  Map<String, dynamic> toJson() => {
+        'taskId': taskId,
+        'status': status.name,
+        if (statusMessage != null) 'statusMessage': statusMessage,
+        'ttl': ttl,
+        if (pollInterval != null) 'pollInterval': pollInterval,
+        'createdAt': createdAt,
+        'lastUpdatedAt': lastUpdatedAt,
+        if (meta != null) '_meta': meta,
+      };
 }
 
 /// Parameters for the `tasks/list` request. Includes pagination.

--- a/lib/src/types/tasks.dart
+++ b/lib/src/types/tasks.dart
@@ -94,25 +94,16 @@ class Task implements BaseResultData {
   });
 
   factory Task.fromJson(Map<String, dynamic> json) {
-    if (!json.containsKey('ttl')) {
-      throw const FormatException('Task.ttl is required');
-    }
-    final createdAt = json['createdAt'];
-    if (createdAt is! String) {
-      throw const FormatException('Task.createdAt is required');
-    }
-    final lastUpdatedAt = json['lastUpdatedAt'];
-    if (lastUpdatedAt is! String) {
-      throw const FormatException('Task.lastUpdatedAt is required');
-    }
+    final createdAt = _readRequiredTaskString(json, 'createdAt');
+    final lastUpdatedAt = _readRequiredTaskString(json, 'lastUpdatedAt');
 
     final meta = json['_meta'] as Map<String, dynamic>?;
     return Task(
       taskId: json['taskId'] as String,
       status: TaskStatusName.fromString(json['status'] as String),
       statusMessage: json['statusMessage'] as String?,
-      ttl: json['ttl'] as int?,
-      pollInterval: json['pollInterval'] as int?,
+      ttl: _readTaskInt(json, 'ttl', requiredField: true),
+      pollInterval: _readTaskInt(json, 'pollInterval'),
       createdAt: createdAt,
       lastUpdatedAt: lastUpdatedAt,
       meta: meta,
@@ -130,6 +121,37 @@ class Task implements BaseResultData {
         'lastUpdatedAt': lastUpdatedAt,
         if (meta != null) '_meta': meta,
       };
+}
+
+String _readRequiredTaskString(Map<String, dynamic> json, String field) {
+  if (!json.containsKey(field)) {
+    throw FormatException('Task.$field is required');
+  }
+  final value = json[field];
+  if (value is! String) {
+    throw FormatException('Task.$field must be a string');
+  }
+  return value;
+}
+
+int? _readTaskInt(
+  Map<String, dynamic> json,
+  String field, {
+  bool requiredField = false,
+}) {
+  if (!json.containsKey(field)) {
+    if (requiredField) {
+      throw FormatException('Task.$field is required');
+    }
+    return null;
+  }
+
+  final value = json[field];
+  if (value == null || value is int) {
+    return value as int?;
+  }
+
+  throw FormatException('Task.$field must be an integer or null');
 }
 
 /// Parameters for the `tasks/list` request. Includes pagination.

--- a/lib/src/types/tasks.dart
+++ b/lib/src/types/tasks.dart
@@ -91,6 +91,18 @@ class Task implements BaseResultData {
   });
 
   factory Task.fromJson(Map<String, dynamic> json) {
+    if (!json.containsKey('ttl')) {
+      throw const FormatException('Task.ttl is required');
+    }
+    final createdAt = json['createdAt'];
+    if (createdAt is! String) {
+      throw const FormatException('Task.createdAt is required');
+    }
+    final lastUpdatedAt = json['lastUpdatedAt'];
+    if (lastUpdatedAt is! String) {
+      throw const FormatException('Task.lastUpdatedAt is required');
+    }
+
     final meta = json['_meta'] as Map<String, dynamic>?;
     return Task(
       taskId: json['taskId'] as String,
@@ -98,23 +110,34 @@ class Task implements BaseResultData {
       statusMessage: json['statusMessage'] as String?,
       ttl: json['ttl'] as int?,
       pollInterval: json['pollInterval'] as int?,
-      createdAt: json['createdAt'] as String?,
-      lastUpdatedAt: json['lastUpdatedAt'] as String?,
+      createdAt: createdAt,
+      lastUpdatedAt: lastUpdatedAt,
       meta: meta,
     );
   }
 
   @override
-  Map<String, dynamic> toJson() => {
-        'taskId': taskId,
-        'status': status.name,
-        if (statusMessage != null) 'statusMessage': statusMessage,
-        'ttl': ttl,
-        if (pollInterval != null) 'pollInterval': pollInterval,
-        if (createdAt != null) 'createdAt': createdAt,
-        if (lastUpdatedAt != null) 'lastUpdatedAt': lastUpdatedAt,
-        if (meta != null) '_meta': meta,
-      };
+  Map<String, dynamic> toJson() {
+    final createdAt = this.createdAt;
+    if (createdAt == null) {
+      throw const FormatException('Task.createdAt is required');
+    }
+    final lastUpdatedAt = this.lastUpdatedAt;
+    if (lastUpdatedAt == null) {
+      throw const FormatException('Task.lastUpdatedAt is required');
+    }
+
+    return {
+      'taskId': taskId,
+      'status': status.name,
+      if (statusMessage != null) 'statusMessage': statusMessage,
+      'ttl': ttl,
+      if (pollInterval != null) 'pollInterval': pollInterval,
+      'createdAt': createdAt,
+      'lastUpdatedAt': lastUpdatedAt,
+      if (meta != null) '_meta': meta,
+    };
+  }
 }
 
 /// Parameters for the `tasks/list` request. Includes pagination.

--- a/test/client/task_client_test.dart
+++ b/test/client/task_client_test.dart
@@ -198,10 +198,17 @@ void main() {
       expect(tasks[1].taskId, '2');
     });
 
-    test('cancelTask sends cancel request', () async {
-      mockClient.mockResponse('tasks/cancel', {});
+    test('cancelTask sends cancel request and returns final task', () async {
+      mockClient.mockResponse('tasks/cancel', {
+        'taskId': 'task-123',
+        'status': 'cancelled',
+        'statusMessage': 'Task cancelled',
+        'createdAt': '2026-05-14T10:00:00Z',
+        'lastUpdatedAt': '2026-05-14T10:05:00Z',
+        'ttl': null,
+      });
 
-      await taskClient.cancelTask('task-123');
+      final task = await taskClient.cancelTask('task-123');
 
       expect(mockClient.requests.last.method, 'tasks/cancel');
       expect(
@@ -210,6 +217,9 @@ void main() {
             .taskId,
         'task-123',
       );
+      expect(task.taskId, 'task-123');
+      expect(task.status, TaskStatus.cancelled);
+      expect(task.ttl, isNull);
     });
 
     test('callToolStream yields error if initial call fails', () async {

--- a/test/client/task_client_test.dart
+++ b/test/client/task_client_test.dart
@@ -103,6 +103,9 @@ void main() {
         'task': {
           'taskId': taskId,
           'status': 'working',
+          'createdAt': '2026-05-14T10:00:00Z',
+          'lastUpdatedAt': '2026-05-14T10:00:00Z',
+          'ttl': null,
           'name': 'Long Task',
           'total': 100,
         },
@@ -114,6 +117,9 @@ void main() {
         {
           'taskId': taskId,
           'status': 'working',
+          'createdAt': '2026-05-14T10:00:00Z',
+          'lastUpdatedAt': '2026-05-14T10:01:00Z',
+          'ttl': null,
           'name': 'Long Task',
           'progress': 50,
           'pollInterval': 10,
@@ -122,6 +128,9 @@ void main() {
         {
           'taskId': taskId,
           'status': 'completed',
+          'createdAt': '2026-05-14T10:00:00Z',
+          'lastUpdatedAt': '2026-05-14T10:02:00Z',
+          'ttl': null,
           'name': 'Long Task',
           'progress': 100,
         }
@@ -186,8 +195,22 @@ void main() {
     test('listTasks returns list of tasks', () async {
       mockClient.mockResponse('tasks/list', {
         'tasks': [
-          {'taskId': '1', 'status': 'working', 'name': 'Task 1'},
-          {'taskId': '2', 'status': 'working', 'name': 'Task 2'},
+          {
+            'taskId': '1',
+            'status': 'working',
+            'createdAt': '2026-05-14T10:00:00Z',
+            'lastUpdatedAt': '2026-05-14T10:01:00Z',
+            'ttl': null,
+            'name': 'Task 1',
+          },
+          {
+            'taskId': '2',
+            'status': 'working',
+            'createdAt': '2026-05-14T10:00:00Z',
+            'lastUpdatedAt': '2026-05-14T10:01:00Z',
+            'ttl': null,
+            'name': 'Task 2',
+          },
         ],
       });
 

--- a/test/client/task_client_test.dart
+++ b/test/client/task_client_test.dart
@@ -221,7 +221,8 @@ void main() {
       expect(tasks[1].taskId, '2');
     });
 
-    test('cancelTask sends cancel request and returns final task', () async {
+    test('cancelTaskWithResult sends cancel request and returns final task',
+        () async {
       mockClient.mockResponse('tasks/cancel', {
         'taskId': 'task-123',
         'status': 'cancelled',
@@ -231,7 +232,7 @@ void main() {
         'ttl': null,
       });
 
-      final task = await taskClient.cancelTask('task-123');
+      final task = await taskClient.cancelTaskWithResult('task-123');
 
       expect(mockClient.requests.last.method, 'tasks/cancel');
       expect(
@@ -243,6 +244,44 @@ void main() {
       expect(task.taskId, 'task-123');
       expect(task.status, TaskStatus.cancelled);
       expect(task.ttl, isNull);
+    });
+
+    test('legacy cancelTask sends cancel request and accepts empty result',
+        () async {
+      mockClient.mockResponse('tasks/cancel', {});
+
+      // ignore: deprecated_member_use_from_same_package
+      await taskClient.cancelTask('task-123');
+
+      expect(mockClient.requests.last.method, 'tasks/cancel');
+      expect(
+        (mockClient.requests.last as JsonRpcCancelTaskRequest)
+            .cancelParams
+            .taskId,
+        'task-123',
+      );
+    });
+
+    test('legacy cancelTask ignores compliant final task result', () async {
+      mockClient.mockResponse('tasks/cancel', {
+        'taskId': 'task-123',
+        'status': 'cancelled',
+        'statusMessage': 'Task cancelled',
+        'createdAt': '2026-05-14T10:00:00Z',
+        'lastUpdatedAt': '2026-05-14T10:05:00Z',
+        'ttl': null,
+      });
+
+      // ignore: deprecated_member_use_from_same_package
+      await taskClient.cancelTask('task-123');
+
+      expect(mockClient.requests.last.method, 'tasks/cancel');
+      expect(
+        (mockClient.requests.last as JsonRpcCancelTaskRequest)
+            .cancelParams
+            .taskId,
+        'task-123',
+      );
     });
 
     test('callToolStream yields error if initial call fails', () async {

--- a/test/interop/test_dart_server.dart
+++ b/test/interop/test_dart_server.dart
@@ -339,6 +339,7 @@ class TestTaskHandler implements ToolTaskHandler {
         taskId: taskId,
         status: TaskStatus.working,
         statusMessage: 'Starting...',
+        ttl: null,
         createdAt: DateTime.now().toIso8601String(),
         lastUpdatedAt: DateTime.now().toIso8601String(),
         meta: {'message': message}, // Store message in metadata
@@ -369,6 +370,7 @@ class TestTaskHandler implements ToolTaskHandler {
       taskId: state.task.taskId,
       status: TaskStatus.working,
       statusMessage: 'Halfway there...',
+      ttl: state.task.ttl,
       createdAt: state.task.createdAt,
       lastUpdatedAt: DateTime.now().toIso8601String(),
       pollInterval: 100,
@@ -382,6 +384,7 @@ class TestTaskHandler implements ToolTaskHandler {
       taskId: state.task.taskId,
       status: TaskStatus.completed,
       statusMessage: 'Done!',
+      ttl: state.task.ttl,
       createdAt: state.task.createdAt,
       lastUpdatedAt: DateTime.now().toIso8601String(),
       pollInterval: 100,

--- a/test/interop/test_dart_server.dart
+++ b/test/interop/test_dart_server.dart
@@ -300,7 +300,7 @@ McpServer createServer() {
   });
 
   server.experimental.onCancelTask((taskId, extra) async {
-    await taskHandler.cancelTask(taskId, extra);
+    return await taskHandler.cancelTask(taskId, extra);
   });
 
   server.experimental.onGetTask((taskId, extra) async {
@@ -399,20 +399,22 @@ class TestTaskHandler implements ToolTaskHandler {
   }
 
   @override
-  Future<void> cancelTask(String taskId, RequestHandlerExtra? extra) async {
+  Future<Task> cancelTask(String taskId, RequestHandlerExtra? extra) async {
     final state = _tasks[taskId];
-    if (state != null) {
-      state.task = Task(
-        taskId: state.task.taskId,
-        status: TaskStatus.cancelled,
-        statusMessage: 'Cancelled',
-        meta: state.task.meta,
-        createdAt: state.task.createdAt,
-        lastUpdatedAt: DateTime.now().toIso8601String(),
-      );
-      // Keep it for a bit or remove? Usually keep for history.
-      // But for this simple test, we just mark it cancelled.
+    if (state == null) {
+      throw McpError(ErrorCode.invalidParams.value, 'Task not found');
     }
+    state.task = Task(
+      taskId: state.task.taskId,
+      status: TaskStatus.cancelled,
+      statusMessage: 'Cancelled',
+      meta: state.task.meta,
+      ttl: state.task.ttl,
+      pollInterval: state.task.pollInterval,
+      createdAt: state.task.createdAt,
+      lastUpdatedAt: DateTime.now().toIso8601String(),
+    );
+    return state.task;
   }
 
   @override

--- a/test/interop/test_dart_server.dart
+++ b/test/interop/test_dart_server.dart
@@ -299,8 +299,8 @@ McpServer createServer() {
     return ListTasksResult(tasks: await taskHandler.listTasks());
   });
 
-  server.experimental.onCancelTask((taskId, extra) async {
-    return await taskHandler.cancelTask(taskId, extra);
+  server.experimental.onCancelTaskWithResult((taskId, extra) async {
+    return await taskHandler.cancelTaskWithResult(taskId, extra);
   });
 
   server.experimental.onGetTask((taskId, extra) async {
@@ -316,7 +316,7 @@ McpServer createServer() {
   return server;
 }
 
-class TestTaskHandler implements ToolTaskHandler {
+class TestTaskHandler extends CancelTaskResultHandler {
   final Map<String, _TaskState> _tasks = {};
   int _counter = 0;
 
@@ -402,7 +402,10 @@ class TestTaskHandler implements ToolTaskHandler {
   }
 
   @override
-  Future<Task> cancelTask(String taskId, RequestHandlerExtra? extra) async {
+  Future<Task> cancelTaskWithResult(
+    String taskId,
+    RequestHandlerExtra? extra,
+  ) async {
     final state = _tasks[taskId];
     if (state == null) {
       throw McpError(ErrorCode.invalidParams.value, 'Task not found');

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -709,11 +709,21 @@ void main() {
           throwsA(isA<FormatException>()),
         );
         expect(
-          () => const Task(
-            taskId: 'missing-timestamps',
-            status: TaskStatus.working,
-            ttl: null,
-          ).toJson(),
+          () => Task.fromJson({
+            'taskId': 'missing-created-at',
+            'status': 'working',
+            'ttl': null,
+            'lastUpdatedAt': '2025-01-15T10:01:00Z',
+          }),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => Task.fromJson({
+            'taskId': 'missing-last-updated-at',
+            'status': 'working',
+            'ttl': null,
+            'createdAt': '2025-01-15T10:00:00Z',
+          }),
           throwsA(isA<FormatException>()),
         );
       });

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -335,6 +335,7 @@ void main() {
         taskId: '123',
         status: TaskStatus.working,
         createdAt: '2025-01-01T00:00:00Z',
+        lastUpdatedAt: '2025-01-01T00:01:00Z',
         ttl: 3600,
       );
       expect(task.status, TaskStatus.working);
@@ -524,6 +525,7 @@ void main() {
             ttl: 7200,
             pollInterval: 1000,
             createdAt: '2025-01-15T10:00:00Z',
+            lastUpdatedAt: '2025-01-15T10:01:00Z',
           ),
         );
 
@@ -571,6 +573,9 @@ void main() {
             taskId: 'task-status-456',
             status: TaskStatus.failed,
             statusMessage: 'Task failed due to error',
+            createdAt: '2025-01-15T10:00:00Z',
+            lastUpdatedAt: '2025-01-15T10:05:00Z',
+            ttl: null,
           ),
         );
 
@@ -596,6 +601,9 @@ void main() {
             'taskId': 'task-abc',
             'status': 'input_required',
             'statusMessage': 'Waiting for user input',
+            'createdAt': '2025-01-15T10:00:00Z',
+            'lastUpdatedAt': '2025-01-15T10:05:00Z',
+            'ttl': null,
           },
         };
         final message = JsonRpcMessage.fromJson(json);
@@ -688,6 +696,26 @@ void main() {
         final json = task.toJson();
         expect(json, containsPair('ttl', null));
         expect(json, isNot(contains('pollInterval')));
+      });
+
+      test('Task rejects missing MCP-required fields', () {
+        expect(
+          () => Task.fromJson({
+            'taskId': 'missing-ttl',
+            'status': 'working',
+            'createdAt': '2025-01-15T10:00:00Z',
+            'lastUpdatedAt': '2025-01-15T10:01:00Z',
+          }),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => const Task(
+            taskId: 'missing-timestamps',
+            status: TaskStatus.working,
+            ttl: null,
+          ).toJson(),
+          throwsA(isA<FormatException>()),
+        );
       });
 
       test('Task all fields serialization', () {

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -676,6 +676,20 @@ void main() {
         );
       });
 
+      test('Task omits null optional pollInterval but keeps required ttl', () {
+        final task = const Task(
+          taskId: 'cancelled-task',
+          status: TaskStatus.cancelled,
+          ttl: null,
+          createdAt: '2025-01-15T10:00:00Z',
+          lastUpdatedAt: '2025-01-15T10:01:00Z',
+        );
+
+        final json = task.toJson();
+        expect(json, containsPair('ttl', null));
+        expect(json, isNot(contains('pollInterval')));
+      });
+
       test('Task all fields serialization', () {
         final task = const Task(
           taskId: 'full-task',

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -728,6 +728,57 @@ void main() {
         );
       });
 
+      test('Task rejects malformed field types with FormatException', () {
+        final validJson = {
+          'taskId': 'typed-task',
+          'status': 'working',
+          'ttl': null,
+          'createdAt': '2025-01-15T10:00:00Z',
+          'lastUpdatedAt': '2025-01-15T10:01:00Z',
+        };
+
+        expect(
+          () => Task.fromJson({...validJson, 'createdAt': 42}),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              'Task.createdAt must be a string',
+            ),
+          ),
+        );
+        expect(
+          () => Task.fromJson({...validJson, 'lastUpdatedAt': false}),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              'Task.lastUpdatedAt must be a string',
+            ),
+          ),
+        );
+        expect(
+          () => Task.fromJson({...validJson, 'ttl': 1.5}),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              'Task.ttl must be an integer or null',
+            ),
+          ),
+        );
+        expect(
+          () => Task.fromJson({...validJson, 'pollInterval': '1000'}),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              'Task.pollInterval must be an integer or null',
+            ),
+          ),
+        );
+      });
+
       test('Task all fields serialization', () {
         final task = const Task(
           taskId: 'full-task',

--- a/test/module_exports_test.dart
+++ b/test/module_exports_test.dart
@@ -16,10 +16,12 @@ void main() {
     test('server module symbols are available', () {
       server_module.McpServer? server;
       server_module.StreamableMcpServer? streamableServer;
+      server_module.CancelTaskResultHandler? cancelTaskResultHandler;
       final registerAppTool = server_module.registerAppTool;
 
       expect(server, isNull);
       expect(streamableServer, isNull);
+      expect(cancelTaskResultHandler, isNull);
       expect(registerAppTool, isNotNull);
     });
 

--- a/test/server/tasks_test.dart
+++ b/test/server/tasks_test.dart
@@ -63,7 +63,15 @@ void main() {
           ],
         );
       });
-      mcpServer.experimental.onCancelTask((taskId, extra) async {});
+      mcpServer.experimental.onCancelTask(
+        (taskId, extra) async => Task(
+          taskId: taskId,
+          status: TaskStatus.cancelled,
+          createdAt: '2026-05-14T10:00:00Z',
+          lastUpdatedAt: '2026-05-14T10:00:00Z',
+          ttl: null,
+        ),
+      );
 
       await mcpServer.connect(transport);
 
@@ -91,13 +99,21 @@ void main() {
       expect(result.tasks.first.taskId, 'task1');
     });
 
-    test('handles cancel task request', () async {
+    test('handles cancel task request with final task result', () async {
       var cancelledTaskId = '';
 
       mcpServer.experimental
           .onListTasks((extra) async => const ListTasksResult(tasks: []));
       mcpServer.experimental.onCancelTask((taskId, extra) async {
         cancelledTaskId = taskId;
+        return Task(
+          taskId: taskId,
+          status: TaskStatus.cancelled,
+          statusMessage: 'Task cancelled',
+          createdAt: '2026-05-14T10:00:00Z',
+          lastUpdatedAt: '2026-05-14T10:05:00Z',
+          ttl: null,
+        );
       });
 
       await mcpServer.connect(transport);
@@ -124,7 +140,13 @@ void main() {
       final response = transport.sentMessages
           .whereType<JsonRpcResponse>()
           .firstWhere((r) => r.id == 2);
-      expect(response.result, isEmpty); // EmptyResult
+      expect(response.result['taskId'], 'task123');
+      expect(response.result['status'], 'cancelled');
+      expect(response.result['statusMessage'], 'Task cancelled');
+      expect(response.result, containsPair('ttl', null));
+      expect(response.result, isNot(contains('pollInterval')));
+      expect(response.result['createdAt'], '2026-05-14T10:00:00Z');
+      expect(response.result['lastUpdatedAt'], '2026-05-14T10:05:00Z');
     });
 
     test('throws error if tasks handlers not registered but requested',

--- a/test/server/tasks_test.dart
+++ b/test/server/tasks_test.dart
@@ -58,6 +58,8 @@ void main() {
               taskId: 'task1',
               status: TaskStatus.working,
               statusMessage: 'Processing...',
+              createdAt: '2026-05-14T10:00:00Z',
+              lastUpdatedAt: '2026-05-14T10:00:00Z',
               ttl: 3600,
             ),
           ],
@@ -147,6 +149,50 @@ void main() {
       expect(response.result, isNot(contains('pollInterval')));
       expect(response.result['createdAt'], '2026-05-14T10:00:00Z');
       expect(response.result['lastUpdatedAt'], '2026-05-14T10:05:00Z');
+    });
+
+    test('rejects cancel task callback results that are not cancelled',
+        () async {
+      mcpServer.experimental
+          .onListTasks((extra) async => const ListTasksResult(tasks: []));
+      mcpServer.experimental.onCancelTask((taskId, extra) async {
+        return Task(
+          taskId: taskId,
+          status: TaskStatus.completed,
+          createdAt: '2026-05-14T10:00:00Z',
+          lastUpdatedAt: '2026-05-14T10:05:00Z',
+          ttl: null,
+        );
+      });
+
+      await mcpServer.connect(transport);
+
+      final initRequest = JsonRpcInitializeRequest(
+        id: 1,
+        initParams: const InitializeRequestParams(
+          protocolVersion: latestProtocolVersion,
+          capabilities: ClientCapabilities(),
+          clientInfo: Implementation(name: 'TestClient', version: '1.0.0'),
+        ),
+      );
+      transport.receiveMessage(initRequest);
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final cancelRequest = JsonRpcCancelTaskRequest(
+        id: 2,
+        cancelParams: const CancelTaskRequestParams(taskId: 'task123'),
+      );
+      transport.receiveMessage(cancelRequest);
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final errorResponse = transport.sentMessages
+          .whereType<JsonRpcError>()
+          .firstWhere((r) => r.id == 2);
+      expect(errorResponse.error.code, equals(ErrorCode.invalidParams.value));
+      expect(
+        errorResponse.error.message,
+        contains('must return a cancelled task'),
+      );
     });
 
     test('throws error if tasks handlers not registered but requested',

--- a/test/server/tasks_test.dart
+++ b/test/server/tasks_test.dart
@@ -238,49 +238,6 @@ void main() {
       expect(errorResponse.error.message, contains('mismatched taskId'));
     });
 
-    test('rejects cancel task callback results without timestamps', () async {
-      mcpServer.experimental
-          .onListTasks((extra) async => const ListTasksResult(tasks: []));
-      mcpServer.experimental.onCancelTask((taskId, extra) async {
-        return Task(
-          taskId: taskId,
-          status: TaskStatus.cancelled,
-          ttl: null,
-        );
-      });
-
-      await mcpServer.connect(transport);
-
-      transport.receiveMessage(
-        JsonRpcInitializeRequest(
-          id: 1,
-          initParams: const InitializeRequestParams(
-            protocolVersion: latestProtocolVersion,
-            capabilities: ClientCapabilities(),
-            clientInfo: Implementation(name: 'TestClient', version: '1.0.0'),
-          ),
-        ),
-      );
-      await Future.delayed(const Duration(milliseconds: 10));
-
-      transport.receiveMessage(
-        JsonRpcCancelTaskRequest(
-          id: 2,
-          cancelParams: const CancelTaskRequestParams(taskId: 'task123'),
-        ),
-      );
-      await Future.delayed(const Duration(milliseconds: 10));
-
-      final errorResponse = transport.sentMessages
-          .whereType<JsonRpcError>()
-          .firstWhere((r) => r.id == 2);
-      expect(errorResponse.error.code, equals(ErrorCode.invalidParams.value));
-      expect(
-        errorResponse.error.message,
-        contains('createdAt and lastUpdatedAt'),
-      );
-    });
-
     test('throws error if tasks handlers not registered but requested',
         () async {
       // Do not register tasks handlers

--- a/test/server/tasks_test.dart
+++ b/test/server/tasks_test.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:mcp_dart/src/server/mcp_server.dart';
+import 'package:mcp_dart/src/server/tasks/handler.dart';
+import 'package:mcp_dart/src/shared/protocol.dart';
 import 'package:mcp_dart/src/shared/transport.dart';
 import 'package:mcp_dart/src/types.dart';
 import 'package:test/test.dart';
@@ -36,6 +38,50 @@ class MockTransport extends Transport {
   }
 }
 
+class _ResultHandler extends CancelTaskResultHandler {
+  var cancelWithResultCalls = 0;
+
+  @override
+  Future<CreateTaskResult> createTask(
+    Map<String, dynamic>? args,
+    RequestHandlerExtra? extra,
+  ) async =>
+      const CreateTaskResult(
+        task: Task(
+          taskId: 'task1',
+          status: TaskStatus.working,
+          createdAt: '2026-05-14T10:00:00Z',
+          lastUpdatedAt: '2026-05-14T10:00:00Z',
+          ttl: null,
+        ),
+      );
+
+  @override
+  Future<Task> getTask(String taskId, RequestHandlerExtra? extra) async => Task(
+        taskId: taskId,
+        status: TaskStatus.cancelled,
+        createdAt: '2026-05-14T10:00:00Z',
+        lastUpdatedAt: '2026-05-14T10:05:00Z',
+        ttl: null,
+      );
+
+  @override
+  Future<Task> cancelTaskWithResult(
+    String taskId,
+    RequestHandlerExtra? extra,
+  ) async {
+    cancelWithResultCalls++;
+    return getTask(taskId, extra);
+  }
+
+  @override
+  Future<CallToolResult> getTaskResult(
+    String taskId,
+    RequestHandlerExtra? extra,
+  ) async =>
+      const CallToolResult(content: []);
+}
+
 void main() {
   group('McpServer - Tasks API', () {
     late McpServer mcpServer;
@@ -65,7 +111,7 @@ void main() {
           ],
         );
       });
-      mcpServer.experimental.onCancelTask(
+      mcpServer.experimental.onCancelTaskWithResult(
         (taskId, extra) async => Task(
           taskId: taskId,
           status: TaskStatus.cancelled,
@@ -106,7 +152,7 @@ void main() {
 
       mcpServer.experimental
           .onListTasks((extra) async => const ListTasksResult(tasks: []));
-      mcpServer.experimental.onCancelTask((taskId, extra) async {
+      mcpServer.experimental.onCancelTaskWithResult((taskId, extra) async {
         cancelledTaskId = taskId;
         return Task(
           taskId: taskId,
@@ -151,11 +197,68 @@ void main() {
       expect(response.result['lastUpdatedAt'], '2026-05-14T10:05:00Z');
     });
 
+    test('legacy onCancelTask returns final task via onGetTask', () async {
+      var cancelledTaskId = '';
+      Task task = const Task(
+        taskId: 'task123',
+        status: TaskStatus.working,
+        createdAt: '2026-05-14T10:00:00Z',
+        lastUpdatedAt: '2026-05-14T10:00:00Z',
+        ttl: null,
+      );
+
+      mcpServer.experimental
+          .onListTasks((extra) async => const ListTasksResult(tasks: []));
+      // ignore: deprecated_member_use_from_same_package
+      mcpServer.experimental.onCancelTask((taskId, extra) async {
+        cancelledTaskId = taskId;
+        task = Task(
+          taskId: taskId,
+          status: TaskStatus.cancelled,
+          statusMessage: 'Task cancelled',
+          createdAt: task.createdAt,
+          lastUpdatedAt: '2026-05-14T10:05:00Z',
+          ttl: task.ttl,
+        );
+      });
+      mcpServer.experimental.onGetTask((taskId, extra) async => task);
+
+      await mcpServer.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcInitializeRequest(
+          id: 1,
+          initParams: const InitializeRequestParams(
+            protocolVersion: latestProtocolVersion,
+            capabilities: ClientCapabilities(),
+            clientInfo: Implementation(name: 'TestClient', version: '1.0.0'),
+          ),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      transport.receiveMessage(
+        JsonRpcCancelTaskRequest(
+          id: 2,
+          cancelParams: const CancelTaskRequestParams(taskId: 'task123'),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      expect(cancelledTaskId, 'task123');
+      final response = transport.sentMessages
+          .whereType<JsonRpcResponse>()
+          .firstWhere((r) => r.id == 2);
+      expect(response.result['taskId'], 'task123');
+      expect(response.result['status'], 'cancelled');
+      expect(response.result, containsPair('ttl', null));
+    });
+
     test('rejects cancel task callback results that are not cancelled',
         () async {
       mcpServer.experimental
           .onListTasks((extra) async => const ListTasksResult(tasks: []));
-      mcpServer.experimental.onCancelTask((taskId, extra) async {
+      mcpServer.experimental.onCancelTaskWithResult((taskId, extra) async {
         return Task(
           taskId: taskId,
           status: TaskStatus.completed,
@@ -199,7 +302,7 @@ void main() {
         () async {
       mcpServer.experimental
           .onListTasks((extra) async => const ListTasksResult(tasks: []));
-      mcpServer.experimental.onCancelTask((taskId, extra) async {
+      mcpServer.experimental.onCancelTaskWithResult((taskId, extra) async {
         return const Task(
           taskId: 'different-task',
           status: TaskStatus.cancelled,
@@ -236,6 +339,16 @@ void main() {
           .firstWhere((r) => r.id == 2);
       expect(errorResponse.error.code, equals(ErrorCode.invalidParams.value));
       expect(errorResponse.error.message, contains('mismatched taskId'));
+    });
+
+    test('CancelTaskResultHandler legacy method delegates to result method',
+        () async {
+      final handler = _ResultHandler();
+
+      // ignore: deprecated_member_use_from_same_package
+      await handler.cancelTask('task123', null);
+
+      expect(handler.cancelWithResultCalls, 1);
     });
 
     test('throws error if tasks handlers not registered but requested',

--- a/test/server/tasks_test.dart
+++ b/test/server/tasks_test.dart
@@ -195,6 +195,92 @@ void main() {
       );
     });
 
+    test('rejects cancel task callback results with mismatched taskId',
+        () async {
+      mcpServer.experimental
+          .onListTasks((extra) async => const ListTasksResult(tasks: []));
+      mcpServer.experimental.onCancelTask((taskId, extra) async {
+        return const Task(
+          taskId: 'different-task',
+          status: TaskStatus.cancelled,
+          createdAt: '2026-05-14T10:00:00Z',
+          lastUpdatedAt: '2026-05-14T10:05:00Z',
+          ttl: null,
+        );
+      });
+
+      await mcpServer.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcInitializeRequest(
+          id: 1,
+          initParams: const InitializeRequestParams(
+            protocolVersion: latestProtocolVersion,
+            capabilities: ClientCapabilities(),
+            clientInfo: Implementation(name: 'TestClient', version: '1.0.0'),
+          ),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      transport.receiveMessage(
+        JsonRpcCancelTaskRequest(
+          id: 2,
+          cancelParams: const CancelTaskRequestParams(taskId: 'task123'),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final errorResponse = transport.sentMessages
+          .whereType<JsonRpcError>()
+          .firstWhere((r) => r.id == 2);
+      expect(errorResponse.error.code, equals(ErrorCode.invalidParams.value));
+      expect(errorResponse.error.message, contains('mismatched taskId'));
+    });
+
+    test('rejects cancel task callback results without timestamps', () async {
+      mcpServer.experimental
+          .onListTasks((extra) async => const ListTasksResult(tasks: []));
+      mcpServer.experimental.onCancelTask((taskId, extra) async {
+        return Task(
+          taskId: taskId,
+          status: TaskStatus.cancelled,
+          ttl: null,
+        );
+      });
+
+      await mcpServer.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcInitializeRequest(
+          id: 1,
+          initParams: const InitializeRequestParams(
+            protocolVersion: latestProtocolVersion,
+            capabilities: ClientCapabilities(),
+            clientInfo: Implementation(name: 'TestClient', version: '1.0.0'),
+          ),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      transport.receiveMessage(
+        JsonRpcCancelTaskRequest(
+          id: 2,
+          cancelParams: const CancelTaskRequestParams(taskId: 'task123'),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final errorResponse = transport.sentMessages
+          .whereType<JsonRpcError>()
+          .firstWhere((r) => r.id == 2);
+      expect(errorResponse.error.code, equals(ErrorCode.invalidParams.value));
+      expect(
+        errorResponse.error.message,
+        contains('createdAt and lastUpdatedAt'),
+      );
+    });
+
     test('throws error if tasks handlers not registered but requested',
         () async {
       // Do not register tasks handlers

--- a/test/shared/protocol_task_handlers_test.dart
+++ b/test/shared/protocol_task_handlers_test.dart
@@ -6,6 +6,9 @@ import 'package:mcp_dart/src/shared/transport.dart';
 import 'package:mcp_dart/src/types.dart';
 import 'package:test/test.dart';
 
+const _taskCreatedAt = '2026-05-14T10:00:00Z';
+const _taskUpdatedAt = '2026-05-14T10:01:00Z';
+
 /// Mock TaskStore for testing protocol task handlers
 class MockTaskStore implements TaskStore {
   final Map<String, Task> tasks = {};
@@ -22,6 +25,9 @@ class MockTaskStore implements TaskStore {
     final task = Task(
       taskId: taskId,
       status: TaskStatus.working,
+      createdAt: _taskCreatedAt,
+      lastUpdatedAt: _taskCreatedAt,
+      ttl: null,
     );
     tasks[taskId] = task;
     return task;
@@ -41,7 +47,14 @@ class MockTaskStore implements TaskStore {
   ]) async {
     results[taskId] = result;
     if (tasks.containsKey(taskId)) {
-      tasks[taskId] = Task(taskId: taskId, status: status);
+      final task = tasks[taskId]!;
+      tasks[taskId] = Task(
+        taskId: taskId,
+        status: status,
+        createdAt: task.createdAt,
+        lastUpdatedAt: _taskUpdatedAt,
+        ttl: task.ttl,
+      );
     }
   }
 
@@ -65,6 +78,9 @@ class MockTaskStore implements TaskStore {
         taskId: taskId,
         status: status,
         statusMessage: statusMessage,
+        createdAt: tasks[taskId]!.createdAt,
+        lastUpdatedAt: _taskUpdatedAt,
+        ttl: tasks[taskId]!.ttl,
       );
     }
   }
@@ -216,6 +232,9 @@ void main() {
         taskId: 'task-1',
         status: TaskStatus.working,
         statusMessage: 'In progress',
+        createdAt: _taskCreatedAt,
+        lastUpdatedAt: _taskCreatedAt,
+        ttl: null,
       );
 
       // Simulate tasks/get request
@@ -269,10 +288,16 @@ void main() {
       taskStore.tasks['task-1'] = const Task(
         taskId: 'task-1',
         status: TaskStatus.working,
+        createdAt: _taskCreatedAt,
+        lastUpdatedAt: _taskCreatedAt,
+        ttl: null,
       );
       taskStore.tasks['task-2'] = const Task(
         taskId: 'task-2',
         status: TaskStatus.completed,
+        createdAt: _taskCreatedAt,
+        lastUpdatedAt: _taskUpdatedAt,
+        ttl: null,
       );
 
       // Simulate tasks/list request
@@ -300,6 +325,9 @@ void main() {
       taskStore.tasks['task-1'] = const Task(
         taskId: 'task-1',
         status: TaskStatus.working,
+        createdAt: _taskCreatedAt,
+        lastUpdatedAt: _taskCreatedAt,
+        ttl: null,
       );
 
       // Simulate tasks/cancel request
@@ -328,6 +356,9 @@ void main() {
       taskStore.tasks['task-1'] = const Task(
         taskId: 'task-1',
         status: TaskStatus.completed,
+        createdAt: _taskCreatedAt,
+        lastUpdatedAt: _taskUpdatedAt,
+        ttl: null,
       );
 
       // Simulate tasks/cancel request
@@ -358,6 +389,9 @@ void main() {
       taskStore.tasks['task-1'] = const Task(
         taskId: 'task-1',
         status: TaskStatus.working,
+        createdAt: _taskCreatedAt,
+        lastUpdatedAt: _taskCreatedAt,
+        ttl: null,
       );
 
       // Add messages to queue
@@ -421,6 +455,9 @@ void main() {
       taskStore.tasks['task-1'] = const Task(
         taskId: 'task-1',
         status: TaskStatus.working,
+        createdAt: _taskCreatedAt,
+        lastUpdatedAt: _taskCreatedAt,
+        ttl: null,
       );
 
       // Send notification with relatedTask
@@ -456,6 +493,9 @@ void main() {
       taskStore.tasks['task-1'] = const Task(
         taskId: 'task-1',
         status: TaskStatus.working,
+        createdAt: _taskCreatedAt,
+        lastUpdatedAt: _taskCreatedAt,
+        ttl: null,
       );
 
       final resultFuture = protocol.request<EmptyResult>(


### PR DESCRIPTION
## Summary
- Return the final cancelled `Task` from `tasks/cancel` instead of `{}` so the high-level server/client path matches MCP 2025-11-25 `CancelTaskResult = Result & Task`.
- Update cancel callback/client APIs, task examples, docs, migration notes, and changelog for the spec-compliant result shape.
- Preserve required `ttl: null` serialization while omitting optional `pollInterval` when it is null.
- Make `Task.createdAt` and `Task.lastUpdatedAt` required non-null constructor fields so valid `Task` instances serialize without throwing from `toJson()`.

## Spec compliance
MCP 2025-11-25 defines `CancelTaskResult` as `Result & Task`, so a successful `tasks/cancel` response must include the cancelled task fields (`taskId`, `status`, `createdAt`, `lastUpdatedAt`, `ttl`, etc.). This PR makes that shape observable through both the server handler and `TaskClient.cancelTask()`.

## Existing issue check
I searched existing GitHub issues/PRs for `tasks/cancel`, `CancelTaskResult`, `cancel task result`, `Task.ttl`, `pollInterval`, and related task terms. I did not find a dedicated issue for this result-shape gap, so this PR does not close an existing issue.

## Test Plan
- [x] `dart format .`
- [x] `dart analyze`
- [x] `dart analyze example`
- [x] `dart analyze` in nested examples:
  - `example/anthropic-client`
  - `example/gemini-client`
  - `example/fetch-server`
  - `example/jaspr-client`
- [x] Targeted task/spec tests covering server result shape, client parsing, `ttl: null`, omitted null `pollInterval`, and missing required task fields
- [x] `dart test` — 879 tests passed
- [x] CI for `93d27c0a8b11d08f928de13ca819c14cd7c27e55`: Analyze, test, CodeQL all passed

## Review notes
- Independent review found one blocker: optional `pollInterval` was serialized as `null`.
- Fixed by omitting null `pollInterval` while keeping required `ttl: null`, then re-ran verification.
- Copilot found one follow-up blocker: `Task.toJson()` could throw during JSON-RPC response serialization if task timestamps were null.
- Fixed by making `Task.createdAt` and `Task.lastUpdatedAt` required non-null fields and removing the throwing `toJson()` guards; Copilot re-reviewed the latest head and generated no new comments.
