### PR TITLE
fix: scope streamable HTTP SSE replay by stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
 
 ### Reliability
 
+- Scoped Streamable HTTP SSE resumability to the stream identified by
+  `Last-Event-ID`, allowing multiple concurrent GET SSE streams per session
+  without replaying events from unrelated streams.
 - Returned `404 Session not found` for stale, unknown, or terminated Streamable
   HTTP session IDs across high-level and bare transports, and retried client
   initialization once without a stale preconfigured session ID.

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -328,7 +328,12 @@ class StreamableHttpClientTransport
 
     // Function to process a complete SSE event
     void processEvent() {
-      if (eventData == null) return;
+      final data = eventData;
+      if (data == null) {
+        eventName = null;
+        eventId = null;
+        return;
+      }
 
       // Update last event ID if provided
       if (eventId != null) {
@@ -336,35 +341,41 @@ class StreamableHttpClientTransport
         onResumptionToken?.call(eventId!);
       }
 
-      if (eventName == null || eventName == 'message') {
-        try {
-          final message = JsonRpcMessage.fromJson(jsonDecode(eventData!));
-
-          // Can't set id directly if it's final, need to create a new message
-          if (replayMessageId != null && message is JsonRpcResponse) {
-            // Create a new response with the same data but different ID
-            final newMessage = JsonRpcResponse(
-              id: replayMessageId,
-              result: message.result,
-              meta: message.meta,
-            );
-            onmessage?.call(newMessage);
-          } else {
-            onmessage?.call(message);
-          }
-        } catch (error) {
-          if (error is Error) {
-            onerror?.call(error);
-          } else {
-            onerror?.call(McpError(0, error.toString()));
-          }
-        }
-      }
-
-      // Reset for next event
+      final currentEventName = eventName;
       eventName = null;
       eventId = null;
       eventData = null;
+
+      if (currentEventName != null && currentEventName != 'message') {
+        return;
+      }
+
+      if (data.trim().isEmpty) {
+        return;
+      }
+
+      try {
+        final message = JsonRpcMessage.fromJson(jsonDecode(data));
+
+        // Can't set id directly if it's final, need to create a new message
+        if (replayMessageId != null && message is JsonRpcResponse) {
+          // Create a new response with the same data but different ID
+          final newMessage = JsonRpcResponse(
+            id: replayMessageId,
+            result: message.result,
+            meta: message.meta,
+          );
+          onmessage?.call(newMessage);
+        } else {
+          onmessage?.call(message);
+        }
+      } catch (error) {
+        if (error is Error) {
+          onerror?.call(error);
+        } else {
+          onerror?.call(McpError(0, error.toString()));
+        }
+      }
     }
 
     // Helper function to handle reconnection logic
@@ -445,7 +456,7 @@ class StreamableHttpClientTransport
                 }
                 break;
               case 'data':
-                eventData = (eventData ?? '') + value;
+                eventData = eventData == null ? value : '$eventData\n$value';
                 break;
             }
           }

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -25,7 +25,10 @@ abstract class EventStore {
   /// Returns the generated event ID for the stored event
   Future<EventId> storeEvent(StreamId streamId, JsonRpcMessage message);
 
-  /// Replays events after a specified event ID
+  /// Replays events after a specified event ID.
+  ///
+  /// Implementations must replay only events from the stream that originally
+  /// produced [lastEventId]. Events from other streams must not be replayed.
   ///
   /// [lastEventId] The last event ID received by the client
   /// [send] Callback function that will be called for each event
@@ -139,12 +142,15 @@ class StreamableHTTPServerTransport
   final String? Function()? _sessionIdGenerator;
   bool _started = false;
   final Map<String, HttpResponse> _streamMapping = {};
+  final Set<StreamId> _standaloneSseStreamIds = {};
+  final Map<StreamId, Set<HttpResponse>> _standaloneSseResponses = {};
   final Map<dynamic, String> _requestToStreamMapping = {};
   final Map<dynamic, JsonRpcMessage> _requestResponseMap = {};
   bool _initialized = false;
   bool _terminated = false;
   final bool _enableJsonResponse;
-  final String _standaloneSseStreamId = '_GET_stream';
+  final String _standaloneSseStreamIdPrefix = '_GET_stream:';
+  final String _legacyStandaloneSseStreamId = '_GET_stream';
   final EventStore? _eventStore;
   final void Function(String sessionId)? _onsessioninitialized;
   final bool _enableDnsRebindingProtection;
@@ -274,6 +280,38 @@ class StreamableHTTPServerTransport
     await _safeClose(response);
   }
 
+  bool _isStandaloneSseStreamId(StreamId streamId) {
+    return streamId == _legacyStandaloneSseStreamId ||
+        streamId.startsWith(_standaloneSseStreamIdPrefix);
+  }
+
+  void _addStandaloneSseResponse(StreamId streamId, HttpResponse response) {
+    _standaloneSseStreamIds.add(streamId);
+    _standaloneSseResponses.putIfAbsent(streamId, () => {}).add(response);
+    _streamMapping.putIfAbsent(streamId, () => response);
+  }
+
+  void _removeStandaloneSseResponse(
+    StreamId streamId,
+    HttpResponse response,
+  ) {
+    final responses = _standaloneSseResponses[streamId];
+    responses?.remove(response);
+
+    if (responses == null || responses.isEmpty) {
+      _standaloneSseResponses.remove(streamId);
+      _standaloneSseStreamIds.remove(streamId);
+      if (identical(_streamMapping[streamId], response)) {
+        _streamMapping.remove(streamId);
+      }
+      return;
+    }
+
+    if (identical(_streamMapping[streamId], response)) {
+      _streamMapping[streamId] = responses.first;
+    }
+  }
+
   Set<String> _parseAcceptedMediaTypes(HttpRequest req) {
     final acceptHeaderValues = req.headers[HttpHeaders.acceptHeader];
     if (acceptHeaderValues == null || acceptHeaderValues.isEmpty) {
@@ -346,26 +384,6 @@ class StreamableHTTPServerTransport
       headers["mcp-session-id"] = sessionId!;
     }
 
-    // Check if there's already an active standalone SSE stream for this session
-    if (_streamMapping[_standaloneSseStreamId] != null) {
-      // Only one GET SSE stream is allowed per session
-      req.response
-        ..statusCode = HttpStatus.conflict
-        ..write(
-          jsonEncode(
-            JsonRpcError(
-              id: null,
-              error: JsonRpcErrorData(
-                code: ErrorCode.connectionClosed.value,
-                message: 'Conflict: Only one SSE stream is allowed per session',
-              ),
-            ).toJson(),
-          ),
-        );
-      await _safeClose(req.response);
-      return;
-    }
-
     // We need to send headers immediately as messages will arrive much later,
     // otherwise the client will just wait for the first message
     req.response.statusCode = HttpStatus.ok;
@@ -373,15 +391,17 @@ class StreamableHTTPServerTransport
       req.response.headers.set(key, value);
     });
 
