### PR TITLE
feat(cli): add conformance and fuzz testing mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@
   titled enum `const` entries, and simple `type` array unions such as nullable
   schemas.
 
+### Tooling
+
+- Added `mcp_dart conformance` with built-in JSON-RPC and protocol-version fixture checks, deterministic JSON-RPC fuzz cases, exact-case filtering, and JSON output for CI/scripts.
+
 ## 2.1.1
 
 ### Compatibility Notes (Potentially Breaking)

--- a/packages/mcp_dart_cli/CHANGELOG.md
+++ b/packages/mcp_dart_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add `mcp_dart conformance` with built-in JSON-RPC and protocol-version fixture checks, deterministic JSON-RPC fuzz cases, exact-case filtering, and JSON output for CI/scripts.
+
 ## 0.1.7
 
 - Fix `mcp_dart inspect` for local projects whose `pubspec.yaml` package name is quoted.

--- a/packages/mcp_dart_cli/README.md
+++ b/packages/mcp_dart_cli/README.md
@@ -52,6 +52,7 @@ mcp_dart create <project_name> --template https://github.com/leehack/mcp_dart/tr
 - `serve`: Runs the MCP server in the current directory.
 - `doctor`: Checks the project for common issues and verifies connectivity.
 - `inspect`: Interacts with an MCP server (local or external).
+- `conformance`: Runs built-in MCP conformance fixture checks for protocol edge cases.
 - `update`: Updates the CLI to the latest version.
 
 ### Doctor
@@ -122,6 +123,24 @@ mcp_dart inspect --url http://localhost:3000/mcp
 **Sampling Support:**
 
 The CLI supports `sampling/createMessage` requests from the server (often used by tools like `summarize` that need an LLM). Currently, it returns a placeholder response to ensure tools complete successfully.
+
+### Conformance
+
+Run built-in fixture checks and deterministic fuzz checks for MCP protocol edge cases. The initial suite covers JSON-RPC malformed-message handling, string request IDs, string progress tokens, and advertised protocol-version support.
+
+```bash
+# Run all built-in fixture cases
+mcp_dart conformance
+
+# Run one case by exact name
+mcp_dart conformance --case jsonrpc.preserves-string-response-id
+
+# Run deterministic generated JSON-RPC fuzz cases
+mcp_dart conformance --fuzz --iterations 64
+
+# Emit machine-readable results for CI or scripts
+mcp_dart conformance --json
+```
 
 ### Serve
 

--- a/packages/mcp_dart_cli/bin/mcp_dart.dart
+++ b/packages/mcp_dart_cli/bin/mcp_dart.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:mason_logger/mason_logger.dart';
+import 'package:mcp_dart_cli/src/conformance_command.dart';
 import 'package:mcp_dart_cli/src/create_command.dart';
 import 'package:mcp_dart_cli/src/serve_command.dart';
 import 'package:mcp_dart_cli/src/doctor_command.dart';
@@ -8,6 +9,19 @@ import 'package:mcp_dart_cli/src/inspect_command.dart';
 import 'package:mcp_dart_cli/src/update_command.dart';
 import 'package:mcp_dart_cli/src/version.dart';
 import 'package:mcp_dart_cli/src/version_check.dart';
