### PR TITLE
fix(streamable-http): recover from stale session ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
 
 ### Reliability
 
+- Returned `404 Session not found` for stale, unknown, or terminated Streamable
+  HTTP session IDs across high-level and bare transports, and retried client
+  initialization once without a stale preconfigured session ID.
 - Honored `RequestOptions.resetTimeoutOnProgress` and `maxTotalTimeout` together
   so progress notifications can reset inactivity timers without bypassing the
   absolute total timeout cap.

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -521,7 +521,23 @@ class StreamableHttpClientTransport
     int? relatedRequestId,
     String? resumptionToken,
     void Function(String)? onResumptionToken,
+  }) {
+    return _send(
+      message,
+      relatedRequestId: relatedRequestId,
+      resumptionToken: resumptionToken,
+      onResumptionToken: onResumptionToken,
+    );
+  }
+
+  Future<void> _send(
+    JsonRpcMessage message, {
+    int? relatedRequestId,
+    String? resumptionToken,
+    void Function(String)? onResumptionToken,
+    bool retryStaleSessionOn404 = true,
   }) async {
+    var retryFailureAlreadyReported = false;
     try {
       if (resumptionToken != null) {
         // If we have a last event ID, we need to reconnect the SSE stream
@@ -576,6 +592,25 @@ class StreamableHttpClientTransport
         }
 
         final text = await response.stream.transform(utf8.decoder).join();
+        if (response.statusCode == 404 &&
+            retryStaleSessionOn404 &&
+            _sessionId != null &&
+            _isInitializeRequest(message)) {
+          _sessionId = null;
+          try {
+            await _send(
+              message,
+              relatedRequestId: relatedRequestId,
+              resumptionToken: resumptionToken,
+              onResumptionToken: onResumptionToken,
+              retryStaleSessionOn404: false,
+            );
+          } catch (_) {
+            retryFailureAlreadyReported = true;
+            rethrow;
+          }
+          return;
+        }
         throw McpError(
           0,
           "Error POSTing to endpoint (HTTP ${response.statusCode}): $text",
@@ -653,10 +688,12 @@ class StreamableHttpClientTransport
         }
       }
     } catch (error) {
-      if (error is Error) {
-        onerror?.call(error);
-      } else {
-        onerror?.call(McpError(0, error.toString()));
+      if (!retryFailureAlreadyReported) {
+        if (error is Error) {
+          onerror?.call(error);
+        } else {
+          onerror?.call(McpError(0, error.toString()));
+        }
       }
       rethrow;
     }
@@ -711,6 +748,13 @@ class StreamableHttpClientTransport
       }
       rethrow;
     }
+  }
+
+  bool _isInitializeRequest(JsonRpcMessage message) {
+    if (message is JsonRpcRequest) {
+      return message.method == 'initialize';
+    }
+    return false;
   }
 
   // Helper method to check if a message is an initialized notification

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -142,6 +142,7 @@ class StreamableHTTPServerTransport
   final Map<dynamic, String> _requestToStreamMapping = {};
   final Map<dynamic, JsonRpcMessage> _requestResponseMap = {};
   bool _initialized = false;
+  bool _terminated = false;
   final bool _enableJsonResponse;
   final String _standaloneSseStreamId = '_GET_stream';
   final EventStore? _eventStore;