+    final streamId = '$_standaloneSseStreamIdPrefix${generateUUID()}';
+
     // Assign the response to the standalone SSE stream before flushing
     // to ensure it's available if a task tries to send a message immediately
-    _streamMapping[_standaloneSseStreamId] = req.response;
+    _addStandaloneSseResponse(streamId, req.response);
 
     await req.response.flush();
 
     // Set up close handler for client disconnects
     req.response.done.then((_) {
-      _streamMapping.remove(_standaloneSseStreamId);
+      _removeStandaloneSseResponse(streamId, req.response);
     });
   }
 
@@ -419,7 +439,18 @@ class StreamableHTTPServerTransport
         },
       );
 
-      _streamMapping[streamId] = res;
+      if (_isStandaloneSseStreamId(streamId)) {
+        _addStandaloneSseResponse(streamId, res);
+      } else {
+        _streamMapping[streamId] = res;
+      }
+      res.done.then((_) {
+        if (_isStandaloneSseStreamId(streamId)) {
+          _removeStandaloneSseResponse(streamId, res);
+        } else if (identical(_streamMapping[streamId], res)) {
+          _streamMapping.remove(streamId);
+        }
+      });
     } catch (error) {
       onerror?.call(error is Error ? error : StateError(error.toString()));
     }
@@ -860,12 +891,19 @@ class StreamableHTTPServerTransport
       _terminated = true;
     }
 
-    // Close all SSE connections - fix concurrent modification by creating a copy of the values first
-    final responses = List<HttpResponse>.from(_streamMapping.values);
+    // Close all SSE connections, including multiple standalone responses that
+    // may share one replay stream identity.
+    final responses = <HttpResponse>{
+      ..._streamMapping.values,
+      for (final streamResponses in _standaloneSseResponses.values)
+        ...streamResponses,
+    };
     for (final response in responses) {
       await _safeClose(response);
     }
     _streamMapping.clear();
+    _standaloneSseStreamIds.clear();
+    _standaloneSseResponses.clear();
 
     // Clear any pending responses
     _requestResponseMap.clear();
@@ -900,24 +938,32 @@ class StreamableHTTPServerTransport
         );
       }
 
-      final standaloneSse = _streamMapping[_standaloneSseStreamId];
-      if (standaloneSse == null) {
+      if (_standaloneSseStreamIds.isEmpty) {
         // The spec says the server MAY send messages on the stream, so it's ok to discard if no stream
         return;
       }
 
-      // Generate and store event ID if event store is provided
-      String? eventId;
-      if (_eventStore != null) {
-        // Stores the event and gets the generated event ID
-        eventId = await _eventStore!.storeEvent(
-          _standaloneSseStreamId,
-          message,
-        );
-      }
+      for (final streamId in List<StreamId>.from(_standaloneSseStreamIds)) {
+        final responses = _standaloneSseResponses[streamId];
+        if (responses == null || responses.isEmpty) {
+          _standaloneSseStreamIds.remove(streamId);
+          _streamMapping.remove(streamId);
+          continue;
+        }
 
-      // Send the message to the standalone SSE stream
-      await _writeSSEEvent(standaloneSse, message, eventId);
+        // Generate and store a stream-specific event ID if event store is provided.
+        String? eventId;
+        if (_eventStore != null) {
+          eventId = await _eventStore!.storeEvent(streamId, message);
+        }
+
+        for (final standaloneSse in List<HttpResponse>.from(responses)) {
+          final sent = await _writeSSEEvent(standaloneSse, message, eventId);
+          if (!sent) {
+            _removeStandaloneSseResponse(streamId, standaloneSse);
+          }
+        }
+      }
       return;
     }
 