+
+bool shouldCheckForUpdate(List<String> arguments) {
+  if (arguments.contains('update')) {
+    return false;
+  }
+
+  final command = arguments.isEmpty ? null : arguments.first;
+  if (command == 'conformance' && arguments.contains('--json')) {
+    return false;
+  }
+
+  return true;
+}
 
 void main(List<String> arguments) async {
   if (arguments.contains('--version') || arguments.contains('-v')) {
@@ -24,11 +38,12 @@ void main(List<String> arguments) async {
     ..addCommand(ServeCommand())
     ..addCommand(DoctorCommand())
     ..addCommand(InspectCommand(logger: logger))
+    ..addCommand(ConformanceCommand(logger: logger))
     ..addCommand(UpdateCommand(logger: logger));
 
   try {
     final exitCode = await runner.run(arguments);
-    if (!arguments.contains('update')) {
+    if (shouldCheckForUpdate(arguments)) {
       await checkForUpdate(logger);
     }
     exit(exitCode ?? 0);

--- a/packages/mcp_dart_cli/lib/src/conformance_command.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_command.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:mason/mason.dart';
+
+import 'conformance_runner.dart';
+
+/// Runs MCP protocol conformance checks against built-in fixtures.
+class ConformanceCommand extends Command<int> {
+  @override
+  final name = 'conformance';
+
+  @override
+  final description =
+      'Runs MCP conformance checks for JSON-RPC and protocol-version edge cases.';
+
+  final Logger _logger;
+  final ConformanceRunner _runner;
+
+  ConformanceCommand({Logger? logger, ConformanceRunner? runner})
+      : _logger = logger ?? Logger(),
+        _runner = runner ?? ConformanceRunner() {
+    argParser
+      ..addOption(
+        'case',
+        help: 'Run one built-in conformance case by exact name.',
+      )
+      ..addFlag(
+        'fuzz',
+        help: 'Run deterministic generated JSON-RPC fuzz cases.',
+        negatable: false,
+      )
+      ..addOption(
+        'iterations',
+        help: 'Number of fuzz cases to generate when --fuzz is set.',
+        defaultsTo: '32',
+      )
+      ..addFlag(
+        'json',
+        help: 'Print machine-readable JSON results.',
+        negatable: false,
+      );
+  }
+
+  @override
+  Future<int> run() async {
+    final filter = argResults?['case'] as String?;
+    final fuzz = argResults?['fuzz'] as bool? ?? false;
+    final iterations = int.tryParse(argResults?['iterations'] as String? ?? '');
+    final json = argResults?['json'] as bool? ?? false;
+
+    if (iterations == null || iterations < 1) {
+      _logger.err('--iterations must be a positive integer.');
+      return ExitCode.usage.code;
+    }
+    if (fuzz && filter != null) {
+      _logger.err('--case cannot be combined with --fuzz.');
+      return ExitCode.usage.code;
+    }
+
+    if (!json) {
+      _logger.info(
+        fuzz
+            ? 'Running MCP conformance fuzz suite...'
+            : 'Running MCP conformance fixture suite...',
+      );
+    }
+
+    final result = fuzz
+        ? await _runner.runFuzzSuite(iterations: iterations)
+        : await _runner.runFixtureSuite(filter: filter);
+    if (result.total == 0) {
+      _logger.err('No conformance cases matched: $filter');
+      return ExitCode.usage.code;
+    }
+
+    if (json) {
+      stdout
+          .writeln(const JsonEncoder.withIndent('  ').convert(result.toJson()));
+    } else {
+      for (final testCase in result.cases) {
+        final marker = testCase.passed ? '[✓]' : '[x]';
+        final line = '$marker ${testCase.name} — ${testCase.description}';
+        if (testCase.passed) {
+          _logger.detail(line);
+        } else {
+          _logger.err(line);
+          if (testCase.diagnostic != null) {
+            _logger.err('    ${testCase.diagnostic}');
+          }
+        }
+      }
+    }
+
+    if (result.passed) {
+      if (!json) {
+        _logger.success(
+          'Conformance passed: ${result.passedCount}/${result.total} cases.',
+        );
+      }
+      return ExitCode.success.code;
+    }
+
+    if (!json) {
+      _logger.err(
+        'Conformance failed: ${result.failedCount}/${result.total} cases failed.',
+      );
+    }
+    return ExitCode.software.code;
+  }
+}

--- a/packages/mcp_dart_cli/lib/src/conformance_runner.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_runner.dart
@@ -1,0 +1,405 @@
+import 'dart:math';
+
+import 'package:mcp_dart/mcp_dart.dart';
+
+/// Result of running one conformance case.
+class ConformanceCaseResult {
+  final String name;
+  final String description;
+  final bool passed;
+  final String? diagnostic;
+
+  const ConformanceCaseResult({
+    required this.name,
+    required this.description,
+    required this.passed,
+    this.diagnostic,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'description': description,
+        'passed': passed,
+        if (diagnostic != null) 'diagnostic': diagnostic,
+      };
+}
+
+/// Result of running a conformance suite.
+class ConformanceSuiteResult {
+  final List<ConformanceCaseResult> cases;
+
+  const ConformanceSuiteResult(this.cases);
+
+  int get total => cases.length;
+  int get passedCount => cases.where((result) => result.passed).length;
+  int get failedCount => total - passedCount;
+  bool get passed => failedCount == 0;
+  List<String> get caseNames => [for (final result in cases) result.name];
+
+  Map<String, dynamic> toJson() => {
+        'passed': passed,
+        'total': total,
+        'passedCount': passedCount,
+        'failedCount': failedCount,
+        'cases': [for (final result in cases) result.toJson()],
+      };
+}
+
+typedef _ConformanceCheck = Future<void> Function();
+
+class _ConformanceCase {
+  final String name;
+  final String description;
+  final _ConformanceCheck check;
+
+  const _ConformanceCase({
+    required this.name,
+    required this.description,
+    required this.check,
+  });
+}
+
+/// Runs the built-in MCP conformance fixture checks.
+class ConformanceRunner {
+  final List<_ConformanceCase> _fixtureCases;
+
+  ConformanceRunner()
+      : _fixtureCases = <_ConformanceCase>[
+          _ConformanceCase(
+            name: 'jsonrpc.rejects-invalid-version',
+            description:
+                'Rejects JSON-RPC messages whose jsonrpc version is not 2.0.',
+            check: _rejectsInvalidJsonRpcVersion,
+          ),
+          _ConformanceCase(
+            name: 'jsonrpc.rejects-malformed-message',
+            description:
+                'Rejects JSON-RPC envelopes without a method, result, or error member.',
+            check: _rejectsMalformedJsonRpcMessage,
+          ),
+          _ConformanceCase(
+            name: 'jsonrpc.preserves-string-response-id',
+            description:
+                'Parses and serializes successful responses with string JSON-RPC IDs.',
+            check: _preservesStringResponseId,
+          ),
+          _ConformanceCase(
+            name: 'jsonrpc.preserves-string-progress-token',
+            description:
+                'Parses and serializes progress notifications with string progress tokens.',
+            check: _preservesStringProgressToken,
+          ),
+          _ConformanceCase(
+            name: 'protocol-version.advertises-latest-2025-11-25',
+            description:
+                'Advertises MCP 2025-11-25 as the latest supported protocol version.',
+            check: _advertisesLatestProtocolVersion,
+          ),
+        ];
+
+  /// Runs the built-in fixture suite.
+  ///
+  /// When [filter] is provided, only exact case-name matches run. Exact matching
+  /// keeps CI diagnostics deterministic and prevents accidental broad filters.
+  Future<ConformanceSuiteResult> runFixtureSuite({String? filter}) async {
+    final selectedCases = filter == null
+        ? _fixtureCases
+        : _fixtureCases.where((testCase) => testCase.name == filter).toList();
+
+    final results = <ConformanceCaseResult>[];
+    for (final testCase in selectedCases) {
+      try {
+        await testCase.check();
+        results.add(
+          ConformanceCaseResult(
+            name: testCase.name,
+            description: testCase.description,
+            passed: true,
+          ),
+        );
+      } catch (error) {
+        results.add(
+          ConformanceCaseResult(
+            name: testCase.name,
+            description: testCase.description,
+            passed: false,
+            diagnostic: error.toString(),
+          ),
+        );
+      }
+    }
+
+    return ConformanceSuiteResult(results);
+  }
+
+  /// Runs deterministic parser-fuzz checks against generated JSON-RPC envelopes.
+  Future<ConformanceSuiteResult> runFuzzSuite({
+    int iterations = 32,
+    int seed = 0,
+  }) async {
+    if (iterations < 1) {
+      throw ArgumentError.value(iterations, 'iterations', 'must be positive');
+    }
+
+    final random = Random(seed);
+    final results = <ConformanceCaseResult>[];
+    for (var index = 0; index < iterations; index += 1) {
+      final fixture = _generatedJsonRpcFixture(random, index);
+      try {
+        fixture.expectation(fixture.message);
+        results.add(
+          ConformanceCaseResult(
+            name: fixture.name,
+            description: fixture.description,
+            passed: true,
+          ),
+        );
+      } catch (error) {
+        results.add(
+          ConformanceCaseResult(
+            name: fixture.name,
+            description: fixture.description,
+            passed: false,
+            diagnostic: 'Payload: ${fixture.message}; error: $error',
+          ),
+        );
+      }
+    }
+
+    return ConformanceSuiteResult(results);
+  }
+}
+
+class _GeneratedJsonRpcFixture {
+  final String name;
+  final String description;
+  final Map<String, dynamic> message;
+  final void Function(Map<String, dynamic> message) expectation;
+
+  const _GeneratedJsonRpcFixture({
+    required this.name,
+    required this.description,
+    required this.message,
+    required this.expectation,
+  });
+}
+
+_GeneratedJsonRpcFixture _generatedJsonRpcFixture(Random random, int index) {
+  final numericId = random.nextInt(1000000);
+  final stringId = 'req-${random.nextInt(1000000)}';
+  final progressToken = random.nextBool() ? numericId : 'progress-$numericId';
+
+  return switch (random.nextInt(6)) {
+    0 => _GeneratedJsonRpcFixture(
+        name: 'fuzz.jsonrpc.invalid-version.$index',
+        description:
+            'Generated request with an invalid JSON-RPC version is rejected.',
+        message: <String, dynamic>{
+          'jsonrpc': '2.${random.nextInt(9) + 1}',
+          'id': random.nextBool() ? numericId : stringId,
+          'method': Method.ping,
+        },
+        expectation: _expectFormatExceptionForPayload,
+      ),
+    1 => _GeneratedJsonRpcFixture(
+        name: 'fuzz.jsonrpc.malformed-envelope.$index',
+        description:
+            'Generated JSON-RPC envelope without request/response members is rejected.',
+        message: <String, dynamic>{
+          'jsonrpc': jsonRpcVersion,
+          'id': random.nextBool() ? numericId : stringId,
+          'params': <String, dynamic>{'noise': random.nextInt(100)},
+        },
+        expectation: _expectFormatExceptionForPayload,
+      ),
+    2 => _GeneratedJsonRpcFixture(
+        name: 'fuzz.jsonrpc.request-id.$index',
+        description: 'Generated requests preserve string-or-integer IDs.',
+        message: <String, dynamic>{
+          'jsonrpc': jsonRpcVersion,
+          'id': random.nextBool() ? numericId : stringId,
+          'method': Method.ping,
+        },
+        expectation: _expectRequestIdRoundTrip,
+      ),
+    3 => _GeneratedJsonRpcFixture(
+        name: 'fuzz.jsonrpc.response-id.$index',
+        description: 'Generated responses preserve string-or-integer IDs.',
+        message: <String, dynamic>{
+          'jsonrpc': jsonRpcVersion,
+          'id': random.nextBool() ? numericId : stringId,
+          'result': <String, dynamic>{},
+        },
+        expectation: _expectResponseIdRoundTrip,
+      ),
+    4 => _GeneratedJsonRpcFixture(
+        name: 'fuzz.jsonrpc.progress-token.$index',
+        description:
+            'Generated progress notifications preserve string-or-integer progress tokens.',
+        message: <String, dynamic>{
+          'jsonrpc': jsonRpcVersion,
+          'method': Method.notificationsProgress,
+          'params': <String, dynamic>{
+            'progressToken': progressToken,
+            'progress': random.nextInt(10),
+            'total': 10,
+          },
+        },
+        expectation: _expectProgressTokenRoundTrip,
+      ),
+    _ => _GeneratedJsonRpcFixture(
+        name: 'fuzz.jsonrpc.error-id.$index',
+        description:
+            'Generated error responses preserve string-or-integer IDs.',
+        message: <String, dynamic>{
+          'jsonrpc': jsonRpcVersion,
+          'id': random.nextBool() ? numericId : stringId,
+          'error': <String, dynamic>{
+            'code': ErrorCode.invalidRequest.value,
+            'message': 'generated invalid request',
+          },
+        },
+        expectation: _expectErrorIdRoundTrip,
+      ),
+  };
+}
+
+Future<void> _rejectsInvalidJsonRpcVersion() async {
+  _expectThrowsFormatException(
+    () => JsonRpcMessage.fromJson(const <String, dynamic>{
+      'jsonrpc': '1.0',
+      'id': 1,
+      'method': Method.ping,
+    }),
+  );
+}
+
+Future<void> _rejectsMalformedJsonRpcMessage() async {
+  _expectThrowsFormatException(
+    () => JsonRpcMessage.fromJson(const <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 1,
+    }),
+  );
+}
+
+Future<void> _preservesStringResponseId() async {
+  final message = JsonRpcMessage.fromJson(const <String, dynamic>{
+    'jsonrpc': jsonRpcVersion,
+    'id': 'request-1',
+    'result': <String, dynamic>{},
+  });
+
+  if (message is! JsonRpcResponse) {
+    throw StateError('Expected JsonRpcResponse, got ${message.runtimeType}.');
+  }
+  if (message.id != 'request-1') {
+    throw StateError('Expected string response ID to be preserved.');
+  }
+  if (message.toJson()['id'] != 'request-1') {
+    throw StateError('Expected serialized response ID to stay a string.');
+  }
+}
+
+Future<void> _preservesStringProgressToken() async {
+  final message = JsonRpcMessage.fromJson(const <String, dynamic>{
+    'jsonrpc': jsonRpcVersion,
+    'method': Method.notificationsProgress,
+    'params': <String, dynamic>{
+      'progressToken': 'progress-1',
+      'progress': 1,
+      'total': 2,
+    },
+  });
+
+  if (message is! JsonRpcProgressNotification) {
+    throw StateError(
+      'Expected JsonRpcProgressNotification, got ${message.runtimeType}.',
+    );
+  }
+  if (message.progressParams.progressToken != 'progress-1') {
+    throw StateError('Expected string progress token to be preserved.');
+  }
+  if (message.toJson()['params']['progressToken'] != 'progress-1') {
+    throw StateError('Expected serialized progress token to stay a string.');
+  }
+}
+
+Future<void> _advertisesLatestProtocolVersion() async {
+  if (latestProtocolVersion != '2025-11-25') {
+    throw StateError(
+      'Expected latestProtocolVersion 2025-11-25, got $latestProtocolVersion.',
+    );
+  }
+  if (supportedProtocolVersions.first != latestProtocolVersion) {
+    throw StateError('Expected latestProtocolVersion to be advertised first.');
+  }
+  if (!supportedProtocolVersions.contains('2025-11-25')) {
+    throw StateError('Expected supported versions to include 2025-11-25.');
+  }
+}
+
+void _expectThrowsFormatException(void Function() callback) {
+  try {
+    callback();
+  } on FormatException {
+    return;
+  }
+
+  throw StateError('Expected FormatException.');
+}
+
+void _expectFormatExceptionForPayload(Map<String, dynamic> message) {
+  _expectThrowsFormatException(() => JsonRpcMessage.fromJson(message));
+}
+
+void _expectRequestIdRoundTrip(Map<String, dynamic> message) {
+  final parsed = JsonRpcMessage.fromJson(message);
+  if (parsed is! JsonRpcRequest) {
+    throw StateError('Expected JsonRpcRequest, got ${parsed.runtimeType}.');
+  }
+  _expectIdRoundTrip(parsed.id, message['id'], parsed.toJson());
+}
+
+void _expectResponseIdRoundTrip(Map<String, dynamic> message) {
+  final parsed = JsonRpcMessage.fromJson(message);
+  if (parsed is! JsonRpcResponse) {
+    throw StateError('Expected JsonRpcResponse, got ${parsed.runtimeType}.');
+  }
+  _expectIdRoundTrip(parsed.id, message['id'], parsed.toJson());
+}
+
+void _expectErrorIdRoundTrip(Map<String, dynamic> message) {
+  final parsed = JsonRpcMessage.fromJson(message);
+  if (parsed is! JsonRpcError) {
+    throw StateError('Expected JsonRpcError, got ${parsed.runtimeType}.');
+  }
+  _expectIdRoundTrip(parsed.id, message['id'], parsed.toJson());
+}
+
+void _expectProgressTokenRoundTrip(Map<String, dynamic> message) {
+  final parsed = JsonRpcMessage.fromJson(message);
+  if (parsed is! JsonRpcProgressNotification) {
+    throw StateError(
+      'Expected JsonRpcProgressNotification, got ${parsed.runtimeType}.',
+    );
+  }
+  final token = message['params']['progressToken'];
+  if (parsed.progressParams.progressToken != token) {
+    throw StateError('Expected progress token $token, got '
+        '${parsed.progressParams.progressToken}.');
+  }
+  if (parsed.toJson()['params']['progressToken'] != token) {
+    throw StateError('Expected serialized progress token to preserve $token.');
+  }
+}
+
+void _expectIdRoundTrip(
+    RequestId actualId, Object expectedId, Map<String, dynamic> json) {
+  if (actualId != expectedId) {
+    throw StateError('Expected ID $expectedId, got $actualId.');
+  }
+  if (json['id'] != expectedId) {
+    throw StateError('Expected serialized ID to preserve $expectedId.');
+  }
+}

--- a/packages/mcp_dart_cli/test/bin/mcp_dart_test.dart
+++ b/packages/mcp_dart_cli/test/bin/mcp_dart_test.dart
@@ -1,0 +1,19 @@
+import 'package:test/test.dart';
+
+import '../../bin/mcp_dart.dart' as cli;
+
+void main() {
+  group('shouldCheckForUpdate', () {
+    test('skips update command', () {
+      expect(cli.shouldCheckForUpdate(['update']), isFalse);
+    });
+
+    test('skips conformance JSON mode to keep stdout machine-readable', () {
+      expect(cli.shouldCheckForUpdate(['conformance', '--json']), isFalse);
+    });
+
+    test('checks updates for normal conformance output', () {
+      expect(cli.shouldCheckForUpdate(['conformance']), isTrue);
+    });
+  });
+}

--- a/packages/mcp_dart_cli/test/src/conformance_command_test.dart
+++ b/packages/mcp_dart_cli/test/src/conformance_command_test.dart
@@ -1,0 +1,142 @@
+import 'package:args/command_runner.dart';
+import 'package:mason/mason.dart';
+import 'package:mcp_dart_cli/src/conformance_command.dart';
+import 'package:mcp_dart_cli/src/conformance_runner.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockLogger extends Mock implements Logger {}
+
+void main() {
+  group('ConformanceRunner', () {
+    test('fixture suite covers initial JSON-RPC and protocol-version cases',
+        () async {
+      final result = await ConformanceRunner().runFixtureSuite();
+
+      expect(result.passed, isTrue);
+      expect(result.total, greaterThanOrEqualTo(5));
+      expect(
+        result.caseNames,
+        containsAll(<String>[
+          'jsonrpc.rejects-invalid-version',
+          'jsonrpc.rejects-malformed-message',
+          'jsonrpc.preserves-string-response-id',
+          'jsonrpc.preserves-string-progress-token',
+          'protocol-version.advertises-latest-2025-11-25',
+        ]),
+      );
+    });
+
+    test('can filter fixture cases by exact name', () async {
+      final result = await ConformanceRunner().runFixtureSuite(
+        filter: 'jsonrpc.preserves-string-response-id',
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.total, 1);
+      expect(result.caseNames, ['jsonrpc.preserves-string-response-id']);
+    });
+
+    test('deterministic fuzz suite exercises generated JSON-RPC envelopes',
+        () async {
+      final result = await ConformanceRunner().runFuzzSuite(
+        iterations: 8,
+        seed: 101,
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.total, 8);
+      expect(result.caseNames.first, startsWith('fuzz.jsonrpc.'));
+    });
+  });
+
+  group('ConformanceCommand', () {
+    late Logger logger;
+    late ConformanceCommand command;
+
+    setUp(() {
+      logger = MockLogger();
+      command = ConformanceCommand(logger: logger);
+    });
+
+    test('has expected name and options', () {
+      expect(command.name, 'conformance');
+      expect(command.argParser.options.containsKey('case'), isTrue);
+      expect(command.argParser.options.containsKey('fuzz'), isTrue);
+      expect(command.argParser.options.containsKey('iterations'), isTrue);
+      expect(command.argParser.options.containsKey('json'), isTrue);
+    });
+
+    test('runs fixture suite and reports success summary', () async {
+      final runner = CommandRunner<int>('mcp_dart', 'CLI')..addCommand(command);
+
+      final exitCode = await runner.run(['conformance']);
+
+      expect(exitCode, ExitCode.success.code);
+      verify(
+        () => logger.info('Running MCP conformance fixture suite...'),
+      ).called(1);
+      verify(
+        () => logger.success(any(that: contains('Conformance passed:'))),
+      ).called(1);
+    });
+
+    test('runs deterministic fuzz suite and reports success summary', () async {
+      final runner = CommandRunner<int>('mcp_dart', 'CLI')..addCommand(command);
+
+      final exitCode = await runner.run([
+        'conformance',
+        '--fuzz',
+        '--iterations',
+        '4',
+      ]);
+
+      expect(exitCode, ExitCode.success.code);
+      verify(
+        () => logger.info('Running MCP conformance fuzz suite...'),
+      ).called(1);
+      verify(
+        () => logger.success('Conformance passed: 4/4 cases.'),
+      ).called(1);
+    });
+
+    test('does not log human output when json output is requested', () async {
+      final runner = CommandRunner<int>('mcp_dart', 'CLI')..addCommand(command);
+
+      final exitCode = await runner.run(['conformance', '--json']);
+
+      expect(exitCode, ExitCode.success.code);
+      verifyNever(() => logger.info(any()));
+      verifyNever(() => logger.success(any()));
+    });
+
+    test('returns usage code when --case is combined with fuzz mode', () async {
+      final runner = CommandRunner<int>('mcp_dart', 'CLI')..addCommand(command);
+
+      final exitCode = await runner.run([
+        'conformance',
+        '--fuzz',
+        '--case',
+        'jsonrpc.preserves-string-response-id',
+      ]);
+
+      expect(exitCode, ExitCode.usage.code);
+      verify(() => logger.err('--case cannot be combined with --fuzz.'))
+          .called(1);
+    });
+
+    test('returns usage code when filter matches no cases', () async {
+      final runner = CommandRunner<int>('mcp_dart', 'CLI')..addCommand(command);
+
+      final exitCode = await runner.run([
+        'conformance',
+        '--case',
+        'missing.case',
+      ]);
+
+      expect(exitCode, ExitCode.usage.code);
+      verify(() => logger.err('No conformance cases matched: missing.case'))
+          .called(1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `mcp_dart conformance` for built-in JSON-RPC/protocol-version fixture checks.
- Add deterministic JSON-RPC fuzz mode with `--fuzz --iterations`.
- Support exact fixture filtering via `--case` and machine-readable `--json` output for CI/scripts.
- Keep `conformance --json` stdout pure by skipping automatic update notices in JSON mode.

Fixes #101

## Production-readiness scope
- Users can run `mcp_dart conformance` locally to catch initial MCP/JSON-RPC edge-case regressions.
- Supported paths: built-in fixture mode, deterministic fuzz mode, exact fixture filtering, and JSON output.
- Unsupported option combinations fail loudly: `--case` cannot be combined with `--fuzz`.
- Existing CLI behavior remains compatible; normal commands still perform update checks, while `conformance --json` skips them to preserve machine-readable stdout.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed bin/mcp_dart.dart lib/src/conformance_command.dart lib/src/conformance_runner.dart test/bin/mcp_dart_test.dart test/src/conformance_command_test.dart`
- [x] `dart analyze` from `packages/mcp_dart_cli`
- [x] `dart test` from `packages/mcp_dart_cli`
- [x] `dart run mcp_dart_cli conformance --json` piped through `python3 -m json.tool`
- [x] `dart run mcp_dart_cli conformance --fuzz --iterations 8 --json` piped through `python3 -m json.tool`
- [x] Invalid combo check: `mcp_dart conformance --fuzz --case jsonrpc.preserves-string-response-id` exits non-zero
- [x] `dart analyze` from repo root
- [x] `dart test` from repo root
- [x] `git diff --check origin/main...HEAD`

## Review Notes
- Independent review found and fixed one blocker: automatic update notices could pollute `--json` stdout.
- Follow-up independent re-review found no blocking security or logic regressions.