@@ -598,9 +599,23 @@ class StreamableHTTPServerTransport
       // https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle/
       final isInitializationRequest = messages.any(_isInitializeRequest);
       if (isInitializationRequest) {
+        final requestSessionId = req.headers.value('mcp-session-id');
+
         // If it's a server with session management and the session ID is already set we should reject the request
-        // to avoid re-initialization.
+        // to avoid re-initialization. A mismatched or terminated session ID means the client referenced a session
+        // this transport cannot serve, so return the Streamable HTTP stale-session 404.
         if (_initialized && sessionId != null) {
+          if (_terminated ||
+              requestSessionId != null && requestSessionId != sessionId) {
+            await _writeJsonRpcErrorResponse(
+              req.response,
+              httpStatus: HttpStatus.notFound,
+              errorCode: ErrorCode.connectionClosed,
+              message: 'Session not found',
+            );
+            return;
+          }
+
           req.response.statusCode = HttpStatus.badRequest;
           req.response.write(
             jsonEncode(
@@ -633,7 +648,21 @@ class StreamableHTTPServerTransport
           await _safeClose(req.response);
           return;
         }
-        sessionId = _sessionIdGenerator?.call();
+
+        final generatedSessionId = _sessionIdGenerator?.call();
+        if (requestSessionId != null &&
+            generatedSessionId != null &&
+            requestSessionId != generatedSessionId) {
+          await _writeJsonRpcErrorResponse(
+            req.response,
+            httpStatus: HttpStatus.notFound,
+            errorCode: ErrorCode.connectionClosed,
+            message: 'Session not found',
+          );
+          return;
+        }
+
+        sessionId = generatedSessionId;
         _initialized = true;
 
         // If we have a session ID and an onsessioninitialized handler, call it immediately
@@ -804,8 +833,8 @@ class StreamableHTTPServerTransport
       );
       await _safeClose(res);
       return false;
-    } else if (requestSessionId != sessionId) {
-      // Reject requests with invalid session ID with 404 Not Found
+    } else if (_terminated || requestSessionId != sessionId) {
+      // Reject terminated or invalid session IDs with 404 Not Found.
       res.statusCode = HttpStatus.notFound;
       res.write(
         jsonEncode(
@@ -827,6 +856,10 @@ class StreamableHTTPServerTransport
 
   @override
   Future<void> close() async {
+    if (sessionId != null) {
+      _terminated = true;
+    }
+
     // Close all SSE connections - fix concurrent modification by creating a copy of the values first
     final responses = List<HttpResponse>.from(_streamMapping.values);
     for (final response in responses) {

--- a/lib/src/server/streamable_mcp_server.dart
+++ b/lib/src/server/streamable_mcp_server.dart
@@ -217,6 +217,17 @@ class StreamableMcpServer {
     // OR be passed the parsed body.
     // To support the routing logic (new vs existing session), we must read it here.
 
+    final sessionId = request.headers.value('mcp-session-id');
+    if (sessionId != null && !_transports.containsKey(sessionId)) {
+      await _respondWithJsonRpcError(
+        request.response,
+        httpStatus: HttpStatus.notFound,
+        errorCode: ErrorCode.connectionClosed,
+        message: 'Session not found',
+      );
+      return;
+    }
+
     final bodyBytes = await _collectBytes(request);
     final bodyString = utf8.decode(bodyBytes);
     dynamic body;
@@ -253,12 +264,11 @@ class StreamableMcpServer {
       return;
     }
 
-    final sessionId = request.headers.value('mcp-session-id');
     StreamableHTTPServerTransport? transport;
 
-    if (sessionId != null && _transports.containsKey(sessionId)) {
+    if (sessionId != null) {
       transport = _transports[sessionId]!;
-    } else if (sessionId == null && _isInitializeRequest(body)) {
+    } else if (_isInitializeRequest(body)) {
       // New initialization request
       transport = _createTransport();
 
@@ -282,10 +292,17 @@ class StreamableMcpServer {
 
   Future<void> _handleGetRequest(HttpRequest request) async {
     final sessionId = request.headers.value('mcp-session-id');
-    if (sessionId == null || !_transports.containsKey(sessionId)) {
+    if (sessionId == null) {
       request.response
         ..statusCode = HttpStatus.badRequest
-        ..write('Invalid or missing session ID')
+        ..write('Missing session ID')
+        ..close();
+      return;
+    }
+    if (!_transports.containsKey(sessionId)) {
+      request.response
+        ..statusCode = HttpStatus.notFound
+        ..write('Session not found')
         ..close();
       return;
     }
@@ -296,10 +313,17 @@ class StreamableMcpServer {
 
   Future<void> _handleDeleteRequest(HttpRequest request) async {
     final sessionId = request.headers.value('mcp-session-id');
-    if (sessionId == null || !_transports.containsKey(sessionId)) {
+    if (sessionId == null) {
       request.response
         ..statusCode = HttpStatus.badRequest
-        ..write('Invalid or missing session ID')
+        ..write('Missing session ID')
+        ..close();
+      return;
+    }
+    if (!_transports.containsKey(sessionId)) {
+      request.response
+        ..statusCode = HttpStatus.notFound
+        ..write('Session not found')
         ..close();
       return;
     }

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -291,6 +291,156 @@ void main() {
       );
     });
 
+    test(
+        'client connect retries initialization without stale session ID after 404',
+        () async {
+      const staleSessionId = 'stale-session-id';
+      const newSessionId = 'new-session-id';
+      final initializeSessionHeaders = <String?>[];
+      final initializedSessionHeaders = <String?>[];
+      var initializeCount = 0;
+      var initializedNotificationCount = 0;
+
+      final retryServer =
+          await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => retryServer.close(force: true));
+      final retryUrl = Uri.parse('http://localhost:${retryServer.port}/mcp');
+
+      retryServer.listen((request) async {
+        if (request.uri.path != '/mcp') {
+          request.response.statusCode = HttpStatus.notFound;
+          await request.response.close();
+          return;
+        }
+
+        if (request.method != 'POST') {
+          request.response.statusCode = HttpStatus.methodNotAllowed;
+          await request.response.close();
+          return;
+        }
+
+        final sessionHeader = request.headers.value('mcp-session-id');
+        final body = await utf8.decoder.bind(request).join();
+        final json = jsonDecode(body) as Map<String, dynamic>;
+
+        if (json['method'] == 'initialize') {
+          initializeSessionHeaders.add(sessionHeader);
+          if (sessionHeader == staleSessionId) {
+            request.response.statusCode = HttpStatus.notFound;
+            request.response.write('Session not found');
+            await request.response.close();
+            return;
+          }
+
+          initializeCount += 1;
+          request.response.headers.contentType = ContentType.json;
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.set('mcp-session-id', newSessionId);
+          request.response.write(
+            jsonEncode(
+              JsonRpcResponse(
+                id: json['id'],
+                result: const InitializeResult(
+                  protocolVersion: latestProtocolVersion,
+                  capabilities: ServerCapabilities(),
+                  serverInfo: Implementation(
+                    name: 'RetrySessionServer',
+                    version: '1.0.0',
+                  ),
+                ).toJson(),
+              ).toJson(),
+            ),
+          );
+          await request.response.close();
+          return;
+        }
+
+        if (json['method'] == 'notifications/initialized') {
+          initializedNotificationCount += 1;
+          initializedSessionHeaders.add(sessionHeader);
+          request.response.statusCode = HttpStatus.accepted;
+          request.response.headers.set('mcp-session-id', newSessionId);
+          await request.response.close();
+          return;
+        }
+
+        request.response.statusCode = HttpStatus.badRequest;
+        await request.response.close();
+      });
+
+      final client = McpClient(
+        const Implementation(name: 'TestClient', version: '1.0.0'),
+      );
+      transport = StreamableHttpClientTransport(
+        retryUrl,
+        opts: const StreamableHttpClientTransportOptions(
+          sessionId: staleSessionId,
+        ),
+      );
+
+      await client.connect(transport);
+
+      expect(initializeCount, 1);
+      expect(initializedNotificationCount, 1);
+      expect(initializeSessionHeaders, [staleSessionId, null]);
+      expect(initializedSessionHeaders, [newSessionId]);
+      expect(transport.sessionId, newSessionId);
+      expect(client.getServerVersion()?.name, 'RetrySessionServer');
+    });
+
+    test('send reports retry failure only once after stale session 404',
+        () async {
+      const staleSessionId = 'stale-session-id';
+      var requestCount = 0;
+      final errors = <Error>[];
+
+      final retryServer =
+          await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => retryServer.close(force: true));
+      final retryUrl = Uri.parse('http://localhost:${retryServer.port}/mcp');
+
+      retryServer.listen((request) async {
+        requestCount += 1;
+        await request.drain<void>();
+        request.response.statusCode = requestCount == 1
+            ? HttpStatus.notFound
+            : HttpStatus.internalServerError;
+        request.response.write(
+          requestCount == 1 ? 'Session not found' : 'Retry failed',
+        );
+        await request.response.close();
+      });
+
+      transport = StreamableHttpClientTransport(
+        retryUrl,
+        opts: const StreamableHttpClientTransportOptions(
+          sessionId: staleSessionId,
+        ),
+      );
+      transport.onerror = errors.add;
+      await transport.start();
+
+      await expectLater(
+        transport.send(
+          JsonRpcRequest(
+            id: 1,
+            method: 'initialize',
+            params: const InitializeRequestParams(
+              protocolVersion: latestProtocolVersion,
+              capabilities: ClientCapabilities(),
+              clientInfo: Implementation(name: 'TestClient', version: '1.0.0'),
+            ).toJson(),
+          ),
+        ),
+        throwsA(isA<McpError>()),
+      );
+
+      expect(requestCount, 2);
+      expect(errors, hasLength(1));
+      expect(errors.single.toString(), contains('Retry failed'));
+      expect(transport.sessionId, isNull);
+    });
+
     test('start initializes the transport', () async {
       transport = StreamableHttpClientTransport(serverUrl);
       await transport.start();

--- a/test/interop/dart_client_with_ts_server_test.dart
+++ b/test/interop/dart_client_with_ts_server_test.dart
@@ -7,6 +7,13 @@ import 'package:test/test.dart';
 import 'package:mcp_dart/mcp_dart.dart';
 import 'package:path/path.dart' as p;
 
+Future<int> _findAvailablePort() async {
+  final socket = await io.ServerSocket.bind(io.InternetAddress.loopbackIPv4, 0);
+  final port = socket.port;
+  await socket.close();
+  return port;
+}
+
 void main() {
   // Locate the TS server (compiled JS version)
   // Default: test/interop/ts/dist/server.js relative to project root
@@ -158,6 +165,52 @@ void main() {
           ),
         );
         expect((echo.content.first as TextContent).text, equals('hello'));
+      });
+
+      test('recovers from stale preconfigured session id during initialize',
+          () async {
+        final stalePort = await _findAvailablePort();
+        final staleServerProcess = await io.Process.start(
+          'node',
+          [tsServerScript, '--transport', 'http', '--port', '$stalePort'],
+          mode: io.ProcessStartMode.normal,
+        );
+
+        staleServerProcess.stdout
+            .transform(io.systemEncoding.decoder)
+            .listen((data) => print('[TS Server] $data'));
+        staleServerProcess.stderr
+            .transform(io.systemEncoding.decoder)
+            .listen((data) => print('[TS Server Error] $data'));
+
+        // Give the node server a moment to start before connecting.
+        await Future.delayed(const Duration(seconds: 2));
+
+        final staleTransport = StreamableHttpClientTransport(
+          Uri.parse('http://localhost:$stalePort/mcp'),
+          opts: const StreamableHttpClientTransportOptions(
+            sessionId: 'stale-session-id',
+          ),
+        );
+        final staleClient = McpClient(
+          const Implementation(name: 'dart-stale-session-test', version: '1.0'),
+          options: const McpClientOptions(
+            capabilities: ClientCapabilities(),
+          ),
+        );
+
+        try {
+          await staleClient.connect(staleTransport);
+
+          expect(staleTransport.sessionId, isNot(equals('stale-session-id')));
+          expect(staleTransport.sessionId, isNotNull);
+
+          final result = await staleClient.listTools();
+          expect(result.tools.map((t) => t.name), containsAll(['echo', 'add']));
+        } finally {
+          await staleClient.close();
+          staleServerProcess.kill();
+        }
       });
     });
   });

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -527,6 +527,160 @@ void main() {
       });
     });
 
+    test('uninitialized transport rejects initialize with unknown session ID',
+        () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => 'new-session-id',
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+      final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+      request.headers
+        ..contentType = ContentType.json
+        ..set(HttpHeaders.acceptHeader, 'application/json, text/event-stream')
+        ..set('mcp-session-id', 'unknown-session-id');
+      request.write(
+        jsonEncode(
+          JsonRpcRequest(
+            id: 1,
+            method: 'initialize',
+            params: const InitializeRequestParams(
+              protocolVersion: latestProtocolVersion,
+              capabilities: ClientCapabilities(),
+              clientInfo: Implementation(name: 'Client', version: '1.0'),
+            ).toJson(),
+          ).toJson(),
+        ),
+      );
+
+      final response = await request.close();
+      final body = await utf8.decodeStream(response);
+
+      expect(response.statusCode, HttpStatus.notFound);
+      expect(body, contains('Session not found'));
+    });
+
+    test('terminated stateful sessions reject subsequent requests with 404',
+        () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => 'terminated-session-id',
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      transport.onmessage = (message) {
+        if (message is! JsonRpcRequest) {
+          return;
+        }
+        unawaited(
+          transport.send(
+            JsonRpcResponse(id: message.id, result: const {'ok': true}),
+          ),
+        );
+      };
+
+      Future<HttpClientResponse> postJsonRpc(
+        JsonRpcMessage message, {
+        String? sessionId,
+      }) async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers
+          ..contentType = ContentType.json
+          ..set(
+            HttpHeaders.acceptHeader,
+            'application/json, text/event-stream',
+          );
+        if (sessionId != null) {
+          request.headers.set('mcp-session-id', sessionId);
+        }
+        request.write(jsonEncode(message.toJson()));
+        return request.close();
+      }
+
+      Future<HttpClientResponse> deleteWithSession(String sessionId) async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.deleteUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers.set('mcp-session-id', sessionId);
+        return request.close();
+      }
+
+      Future<HttpClientResponse> getWithSession(String sessionId) async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.getUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers
+          ..set(HttpHeaders.acceptHeader, 'text/event-stream')
+          ..set('mcp-session-id', sessionId);
+        return request.close();
+      }
+
+      final initResponse = await postJsonRpc(
+        JsonRpcRequest(
+          id: 1,
+          method: 'initialize',
+          params: const InitializeRequestParams(
+            protocolVersion: latestProtocolVersion,
+            capabilities: ClientCapabilities(),
+            clientInfo: Implementation(name: 'Client', version: '1.0'),
+          ).toJson(),
+        ),
+      );
+      expect(initResponse.statusCode, HttpStatus.ok);
+      final sessionId = initResponse.headers.value('mcp-session-id');
+      expect(sessionId, 'terminated-session-id');
+      await initResponse.drain();
+
+      final deleteResponse = await deleteWithSession(sessionId!);
+      expect(deleteResponse.statusCode, HttpStatus.ok);
+      await deleteResponse.drain();
+
+      final postAfterDelete = await postJsonRpc(
+        const JsonRpcRequest(id: 2, method: 'ping'),
+        sessionId: sessionId,
+      );
+      final postAfterDeleteBody = await utf8.decodeStream(postAfterDelete);
+      expect(postAfterDelete.statusCode, HttpStatus.notFound);
+      expect(postAfterDeleteBody, contains('Session not found'));
+
+      final initAfterDelete = await postJsonRpc(
+        JsonRpcRequest(
+          id: 3,
+          method: 'initialize',
+          params: const InitializeRequestParams(
+            protocolVersion: latestProtocolVersion,
+            capabilities: ClientCapabilities(),
+            clientInfo: Implementation(name: 'Client', version: '1.0'),
+          ).toJson(),
+        ),
+        sessionId: sessionId,
+      );
+      final initAfterDeleteBody = await utf8.decodeStream(initAfterDelete);
+      expect(initAfterDelete.statusCode, HttpStatus.notFound);
+      expect(initAfterDeleteBody, contains('Session not found'));
+
+      final getAfterDelete = await getWithSession(sessionId);
+      final getAfterDeleteBody = await utf8.decodeStream(getAfterDelete);
+      expect(getAfterDelete.statusCode, HttpStatus.notFound);
+      expect(getAfterDeleteBody, contains('Session not found'));
+
+      final deleteAfterDelete = await deleteWithSession(sessionId);
+      final deleteAfterDeleteBody = await utf8.decodeStream(deleteAfterDelete);
+      expect(deleteAfterDelete.statusCode, HttpStatus.notFound);
+      expect(deleteAfterDeleteBody, contains('Session not found'));
+    });
+
     test('session validation works correctly', () async {
       // Create a transport with session management
       final transport = StreamableHTTPServerTransport(
@@ -795,6 +949,66 @@ void main() {
       expect(transport.sessionId, isNull);
 
       await transport.close();
+    });
+
+    test('stateless mode allows initialization with session header', () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => null,
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      transport.onmessage = (message) {
+        if (message is JsonRpcRequest && message.method == 'initialize') {
+          unawaited(
+            transport.send(
+              JsonRpcResponse(
+                id: message.id,
+                result: const {
+                  'protocolVersion': latestProtocolVersion,
+                  'capabilities': {},
+                  'serverInfo': {'name': 'StatelessServer', 'version': '1.0.0'},
+                },
+              ),
+            ),
+          );
+        }
+      };
+
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+      final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+      request.headers
+        ..contentType = ContentType.json
+        ..set(
+          HttpHeaders.acceptHeader,
+          'application/json, text/event-stream',
+        )
+        ..set('mcp-session-id', 'ignored-in-stateless-mode');
+      request.write(
+        jsonEncode(
+          const JsonRpcRequest(
+            id: 1,
+            method: 'initialize',
+            params: {
+              'protocolVersion': latestProtocolVersion,
+              'capabilities': {},
+              'clientInfo': {'name': 'TestClient', 'version': '1.0.0'},
+            },
+          ).toJson(),
+        ),
+      );
+
+      final response = await request.close();
+      expect(response.statusCode, HttpStatus.ok);
+      expect(response.headers.value('mcp-session-id'), isNull);
+      final messages =
+          _decodeSseJsonMessages(await utf8.decodeStream(response));
+      expect(messages.single['id'], 1);
+      expect(transport.sessionId, isNull);
     });
 
     test('close cleans up all resources', () async {

--- a/test/server/streamable_mcp_server_test.dart
+++ b/test/server/streamable_mcp_server_test.dart
@@ -12,6 +12,60 @@ void main() {
     final host = 'localhost';
     final baseUrl = 'http://$host:$port/mcp';
 
+    Future<http.Response> postPingWithSession(String sessionId) {
+      return http.post(
+        Uri.parse(baseUrl),
+        body: jsonEncode(const JsonRpcRequest(id: 2, method: 'ping').toJson()),
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json, text/event-stream',
+          'mcp-session-id': sessionId,
+        },
+      );
+    }
+
+    Future<http.Response> postInitialize({String? sessionId}) {
+      final headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        if (sessionId != null) 'mcp-session-id': sessionId,
+      };
+      return http.post(
+        Uri.parse(baseUrl),
+        body: jsonEncode(
+          JsonRpcRequest(
+            id: 1,
+            method: 'initialize',
+            params: const InitializeRequestParams(
+              protocolVersion: latestProtocolVersion,
+              capabilities: ClientCapabilities(),
+              clientInfo: Implementation(name: 'Client', version: '1.0'),
+            ).toJson(),
+          ).toJson(),
+        ),
+        headers: headers,
+      );
+    }
+
+    Future<http.Response> getSseWithSession(String sessionId) async {
+      final client = http.Client();
+      addTearDown(client.close);
+      final req = http.Request('GET', Uri.parse(baseUrl));
+      req.headers['Accept'] = 'text/event-stream';
+      req.headers['mcp-session-id'] = sessionId;
+      final streamedRes = await client.send(req);
+      return http.Response.fromStream(streamedRes);
+    }
+
+    Future<http.Response> deleteSession(String sessionId) async {
+      final client = http.Client();
+      addTearDown(client.close);
+      final req = http.Request('DELETE', Uri.parse(baseUrl));
+      req.headers['mcp-session-id'] = sessionId;
+      final streamedRes = await client.send(req);
+      return http.Response.fromStream(streamedRes);
+    }
+
     setUp(() async {
       server = StreamableMcpServer(
         serverFactory: (sessionId) {
@@ -349,6 +403,62 @@ void main() {
     test('rejects GET without session ID', () async {
       final res = await http.get(Uri.parse(baseUrl));
       expect(res.statusCode, HttpStatus.badRequest);
+    });
+
+    test('returns 404 for unknown session IDs', () async {
+      final postRes = await postPingWithSession('unknown-session-id');
+      expect(postRes.statusCode, HttpStatus.notFound);
+      expect(postRes.body, contains('Session not found'));
+
+      final malformedPostRes = await http.post(
+        Uri.parse(baseUrl),
+        body: 'not json',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json, text/event-stream',
+          'mcp-session-id': 'unknown-session-id',
+        },
+      );
+      expect(malformedPostRes.statusCode, HttpStatus.notFound);
+      expect(malformedPostRes.body, contains('Session not found'));
+
+      final initRes = await postInitialize(sessionId: 'unknown-session-id');
+      expect(initRes.statusCode, HttpStatus.notFound);
+      expect(initRes.body, contains('Session not found'));
+
+      final getRes = await getSseWithSession('unknown-session-id');
+      expect(getRes.statusCode, HttpStatus.notFound);
+      expect(getRes.body, contains('Session not found'));
+
+      final deleteRes = await deleteSession('unknown-session-id');
+      expect(deleteRes.statusCode, HttpStatus.notFound);
+      expect(deleteRes.body, contains('Session not found'));
+    });
+
+    test('returns 404 for requests after session termination', () async {
+      final initRes = await postInitialize();
+      expect(initRes.statusCode, HttpStatus.ok);
+      final sessionId = initRes.headers['mcp-session-id'];
+      expect(sessionId, isNotNull);
+
+      final deleteRes = await deleteSession(sessionId!);
+      expect(deleteRes.statusCode, HttpStatus.ok);
+
+      final postRes = await postPingWithSession(sessionId);
+      expect(postRes.statusCode, HttpStatus.notFound);
+      expect(postRes.body, contains('Session not found'));
+
+      final initAfterDelete = await postInitialize(sessionId: sessionId);
+      expect(initAfterDelete.statusCode, HttpStatus.notFound);
+      expect(initAfterDelete.body, contains('Session not found'));
+
+      final getRes = await getSseWithSession(sessionId);
+      expect(getRes.statusCode, HttpStatus.notFound);
+      expect(getRes.body, contains('Session not found'));
+
+      final deleteAfterDelete = await deleteSession(sessionId);
+      expect(deleteAfterDelete.statusCode, HttpStatus.notFound);
+      expect(deleteAfterDelete.body, contains('Session not found'));
     });
 
     test('authentication', () async {


### PR DESCRIPTION
## Summary
- Return `404 Session not found` for stale, unknown, or terminated Streamable HTTP session IDs in both the high-level `StreamableMcpServer` router and bare `StreamableHTTPServerTransport`.
- Preserve existing missing-header behavior as `400 Bad Request`, while distinguishing stale/unknown session IDs from absent required session headers.
- Recover client initialization from a stale preconfigured session ID by clearing it and retrying once without double-firing `onerror` callbacks.
- Preserve stateless bare transport compatibility when `sessionIdGenerator` returns `null`, even if a client sends `MCP-Session-Id` on initialization.

Fixes #125.

## Compatibility / spec notes
- MCP 2025-11-25 Streamable HTTP behavior is now explicit for missing vs. stale/unknown/terminated session IDs.
- Existing stateless transport behavior remains source/runtime compatible: no session ID is issued and incoming session headers are ignored when session management is disabled.
- Deterministic/predeclared bare-transport session IDs remain supported for interop tests, while mismatched client-provided session IDs are rejected with `404`.

## Tests
- [x] `dart analyze`
- [x] `dart test test/interop/ts_client_with_dart_server_test.dart test/client/streamable_https_test.dart test/server/streamable_https_test.dart test/server/streamable_mcp_server_test.dart`
- [x] `dart test` — 924 tests passed locally
- [x] `git diff --check`
- [x] `npm run build --prefix test/interop/ts`
- [x] `dart test --reporter expanded --tags interop` — Dart↔TypeScript stdio + Streamable HTTP interop/E2E passed, including stale preconfigured session-id recovery against the TypeScript Streamable HTTP server
- [x] GitHub Actions on latest head `df412cf935d040b0ad1b67e91d5ee237fe360a05`:
  - Analyze (actions) ✅
  - Analyze (javascript-typescript) ✅
  - CodeQL ✅
  - Core tests ✅
  - Codecov project/patch ✅

## Review notes
- Independent pre-push review found and fixed retry-failure `onerror` duplication plus TS interop deterministic-session behavior.
- Post-push deep review found and fixed a stateless bare-transport compatibility regression.
- Second-pass review after the stateless fix found no remaining blockers or warnings in the Streamable HTTP/session-recovery scope.
- Copilot review for latest head `df412cf935d040b0ad1b67e91d5ee237fe360a05` generated no new comments.
- Unresolved GitHub review threads: none.