--- a/test/client/streamable_https_advanced_test.dart
+++ b/test/client/streamable_https_advanced_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:mcp_dart/src/client/streamable_https.dart';
@@ -261,6 +262,158 @@ void main() {
 
       // Should have received parsing error
       expect(receivedErrors.isNotEmpty, isTrue);
+    });
+
+    test('ignores empty priming SSE event in POST response stream', () async {
+      final receivedErrors = <Error>[];
+      final messageCompleter = Completer<JsonRpcMessage>();
+
+      final subscription = requestController!.stream.listen((request) async {
+        if (request.uri.path == '/mcp' && request.method == 'POST') {
+          final requestBody = await utf8.decoder.bind(request).join();
+          final requestJson = jsonDecode(requestBody) as Map<String, dynamic>;
+
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType =
+              ContentType('text', 'event-stream');
+          request.response.bufferOutput = false;
+
+          request.response.write('data:\n\n');
+          await request.response.flush();
+
+          request.response.write(
+            'event: message\n'
+            'data: ${jsonEncode({
+                  'jsonrpc': '2.0',
+                  'id': requestJson['id'],
+                  'result': {'ok': true},
+                })}\n\n',
+          );
+          await request.response.flush();
+          await request.response.close();
+        }
+      });
+
+      transport = StreamableHttpClientTransport(serverUrl);
+      transport.onerror = receivedErrors.add;
+      transport.onmessage = (message) {
+        if (!messageCompleter.isCompleted) {
+          messageCompleter.complete(message);
+        }
+      };
+
+      await transport.start();
+      await transport.send(
+        const JsonRpcRequest(
+          id: 1,
+          method: 'test/method',
+          params: {},
+        ),
+      );
+
+      final message = await messageCompleter.future.timeout(
+        const Duration(seconds: 3),
+      );
+      await subscription.cancel();
+
+      expect(message, isA<JsonRpcResponse>());
+      expect((message as JsonRpcResponse).result, containsPair('ok', true));
+      expect(receivedErrors, isEmpty);
+    });
+
+    test('resumed SSE response rewrites id and joins multi-line data',
+        () async {
+      final receivedErrors = <Error>[];
+      final receivedTokens = <String>[];
+      final messageCompleter = Completer<JsonRpcMessage>();
+      final sawResumeRequest = Completer<void>();
+
+      final subscription = requestController!.stream.listen((request) async {
+        if (request.uri.path == '/mcp' && request.method == 'GET') {
+          expect(request.headers.value('last-event-id'), 'resume-token-1');
+          if (!sawResumeRequest.isCompleted) {
+            sawResumeRequest.complete();
+          }
+
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType =
+              ContentType('text', 'event-stream');
+          request.response.bufferOutput = false;
+          request.response.write(
+            'event: message\n'
+            'id: server-event-2\n'
+            'data: {"jsonrpc":"2.0","id":1,\n'
+            'data: "result":{"ok":true}}\n\n',
+          );
+          await request.response.flush();
+        }
+      });
+
+      transport = StreamableHttpClientTransport(serverUrl);
+      transport.onerror = receivedErrors.add;
+      transport.onmessage = (message) {
+        if (!messageCompleter.isCompleted) {
+          messageCompleter.complete(message);
+        }
+      };
+
+      await transport.start();
+      await transport.send(
+        const JsonRpcRequest(id: 99, method: 'test/resume', params: {}),
+        resumptionToken: 'resume-token-1',
+        onResumptionToken: receivedTokens.add,
+      );
+
+      await sawResumeRequest.future.timeout(const Duration(seconds: 3));
+      final message = await messageCompleter.future.timeout(
+        const Duration(seconds: 3),
+      );
+      await subscription.cancel();
+
+      expect(message, isA<JsonRpcResponse>());
+      final response = message as JsonRpcResponse;
+      expect(response.id, 99);
+      expect(response.result, containsPair('ok', true));
+      expect(receivedTokens, contains('server-event-2'));
+      expect(receivedErrors, isEmpty);
+    });
+
+    test('invalid resumed SSE message reports parser errors', () async {
+      final receivedErrors = <Error>[];
+      final sawResumeRequest = Completer<void>();
+
+      final subscription = requestController!.stream.listen((request) async {
+        if (request.uri.path == '/mcp' && request.method == 'GET') {
+          if (!sawResumeRequest.isCompleted) {
+            sawResumeRequest.complete();
+          }
+
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType =
+              ContentType('text', 'event-stream');
+          request.response.bufferOutput = false;
+          request.response.write(
+            'event: message\n'
+            'data: {"jsonrpc":"2.0","method":123}\n\n',
+          );
+          await request.response.flush();
+        }
+      });
+
+      transport = StreamableHttpClientTransport(serverUrl);
+      transport.onerror = receivedErrors.add;
+
+      await transport.start();
+      await transport.send(
+        const JsonRpcRequest(id: 100, method: 'test/resume', params: {}),
+        resumptionToken: 'resume-token-invalid',
+      );
+
+      await sawResumeRequest.future.timeout(const Duration(seconds: 3));
+      await pumpEventQueue(times: 5);
+      await subscription.cancel();
+
+      expect(receivedErrors, isNotEmpty);
     });
 
     test('custom reconnection options are respected', () {

--- a/test/interop/ts/src/replay_client.ts
+++ b/test/interop/ts/src/replay_client.ts
@@ -1,0 +1,100 @@
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+
+function getArg(name: string, required = true): string | undefined {
+  const index = process.argv.indexOf(name);
+  if (index >= 0 && index + 1 < process.argv.length) {
+    return process.argv[index + 1];
+  }
+  if (required) {
+    throw new Error(`Missing required argument: ${name}`);
+  }
+  return undefined;
+}
+
+function getNotificationParams(message: JSONRPCMessage): Record<string, unknown> | undefined {
+  if (!('method' in message) || message.method !== 'notifications/message') {
+    return undefined;
+  }
+
+  const params = message.params;
+  if (typeof params !== 'object' || params === null || Array.isArray(params)) {
+    return undefined;
+  }
+
+  return params as Record<string, unknown>;
+}
+
+async function main(): Promise<void> {
+  const url = getArg('--url')!;
+  const sessionId = getArg('--session-id')!;
+  const lastEventId = getArg('--last-event-id')!;
+  const expectedSeq = Number(getArg('--expect-seq')!);
+  const expectedToken = getArg('--expect-token', false);
+  const rejectedToken = getArg('--reject-token', false);
+  const timeoutMs = Number(getArg('--timeout-ms', false) ?? '5000');
+
+  const transport = new StreamableHTTPClientTransport(new URL(url), {
+    sessionId,
+    reconnectionOptions: {
+      initialReconnectionDelay: 100,
+      maxReconnectionDelay: 100,
+      reconnectionDelayGrowFactor: 1,
+      maxRetries: 0,
+    },
+  });
+
+  const tokens: string[] = [];
+
+  const receivedExpected = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(
+        new Error(
+          `Timed out waiting for notifications/message with seq=${expectedSeq}; tokens=${tokens.join(',')}`
+        )
+      );
+    }, timeoutMs);
+
+    transport.onerror = (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    };
+
+    transport.onmessage = (message) => {
+      const params = getNotificationParams(message);
+      if (params?.seq !== expectedSeq) {
+        return;
+      }
+      clearTimeout(timeout);
+      resolve();
+    };
+  });
+
+  await transport.start();
+  try {
+    await transport.resumeStream(lastEventId, {
+      onresumptiontoken: (token) => {
+        tokens.push(token);
+      },
+    });
+
+    await receivedExpected;
+
+    if (expectedToken !== undefined && !tokens.includes(expectedToken)) {
+      throw new Error(
+        `Expected replay token ${expectedToken}, got ${tokens.join(',')}`
+      );
+    }
+
+    if (rejectedToken !== undefined && tokens.includes(rejectedToken)) {
+      throw new Error(`Unexpected replay token ${rejectedToken}`);
+    }
+  } finally {
+    await transport.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/test/interop/ts_client_with_dart_server_test.dart
+++ b/test/interop/ts_client_with_dart_server_test.dart
@@ -1,26 +1,113 @@
 @Tags(['interop'])
 library;
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:mcp_dart/src/server/streamable_https.dart';
-import 'package:mcp_dart/src/shared/uuid.dart';
+import 'package:http/http.dart' as http;
+import 'package:mcp_dart/mcp_dart.dart';
 import 'package:test/test.dart';
 import 'package:path/path.dart' as p;
 
 import 'test_dart_server.dart';
 
+class _SseEvent {
+  final String? id;
+  final String data;
+
+  const _SseEvent({this.id, required this.data});
+
+  Map<String, dynamic> get json => jsonDecode(data) as Map<String, dynamic>;
+}
+
+class _SseConnection {
+  final HttpClient client;
+  final HttpClientResponse response;
+
+  const _SseConnection(this.client, this.response);
+
+  void close() => client.close(force: true);
+}
+
+Future<int> _findAvailablePort() async {
+  final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final port = socket.port;
+  await socket.close();
+  return port;
+}
+
+Future<_SseEvent> _readSseEvent(StreamIterator<String> lines) async {
+  String? id;
+  final dataLines = <String>[];
+
+  while (await lines.moveNext().timeout(const Duration(seconds: 3))) {
+    final line = lines.current;
+    if (line.isEmpty) {
+      if (id != null || dataLines.isNotEmpty) {
+        return _SseEvent(id: id, data: dataLines.join('\n'));
+      }
+      continue;
+    }
+
+    if (line.startsWith(':')) {
+      continue;
+    }
+
+    final colonIndex = line.indexOf(':');
+    if (colonIndex < 0) {
+      continue;
+    }
+
+    final field = line.substring(0, colonIndex);
+    final valueStart = colonIndex +
+        1 +
+        (line.length > colonIndex + 1 && line[colonIndex + 1] == ' ' ? 1 : 0);
+    final value = line.substring(valueStart);
+
+    switch (field) {
+      case 'id':
+        id = value;
+        break;
+      case 'data':
+        dataLines.add(value);
+        break;
+    }
+  }
+
+  throw StateError('SSE stream ended before an event was received');
+}
+
+Future<_SseConnection> _openGetSse(
+  String baseUrl,
+  String sessionId, {
+  String? lastEventId,
+}) async {
+  final client = HttpClient();
+  final req = await client.getUrl(Uri.parse(baseUrl));
+  req.headers
+    ..set(HttpHeaders.acceptHeader, 'text/event-stream')
+    ..set('mcp-session-id', sessionId);
+  if (lastEventId != null) {
+    req.headers.set('Last-Event-ID', lastEventId);
+  }
+  final response = await req.close();
+  return _SseConnection(client, response);
+}
+
 void main() {
   // Use compiled JS client for reliability (avoids npx tsx issues in CI)
   final tsClientPath =
       p.join(Directory.current.path, 'test/interop/ts/dist/client.js');
+  final tsReplayClientPath =
+      p.join(Directory.current.path, 'test/interop/ts/dist/replay_client.js');
   final dartServerPath =
       p.join(Directory.current.path, 'test/interop/test_dart_server.dart');
 
   // Check if we should skip
-  final skipTests =
-      !File(tsClientPath).existsSync() || !File(dartServerPath).existsSync();
+  final skipTests = !File(tsClientPath).existsSync() ||
+      !File(tsReplayClientPath).existsSync() ||
+      !File(dartServerPath).existsSync();
   final isCi = Platform.environment['CI'] == 'true';
 
   group('TS Client with Dart Server', () {
@@ -188,6 +275,164 @@ void main() {
         }
       },
       timeout: const Timeout(Duration(seconds: 120)),
+    );
+
+    test(
+      'official TS client resumes Dart server SSE replay by Last-Event-ID',
+      () async {
+        final port = await _findAvailablePort();
+        final baseUrl = 'http://127.0.0.1:$port/mcp';
+        final servers = <String, McpServer>{};
+
+        final streamableServer = StreamableMcpServer(
+          serverFactory: (sessionId) {
+            final mcpServer = McpServer(
+              const Implementation(name: 'DartReplayInterop', version: '1.0'),
+            );
+            servers[sessionId] = mcpServer;
+            return mcpServer;
+          },
+          host: '127.0.0.1',
+          port: port,
+          eventStore: InMemoryEventStore(),
+        );
+
+        Future<void> sendServerNotification(
+          McpServer mcpServer,
+          Map<String, Object> params,
+        ) async {
+          await mcpServer.server.notification(
+            JsonRpcNotification(
+              method: 'notifications/message',
+              params: params,
+            ),
+          );
+        }
+
+        await streamableServer.start();
+        try {
+          final initRes = await http.post(
+            Uri.parse(baseUrl),
+            body: jsonEncode({
+              'jsonrpc': '2.0',
+              'id': 1,
+              'method': 'initialize',
+              'params': {
+                'protocolVersion': '2025-11-25',
+                'capabilities': <String, Object>{},
+                'clientInfo': {'name': 'dart-interop-test', 'version': '1.0'},
+              },
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              'Accept': 'application/json, text/event-stream',
+            },
+          );
+          expect(initRes.statusCode, HttpStatus.ok);
+          final sessionId = initRes.headers['mcp-session-id'];
+          expect(sessionId, isNotNull);
+
+          final initializedRes = await http.post(
+            Uri.parse(baseUrl),
+            body: jsonEncode(
+              const JsonRpcNotification(
+                method: 'notifications/initialized',
+              ).toJson(),
+            ),
+            headers: {
+              'Content-Type': 'application/json',
+              'Accept': 'application/json, text/event-stream',
+              'mcp-session-id': sessionId!,
+            },
+          );
+          expect(initializedRes.statusCode, HttpStatus.accepted);
+
+          final mcpServer = servers[sessionId];
+          expect(mcpServer, isNotNull);
+
+          final streamAFuture = _openGetSse(baseUrl, sessionId);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          await sendServerNotification(mcpServer!, {'warmup': 'A'});
+          final streamA =
+              await streamAFuture.timeout(const Duration(seconds: 3));
+
+          final streamBFuture = _openGetSse(baseUrl, sessionId);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          await sendServerNotification(mcpServer, {'warmup': 'B'});
+          final streamB =
+              await streamBFuture.timeout(const Duration(seconds: 3));
+
+          final linesA = StreamIterator(
+            streamA.response
+                .transform(utf8.decoder)
+                .transform(const LineSplitter()),
+          );
+          final linesB = StreamIterator(
+            streamB.response
+                .transform(utf8.decoder)
+                .transform(const LineSplitter()),
+          );
+
+          await _readSseEvent(linesA); // stream A warmup
+          await _readSseEvent(linesA); // stream B warmup broadcast to A
+          await _readSseEvent(linesB); // stream B warmup
+
+          await sendServerNotification(mcpServer, {'seq': 1});
+          await sendServerNotification(mcpServer, {'seq': 2});
+
+          final aFirst = await _readSseEvent(linesA);
+          final aSecond = await _readSseEvent(linesA);
+          final bFirst = await _readSseEvent(linesB);
+          final bSecond = await _readSseEvent(linesB);
+
+          expect(aFirst.json['params'], containsPair('seq', 1));
+          expect(aSecond.json['params'], containsPair('seq', 2));
+          expect(bFirst.json['params'], containsPair('seq', 1));
+          expect(bSecond.json['params'], containsPair('seq', 2));
+          expect(aFirst.id, isNotNull);
+          expect(aSecond.id, isNotNull);
+          expect(bSecond.id, isNotNull);
+          expect(aSecond.id, isNot(bSecond.id));
+
+          final result = await Process.run(
+            'node',
+            [
+              tsReplayClientPath,
+              '--url',
+              baseUrl,
+              '--session-id',
+              sessionId,
+              '--last-event-id',
+              aFirst.id!,
+              '--expect-seq',
+              '2',
+              '--expect-token',
+              aSecond.id!,
+              '--reject-token',
+              bSecond.id!,
+            ],
+            runInShell: true,
+          );
+
+          if (result.exitCode != 0) {
+            print('TS replay client stdout: ${result.stdout}');
+            print('TS replay client stderr: ${result.stderr}');
+          }
+          expect(
+            result.exitCode,
+            equals(0),
+            reason: 'Official TS StreamableHTTPClientTransport replay failed',
+          );
+
+          await linesA.cancel();
+          await linesB.cancel();
+          streamA.close();
+          streamB.close();
+        } finally {
+          await streamableServer.stop();
+        }
+      },
+      timeout: const Timeout(Duration(seconds: 30)),
     );
   });
 }

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:mcp_dart/src/server/in_memory_event_store.dart';
 import 'package:mcp_dart/src/server/streamable_https.dart';
 import 'package:mcp_dart/src/shared/uuid.dart';
 import 'package:mcp_dart/src/types.dart';
@@ -99,6 +100,69 @@ List<Map<String, dynamic>> _decodeSseJsonMessages(String body) {
     }
   }
   return messages;
+}
+
+class _SseEvent {
+  final String? id;
+  final String? event;
+  final String data;
+
+  const _SseEvent({
+    this.id,
+    this.event,
+    required this.data,
+  });
+
+  Map<String, dynamic> get json => jsonDecode(data) as Map<String, dynamic>;
+}
+
+Future<_SseEvent> _readSseEvent(StreamIterator<String> lines) async {
+  String? id;
+  String? event;
+  final dataLines = <String>[];
+
+  while (await lines.moveNext()) {
+    final line = lines.current;
+    if (line.isEmpty) {
+      if (id != null || event != null || dataLines.isNotEmpty) {
+        return _SseEvent(
+          id: id,
+          event: event,
+          data: dataLines.join('\n'),
+        );
+      }
+      continue;
+    }
+
+    if (line.startsWith(':')) {
+      continue;
+    }
+
+    final colonIndex = line.indexOf(':');
+    if (colonIndex < 0) {
+      continue;
+    }
+
+    final field = line.substring(0, colonIndex);
+    final valueStart = colonIndex +
+        1 +
+        (line.length > colonIndex + 1 && line[colonIndex + 1] == ' ' ? 1 : 0);
+    final value = line.substring(valueStart);
+
+    switch (field) {
+      case 'id':
+        id = value;
+        break;
+      case 'event':
+        event = value;
+        break;
+      case 'data':
+        dataLines.add(value);
+        break;
+    }
+  }
+
+  throw StateError('SSE stream ended before an event was received');
 }
 
 void main() {
@@ -757,6 +821,320 @@ void main() {
       expect(invalidResult, equals("Invalid session rejected correctly"));
 
       await transport.close();
+    });
+
+    test('allows multiple concurrent GET SSE streams for one session',
+        () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => 'multi-stream-session-id',
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      transport.onmessage = (message) {
+        if (message is JsonRpcRequest && message.method == 'initialize') {
+          unawaited(
+            transport.send(
+              JsonRpcResponse(
+                id: message.id,
+                result: const {
+                  'protocolVersion': latestProtocolVersion,
+                  'capabilities': {},
+                  'serverInfo': {
+                    'name': 'MultiStreamServer',
+                    'version': '1.0.0',
+                  },
+                },
+              ),
+            ),
+          );
+        }
+      };
+
+      Future<String> initializeSession() async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers
+          ..contentType = ContentType.json
+          ..set(
+            HttpHeaders.acceptHeader,
+            'application/json, text/event-stream',
+          );
+        request.write(
+          jsonEncode(
+            JsonRpcRequest(
+              id: 1,
+              method: 'initialize',
+              params: const InitializeRequestParams(
+                protocolVersion: latestProtocolVersion,
+                capabilities: ClientCapabilities(),
+                clientInfo: Implementation(name: 'Client', version: '1.0'),
+              ).toJson(),
+            ).toJson(),
+          ),
+        );
+
+        final response = await request.close();
+        expect(response.statusCode, HttpStatus.ok);
+        final sessionId = response.headers.value('mcp-session-id');
+        await response.drain<void>();
+        expect(sessionId, 'multi-stream-session-id');
+        return sessionId!;
+      }
+
+      Future<HttpClientResponse> openGetSse(String sessionId) async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.getUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers
+          ..set(HttpHeaders.acceptHeader, 'text/event-stream')
+          ..set('mcp-session-id', sessionId);
+        return request.close();
+      }
+
+      final sessionId = await initializeSession();
+      final firstFuture = openGetSse(sessionId);
+      await Future.delayed(const Duration(milliseconds: 50));
+      await transport.send(
+        const JsonRpcNotification(
+          method: 'notifications/message',
+          params: {'stream': 'first'},
+        ),
+      );
+      final first = await firstFuture.timeout(const Duration(seconds: 3));
+      expect(first.statusCode, HttpStatus.ok);
+      expect(first.headers.contentType?.mimeType, 'text/event-stream');
+      final firstLines = StreamIterator(
+        first.transform(utf8.decoder).transform(const LineSplitter()),
+      );
+
+      final secondFuture = openGetSse(sessionId);
+      await Future.delayed(const Duration(milliseconds: 50));
+      await transport.send(
+        const JsonRpcNotification(
+          method: 'notifications/message',
+          params: {'stream': 'second'},
+        ),
+      );
+      final second = await secondFuture.timeout(const Duration(seconds: 3));
+      expect(second.statusCode, HttpStatus.ok);
+      expect(second.headers.contentType?.mimeType, 'text/event-stream');
+      final secondLines = StreamIterator(
+        second.transform(utf8.decoder).transform(const LineSplitter()),
+      );
+
+      final firstOnly = await _readSseEvent(firstLines);
+      final broadcastToFirst = await _readSseEvent(firstLines);
+      final broadcastToSecond = await _readSseEvent(secondLines);
+
+      expect(firstOnly.json['params'], containsPair('stream', 'first'));
+      expect(broadcastToFirst.json['params'], containsPair('stream', 'second'));
+      expect(
+        broadcastToSecond.json['params'],
+        containsPair('stream', 'second'),
+      );
+      expect(firstOnly.id, isNull);
+      expect(broadcastToFirst.id, isNull);
+      expect(broadcastToSecond.id, isNull);
+
+      await firstLines.cancel();
+      await secondLines.cancel();
+    });
+
+    test('GET Last-Event-ID replay is scoped to the original SSE stream',
+        () async {
+      final eventStore = InMemoryEventStore();
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => 'replay-session-id',
+          eventStore: eventStore,
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      transport.onmessage = (message) {
+        if (message is JsonRpcRequest && message.method == 'initialize') {
+          unawaited(
+            transport.send(
+              JsonRpcResponse(
+                id: message.id,
+                result: const {
+                  'protocolVersion': latestProtocolVersion,
+                  'capabilities': {},
+                  'serverInfo': {
+                    'name': 'ReplayServer',
+                    'version': '1.0.0',
+                  },
+                },
+              ),
+            ),
+          );
+        }
+      };
+
+      Future<String> initializeSession() async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers
+          ..contentType = ContentType.json
+          ..set(
+            HttpHeaders.acceptHeader,
+            'application/json, text/event-stream',
+          );
+        request.write(
+          jsonEncode(
+            JsonRpcRequest(
+              id: 1,
+              method: 'initialize',
+              params: const InitializeRequestParams(
+                protocolVersion: latestProtocolVersion,
+                capabilities: ClientCapabilities(),
+                clientInfo: Implementation(name: 'Client', version: '1.0'),
+              ).toJson(),
+            ).toJson(),
+          ),
+        );
+
+        final response = await request.close();
+        expect(response.statusCode, HttpStatus.ok);
+        final sessionId = response.headers.value('mcp-session-id');
+        await response.drain<void>();
+        expect(sessionId, 'replay-session-id');
+        return sessionId!;
+      }
+
+      Future<HttpClientResponse> openGetSse(
+        String sessionId, {
+        String? lastEventId,
+      }) async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.getUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers
+          ..set(HttpHeaders.acceptHeader, 'text/event-stream')
+          ..set('mcp-session-id', sessionId);
+        if (lastEventId != null) {
+          request.headers.set('Last-Event-ID', lastEventId);
+        }
+        return request.close();
+      }
+
+      final sessionId = await initializeSession();
+      final streamAFuture = openGetSse(sessionId);
+      await Future.delayed(const Duration(milliseconds: 50));
+      await transport.send(
+        const JsonRpcNotification(
+          method: 'notifications/message',
+          params: {'warmup': 'A'},
+        ),
+      );
+      final streamA = await streamAFuture.timeout(const Duration(seconds: 3));
+      expect(streamA.statusCode, HttpStatus.ok);
+
+      final streamBFuture = openGetSse(sessionId);
+      await Future.delayed(const Duration(milliseconds: 50));
+      await transport.send(
+        const JsonRpcNotification(
+          method: 'notifications/message',
+          params: {'warmup': 'B'},
+        ),
+      );
+      final streamB = await streamBFuture.timeout(const Duration(seconds: 3));
+      expect(streamB.statusCode, HttpStatus.ok);
+
+      final linesA = StreamIterator(
+        streamA.transform(utf8.decoder).transform(const LineSplitter()),
+      );
+      final linesB = StreamIterator(
+        streamB.transform(utf8.decoder).transform(const LineSplitter()),
+      );
+
+      await _readSseEvent(linesA);
+      await _readSseEvent(linesA);
+      await _readSseEvent(linesB);
+
+      await transport.send(
+        const JsonRpcNotification(
+          method: 'notifications/message',
+          params: {'seq': 1},
+        ),
+      );
+      await transport.send(
+        const JsonRpcNotification(
+          method: 'notifications/message',
+          params: {'seq': 2},
+        ),
+      );
+
+      final aFirst = await _readSseEvent(linesA);
+      final aSecond = await _readSseEvent(linesA);
+      final bFirst = await _readSseEvent(linesB);
+      final bSecond = await _readSseEvent(linesB);
+
+      expect(aFirst.id, isNotNull);
+      expect(aSecond.id, isNotNull);
+      expect(bFirst.id, isNotNull);
+      expect(bSecond.id, isNotNull);
+      expect(aFirst.id, isNot(bFirst.id));
+      expect(aSecond.id, isNot(bSecond.id));
+      expect(aFirst.json['params'], containsPair('seq', 1));
+      expect(aSecond.json['params'], containsPair('seq', 2));
+      expect(bFirst.json['params'], containsPair('seq', 1));
+      expect(bSecond.json['params'], containsPair('seq', 2));
+
+      final replay = await openGetSse(sessionId, lastEventId: aFirst.id);
+      expect(replay.statusCode, HttpStatus.ok);
+      final replayLines = StreamIterator(
+        replay.transform(utf8.decoder).transform(const LineSplitter()),
+      );
+      final replayed = await _readSseEvent(replayLines);
+
+      expect(replayed.id, aSecond.id);
+      expect(replayed.json['params'], containsPair('seq', 2));
+      expect(replayed.id, isNot(bSecond.id));
+
+      await Future.delayed(const Duration(milliseconds: 50));
+      await transport.send(
+        const JsonRpcNotification(
+          method: 'notifications/message',
+          params: {'seq': 3},
+        ),
+      );
+
+      final aThird = await _readSseEvent(linesA);
+      final bThird = await _readSseEvent(linesB);
+      final replayThird = await _readSseEvent(replayLines);
+
+      expect(aThird.json['params'], containsPair('seq', 3));
+      expect(bThird.json['params'], containsPair('seq', 3));
+      expect(replayThird.json['params'], containsPair('seq', 3));
+      expect(aThird.id, replayThird.id);
+      expect(aThird.id, isNot(bThird.id));
+
+      await transport.close();
+      expect(
+        await linesA.moveNext().timeout(const Duration(seconds: 3)),
+        isFalse,
+      );
+      expect(
+        await linesB.moveNext().timeout(const Duration(seconds: 3)),
+        isFalse,
+      );
+      expect(
+        await replayLines.moveNext().timeout(const Duration(seconds: 3)),
+        isFalse,
+      );
+
+      await linesA.cancel();
+      await linesB.cancel();
+      await replayLines.cancel();
     });
 
     test('event resumability works with EventStore', () async {

--- a/test/server/streamable_mcp_server_test.dart
+++ b/test/server/streamable_mcp_server_test.dart
@@ -1,9 +1,60 @@
 import 'dart:convert';
+import 'dart:async';
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:mcp_dart/mcp_dart.dart';
 import 'package:test/test.dart';
+
+class _SseEvent {
+  final String? id;
+  final String data;
+
+  const _SseEvent({this.id, required this.data});
+
+  Map<String, dynamic> get json => jsonDecode(data) as Map<String, dynamic>;
+}
+
+Future<_SseEvent> _readSseEvent(StreamIterator<String> lines) async {
+  String? id;
+  final dataLines = <String>[];
+
+  while (await lines.moveNext().timeout(const Duration(seconds: 3))) {
+    final line = lines.current;
+    if (line.isEmpty) {
+      if (id != null || dataLines.isNotEmpty) {
+        return _SseEvent(id: id, data: dataLines.join('\n'));
+      }
+      continue;
+    }
+
+    if (line.startsWith(':')) {
+      continue;
+    }
+
+    final colonIndex = line.indexOf(':');
+    if (colonIndex < 0) {
+      continue;
+    }
+
+    final field = line.substring(0, colonIndex);
+    final valueStart = colonIndex +
+        1 +
+        (line.length > colonIndex + 1 && line[colonIndex + 1] == ' ' ? 1 : 0);
+    final value = line.substring(valueStart);
+
+    switch (field) {
+      case 'id':
+        id = value;
+        break;
+      case 'data':
+        dataLines.add(value);
+        break;
+    }
+  }
+
+  throw StateError('SSE stream ended before an event was received');
+}
 
 void main() {
   group('StreamableMcpServer', () {
@@ -459,6 +510,162 @@ void main() {
       final deleteAfterDelete = await deleteSession(sessionId);
       expect(deleteAfterDelete.statusCode, HttpStatus.notFound);
       expect(deleteAfterDelete.body, contains('Session not found'));
+    });
+
+    test('E2E GET Last-Event-ID replay is stream-scoped over HTTP', () async {
+      await server.stop();
+
+      final servers = <String, McpServer>{};
+      server = StreamableMcpServer(
+        serverFactory: (sessionId) {
+          final mcpServer = McpServer(
+            const Implementation(name: 'ReplayE2EServer', version: '1.0'),
+          );
+          servers[sessionId] = mcpServer;
+          return mcpServer;
+        },
+        host: host,
+        port: port,
+        eventStore: InMemoryEventStore(),
+      );
+      await server.start();
+
+      Future<HttpClientResponse> openGetSse(
+        String sessionId, {
+        String? lastEventId,
+      }) async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final req = await client.getUrl(Uri.parse(baseUrl));
+        req.headers
+          ..set(HttpHeaders.acceptHeader, 'text/event-stream')
+          ..set('mcp-session-id', sessionId);
+        if (lastEventId != null) {
+          req.headers.set('Last-Event-ID', lastEventId);
+        }
+        return req.close();
+      }
+
+      Future<void> sendServerNotification(
+        McpServer mcpServer,
+        Map<String, Object> params,
+      ) async {
+        await mcpServer.server.notification(
+          JsonRpcNotification(
+            method: 'notifications/message',
+            params: params,
+          ),
+        );
+      }
+
+      final initRes = await postInitialize();
+      expect(initRes.statusCode, HttpStatus.ok);
+      final sessionId = initRes.headers['mcp-session-id'];
+      expect(sessionId, isNotNull);
+
+      final initializedRes = await http.post(
+        Uri.parse(baseUrl),
+        body: jsonEncode(
+          const JsonRpcNotification(
+            method: 'notifications/initialized',
+          ).toJson(),
+        ),
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json, text/event-stream',
+          'mcp-session-id': sessionId!,
+        },
+      );
+      expect(initializedRes.statusCode, HttpStatus.accepted);
+
+      final mcpServer = servers[sessionId];
+      expect(mcpServer, isNotNull);
+
+      final streamAFuture = openGetSse(sessionId);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await sendServerNotification(mcpServer!, {'warmup': 'A'});
+      final streamA = await streamAFuture.timeout(const Duration(seconds: 3));
+      expect(streamA.statusCode, HttpStatus.ok);
+      expect(streamA.headers.contentType?.mimeType, 'text/event-stream');
+
+      final streamBFuture = openGetSse(sessionId);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await sendServerNotification(mcpServer, {'warmup': 'B'});
+      final streamB = await streamBFuture.timeout(const Duration(seconds: 3));
+      expect(streamB.statusCode, HttpStatus.ok);
+      expect(streamB.headers.contentType?.mimeType, 'text/event-stream');
+
+      final linesA = StreamIterator(
+        streamA.transform(utf8.decoder).transform(const LineSplitter()),
+      );
+      final linesB = StreamIterator(
+        streamB.transform(utf8.decoder).transform(const LineSplitter()),
+      );
+
+      addTearDown(linesA.cancel);
+      addTearDown(linesB.cancel);
+
+      await _readSseEvent(linesA); // stream A warmup
+      await _readSseEvent(linesA); // stream B warmup broadcast to A
+      await _readSseEvent(linesB); // stream B warmup
+
+      await sendServerNotification(mcpServer, {'seq': 1});
+      await sendServerNotification(mcpServer, {'seq': 2});
+
+      final aFirst = await _readSseEvent(linesA);
+      final aSecond = await _readSseEvent(linesA);
+      final bFirst = await _readSseEvent(linesB);
+      final bSecond = await _readSseEvent(linesB);
+
+      expect(aFirst.id, isNotNull);
+      expect(aSecond.id, isNotNull);
+      expect(bFirst.id, isNotNull);
+      expect(bSecond.id, isNotNull);
+      expect(aFirst.id, isNot(bFirst.id));
+      expect(aSecond.id, isNot(bSecond.id));
+      expect(aFirst.json['params'], containsPair('seq', 1));
+      expect(aSecond.json['params'], containsPair('seq', 2));
+      expect(bFirst.json['params'], containsPair('seq', 1));
+      expect(bSecond.json['params'], containsPair('seq', 2));
+
+      final replay = await openGetSse(sessionId, lastEventId: aFirst.id);
+      expect(replay.statusCode, HttpStatus.ok);
+      expect(replay.headers.contentType?.mimeType, 'text/event-stream');
+      final replayLines = StreamIterator(
+        replay.transform(utf8.decoder).transform(const LineSplitter()),
+      );
+      addTearDown(replayLines.cancel);
+
+      final replayed = await _readSseEvent(replayLines);
+      expect(replayed.id, aSecond.id);
+      expect(replayed.json['params'], containsPair('seq', 2));
+      expect(replayed.id, isNot(bSecond.id));
+
+      await sendServerNotification(mcpServer, {'seq': 3});
+      final aThird = await _readSseEvent(linesA);
+      final bThird = await _readSseEvent(linesB);
+      final replayThird = await _readSseEvent(replayLines);
+
+      expect(aThird.json['params'], containsPair('seq', 3));
+      expect(bThird.json['params'], containsPair('seq', 3));
+      expect(replayThird.json['params'], containsPair('seq', 3));
+      expect(aThird.id, replayThird.id);
+      expect(aThird.id, isNot(bThird.id));
+
+      final deleteRes = await deleteSession(sessionId);
+      expect(deleteRes.statusCode, HttpStatus.ok);
+      expect(
+        await linesA.moveNext().timeout(const Duration(seconds: 3)),
+        isFalse,
+      );
+      expect(
+        await linesB.moveNext().timeout(const Duration(seconds: 3)),
+        isFalse,
+      );
+      expect(
+        await replayLines.moveNext().timeout(const Duration(seconds: 3)),
+        isFalse,
+      );
     });
 
     test('authentication', () async {


### PR DESCRIPTION
## Summary
- Scope Streamable HTTP SSE replay to the stream identified by `Last-Event-ID` instead of replaying session-wide events.
- Support multiple concurrent GET SSE streams for the same MCP session with stream-specific event IDs and cleanup.
- Preserve stale/unknown/terminated session hardening and one-time initialization retry behavior.
- Add regression, HTTP E2E, and official TypeScript SDK interop coverage for stream-scoped replay.

Fixes #126

## Spec compliance / compatibility
- `Last-Event-ID` now resumes only the stream associated with that event ID.
- Concurrent SSE streams for one session no longer overwrite each other.
- Replay does not leak events from other concurrent streams.
- Event IDs stay backwards-compatible for existing clients while adding stream affinity.
- Unknown/stale session IDs continue to return `404 Session not found`.

## Test plan
- [x] `npm run build` in `test/interop/ts`
- [x] `dart analyze`
- [x] `dart test test/interop/ts_client_with_dart_server_test.dart --name "official TS client resumes"`
- [x] `dart test test/server/streamable_mcp_server_test.dart --name "E2E GET Last-Event-ID"`
- [x] `dart test -t interop`
- [x] `dart test test/server/streamable_mcp_server_test.dart test/server/in_memory_event_store_test.dart test/server/streamable_https_test.dart test/client/streamable_https_advanced_test.dart test/client/streamable_https_test.dart`
- [x] `dart test`
