### PR TITLE
fix: preserve task progress and cancellation lifecycle

### DIFF
--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -221,6 +221,7 @@ class _TimeoutInfo {
 class _TaskAugmentedRequestState {
   final int messageId;
   final RequestId? relatedRequestId;
+  final AbortSignal? signal;
   StreamSubscription? abortSubscription;
   String? taskId;
   bool cancelRequested = false;
@@ -230,6 +231,7 @@ class _TaskAugmentedRequestState {
   _TaskAugmentedRequestState({
     required this.messageId,
     required this.relatedRequestId,
+    required this.signal,
   });
 }
 
@@ -612,8 +614,17 @@ abstract class Protocol {
   Object? _preTaskIdCancellationReason(
     _TaskAugmentedRequestState? state,
   ) {
-    if (state != null && state.cancelRequested && state.taskId == null) {
+    if (state == null || state.taskId != null) {
+      return null;
+    }
+    if (state.cancelRequested) {
       return state.cancelReason ?? AbortError("Request cancelled");
+    }
+    final signal = state.signal;
+    if (signal != null && signal.aborted) {
+      state.cancelRequested = true;
+      state.cancelReason = signal.reason ?? AbortError("Request cancelled");
+      return state.cancelReason;
     }
     return null;
   }
@@ -1250,6 +1261,7 @@ abstract class Protocol {
         ? _TaskAugmentedRequestState(
             messageId: messageId,
             relatedRequestId: relatedRequestId,
+            signal: options?.signal,
           )
         : null;
     if (taskRequestState != null) {

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -218,6 +218,21 @@ class _TimeoutInfo {
   });
 }
 
+class _TaskAugmentedRequestState {
+  final int messageId;
+  final RequestId? relatedRequestId;
+  StreamSubscription? abortSubscription;
+  String? taskId;
+  bool cancelRequested = false;
+  Object? cancelReason;
+  bool cancelSent = false;
+
+  _TaskAugmentedRequestState({
+    required this.messageId,
+    required this.relatedRequestId,
+  });
+}
+
 /// Implements MCP protocol framing on top of a pluggable transport, including
 /// features like request/response linking, notifications, and progress.
 ///
@@ -274,6 +289,15 @@ abstract class Protocol {
 
   /// Resolvers for side-channeled requests (via tasks).
   final Map<int, void Function(JsonRpcMessage response)> _requestResolvers = {};
+
+  /// Task-augmented outgoing requests whose lifecycle continues after the
+  /// initial CreateTaskResult response.
+  final Map<int, _TaskAugmentedRequestState> _taskRequestsByMessageId = {};
+  final Map<String, _TaskAugmentedRequestState> _taskRequestsByTaskId = {};
+
+  /// Terminal task statuses that arrived before their CreateTaskResult was
+  /// parsed and registered locally.
+  final Set<String> _earlyTerminalTaskIds = {};
 
   /// Callback invoked when the underlying transport connection is closed.
   void Function()? onclose;
@@ -542,6 +566,135 @@ abstract class Protocol {
     }
   }
 
+  bool get _hasUnidentifiedTaskRequests => _taskRequestsByMessageId.values.any(
+        (pendingState) => pendingState.taskId == null,
+      );
+
+  void _clearEarlyTerminalTaskIdsIfUnneeded() {
+    if (!_hasUnidentifiedTaskRequests) {
+      _earlyTerminalTaskIds.clear();
+    }
+  }
+
+  void _cleanupTaskAugmentedRequest(
+    _TaskAugmentedRequestState state, {
+    bool cleanupProgress = true,
+  }) {
+    _taskRequestsByMessageId.remove(state.messageId);
+    final taskId = state.taskId;
+    if (taskId != null) {
+      final currentState = _taskRequestsByTaskId[taskId];
+      if (identical(currentState, state)) {
+        _taskRequestsByTaskId.remove(taskId);
+      }
+    }
+    _clearEarlyTerminalTaskIdsIfUnneeded();
+    state.abortSubscription?.cancel();
+    state.abortSubscription = null;
+    if (cleanupProgress) {
+      _cleanupProgressHandler(state.messageId);
+    }
+  }
+
+  void _onTaskStatusNotification(JsonRpcTaskStatusNotification notification) {
+    if (!notification.statusParams.status.isTerminal) {
+      return;
+    }
+
+    final state = _taskRequestsByTaskId[notification.statusParams.taskId];
+    if (state != null) {
+      _cleanupTaskAugmentedRequest(state);
+    } else if (_hasUnidentifiedTaskRequests) {
+      _earlyTerminalTaskIds.add(notification.statusParams.taskId);
+    }
+  }
+
+  Object? _preTaskIdCancellationReason(
+    _TaskAugmentedRequestState? state,
+  ) {
+    if (state != null && state.cancelRequested && state.taskId == null) {
+      return state.cancelReason ?? AbortError("Request cancelled");
+    }
+    return null;
+  }
+
+  void _handleTaskCancellationResponse(
+    _TaskAugmentedRequestState state,
+    JsonRpcMessage responseMessage,
+  ) {
+    switch (responseMessage) {
+      case final JsonRpcResponse response:
+        try {
+          final task = Task.fromJson(response.result);
+          if (task.taskId != state.taskId) {
+            _cleanupTaskAugmentedRequest(state);
+            _onerror(
+              StateError(
+                "Task cancellation response taskId mismatch: "
+                "expected ${state.taskId}, got ${task.taskId}",
+              ),
+            );
+          } else if (task.status.isTerminal) {
+            _cleanupTaskAugmentedRequest(state);
+          }
+        } catch (e) {
+          _cleanupTaskAugmentedRequest(state);
+          _onerror(
+            StateError(
+              "Failed to parse task cancellation result for task "
+              "${state.taskId}: $e",
+            ),
+          );
+        }
+      case final JsonRpcError error:
+        _cleanupTaskAugmentedRequest(state);
+        _onerror(
+          McpError(
+            error.error.code,
+            error.error.message,
+            error.error.data,
+          ),
+        );
+      default:
+        _onerror(
+          ArgumentError(
+            "Invalid task cancellation response type: "
+            "${responseMessage.runtimeType}",
+          ),
+        );
+    }
+  }
+
+  void _sendTaskCancellation(_TaskAugmentedRequestState state) {
+    final taskId = state.taskId;
+    if (taskId == null || state.cancelSent) {
+      return;
+    }
+    state.cancelSent = true;
+
+    final cancelRequest = JsonRpcCancelTaskRequest(
+      id: _requestMessageId++,
+      cancelParams: CancelTaskRequest(taskId: taskId),
+    );
+    _requestResolvers[cancelRequest.id as int] = (responseMessage) {
+      _handleTaskCancellationResponse(state, responseMessage);
+    };
+
+    _transport
+        ?.sendPreservingRequestId(
+      cancelRequest,
+      relatedRequestId: state.relatedRequestId,
+    )
+        .catchError((e) {
+      _requestResolvers.remove(cancelRequest.id);
+      _cleanupTaskAugmentedRequest(state);
+      _onerror(
+        StateError("Failed to send task cancellation for task $taskId: $e"),
+      );
+      return null;
+    });
+  }
+
   Object _nextAvailableProgressToken(int preferredToken) {
     var token = preferredToken;
     while (_progressHandlers.containsKey(token)) {
@@ -590,6 +743,7 @@ abstract class Protocol {
     final errorHandlers = Map.of(_responseErrorHandlers);
     final pendingTimeouts = Map.of(_timeoutInfo);
     final pendingRequestHandlers = Map.of(_requestHandlerAbortControllers);
+    final pendingTaskRequests = Map.of(_taskRequestsByMessageId);
 
     _responseCompleters.clear();
     _responseErrorHandlers.clear();
@@ -600,10 +754,15 @@ abstract class Protocol {
     _requestHandlerAbortControllers.clear();
     _pendingDebouncedNotifications.clear();
     _requestResolvers.clear();
+    _taskRequestsByMessageId.clear();
+    _taskRequestsByTaskId.clear();
+    _earlyTerminalTaskIds.clear();
     _transport = null;
 
     pendingTimeouts.forEach((_, info) => info.timeoutTimer.cancel());
     pendingRequestHandlers.forEach((_, controller) => controller.abort());
+    pendingTaskRequests
+        .forEach((_, state) => state.abortSubscription?.cancel());
 
     final error = McpError(
       ErrorCode.connectionClosed.value,
@@ -647,6 +806,10 @@ abstract class Protocol {
 
   /// Handles incoming JSON-RPC notifications.
   void _onnotification(JsonRpcNotification notification) {
+    if (notification is JsonRpcTaskStatusNotification) {
+      _onTaskStatusNotification(notification);
+    }
+
     final handler = _notificationHandlers[notification.method] ??
         fallbackNotificationHandler;
     if (handler == null) {
@@ -910,14 +1073,33 @@ abstract class Protocol {
     final errorHandler = _responseErrorHandlers.remove(messageId);
     _cleanupTimeout(messageId);
 
-    _cleanupProgressHandler(messageId);
+    final taskRequestState = _taskRequestsByMessageId[messageId];
+    final preserveTaskProgress =
+        taskRequestState != null && errorPayload == null;
+    if (!preserveTaskProgress) {
+      _cleanupProgressHandler(messageId);
+      if (taskRequestState != null) {
+        _cleanupTaskAugmentedRequest(taskRequestState, cleanupProgress: false);
+      }
+    }
 
     if (completer == null || completer.isCompleted) {
       return;
     }
 
     if (errorPayload != null) {
-      _handleResponseError(messageId, errorPayload, completer, errorHandler);
+      final cancellationReason = _preTaskIdCancellationReason(taskRequestState);
+      if (cancellationReason != null) {
+        try {
+          completer.completeError(cancellationReason);
+        } catch (e) {
+          _onerror(
+            StateError("Error completing cancelled request $messageId: $e"),
+          );
+        }
+      } else {
+        _handleResponseError(messageId, errorPayload, completer, errorHandler);
+      }
     } else if (responseMessage is JsonRpcResponse) {
       try {
         completer.complete(responseMessage);
@@ -1064,7 +1246,50 @@ abstract class Protocol {
       meta: finalMeta,
     );
 
+    final taskRequestState = options?.task != null
+        ? _TaskAugmentedRequestState(
+            messageId: messageId,
+            relatedRequestId: relatedRequestId,
+          )
+        : null;
+    if (taskRequestState != null) {
+      _taskRequestsByMessageId[messageId] = taskRequestState;
+    }
+
     void cancel([Object? reason]) {
+      final errorReason = reason ?? AbortError("Request cancelled");
+      final activeTaskState = taskRequestState;
+      if (activeTaskState != null) {
+        final alreadyCancelRequested = activeTaskState.cancelRequested;
+        if (!alreadyCancelRequested) {
+          activeTaskState.cancelRequested = true;
+          activeTaskState.cancelReason = errorReason;
+        }
+        if (activeTaskState.taskId != null) {
+          _sendTaskCancellation(activeTaskState);
+          if (!completer.isCompleted) {
+            completer.completeError(
+              activeTaskState.cancelReason ?? errorReason,
+            );
+          }
+        } else if (errorReason is McpError &&
+            errorReason.code == ErrorCode.requestTimeout.value) {
+          _responseCompleters.remove(messageId);
+          _responseErrorHandlers.remove(messageId);
+          _cleanupProgressHandler(messageId);
+          _cleanupTaskAugmentedRequest(
+            activeTaskState,
+            cleanupProgress: false,
+          );
+          _cleanupTimeout(messageId);
+          if (!completer.isCompleted) {
+            completer
+                .completeError(activeTaskState.cancelReason ?? errorReason);
+          }
+        }
+        return;
+      }
+
       if (completer.isCompleted) return;
 
       _responseCompleters.remove(messageId);
@@ -1096,7 +1321,6 @@ abstract class Protocol {
         return null;
       });
 
-      final errorReason = reason ?? AbortError("Request cancelled");
       completer.completeError(errorReason);
     }
 
@@ -1120,6 +1344,7 @@ abstract class Protocol {
           );
         },
       );
+      taskRequestState?.abortSubscription = abortSubscription;
     }
 
     final timeoutDuration = options?.timeout ?? defaultRequestTimeout;
@@ -1162,8 +1387,13 @@ abstract class Protocol {
       ).catchError((e) {
         _cleanupTimeout(messageId);
         _cleanupProgressHandler(messageId);
+        final state = taskRequestState;
+        if (state != null) {
+          _cleanupTaskAugmentedRequest(state, cleanupProgress: false);
+        }
         if (!completer.isCompleted) {
-          completer.completeError(e);
+          final cancellationReason = _preTaskIdCancellationReason(state);
+          completer.completeError(cancellationReason ?? e);
         }
       });
     } else {
@@ -1176,30 +1406,92 @@ abstract class Protocol {
           .catchError((error) {
         _cleanupTimeout(messageId);
         _cleanupProgressHandler(messageId);
+        final state = taskRequestState;
+        if (state != null) {
+          _cleanupTaskAugmentedRequest(state, cleanupProgress: false);
+        }
         if (!completer.isCompleted) {
-          completer.completeError(error);
+          final cancellationReason = _preTaskIdCancellationReason(state);
+          completer.completeError(cancellationReason ?? error);
         }
         return null;
       });
     }
 
+    var preserveTaskLifecycle = false;
     return completer.future.then((response) {
+      Object? taskCancellationError;
+      late final T result;
       try {
-        return resultFactory(
+        result = resultFactory(
           response.toJson()['result'] as Map<String, dynamic>,
         );
+        final state = taskRequestState;
+        if (state != null) {
+          if (result is CreateTaskResult) {
+            final createdTask = result as CreateTaskResult;
+            final taskId = createdTask.task.taskId;
+            state.taskId = taskId;
+            final taskIsTerminal = createdTask.task.status.isTerminal ||
+                _earlyTerminalTaskIds.remove(taskId);
+
+            if (state.cancelRequested || options?.signal?.aborted == true) {
+              if (!state.cancelRequested && options?.signal?.aborted == true) {
+                state.cancelRequested = true;
+                state.cancelReason =
+                    options?.signal?.reason ?? AbortError("Request cancelled");
+              }
+              if (taskIsTerminal) {
+                _cleanupTaskAugmentedRequest(state);
+              } else {
+                _taskRequestsByTaskId[taskId] = state;
+                _clearEarlyTerminalTaskIdsIfUnneeded();
+                _sendTaskCancellation(state);
+                preserveTaskLifecycle = true;
+              }
+              taskCancellationError =
+                  state.cancelReason ?? AbortError("Request cancelled");
+            } else if (taskIsTerminal) {
+              _cleanupTaskAugmentedRequest(state);
+            } else {
+              _taskRequestsByTaskId[taskId] = state;
+              _clearEarlyTerminalTaskIdsIfUnneeded();
+              preserveTaskLifecycle = true;
+            }
+          } else {
+            _cleanupTaskAugmentedRequest(state);
+          }
+        }
       } catch (e, s) {
+        final state = taskRequestState;
+        final cancellationReason = _preTaskIdCancellationReason(state);
+        if (state != null) {
+          _cleanupTaskAugmentedRequest(state);
+        }
+        if (cancellationReason != null) {
+          throw cancellationReason;
+        }
         throw McpError(
           ErrorCode.internalError.value,
           "Failed to parse result for ${requestData.method}",
           "$e\n$s",
         );
       }
+      if (taskCancellationError != null) {
+        throw taskCancellationError;
+      }
+      return result;
     }).whenComplete(() {
-      abortSubscription?.cancel();
       _responseCompleters.remove(messageId);
       _responseErrorHandlers.remove(messageId);
-      _cleanupProgressHandler(messageId);
+      if (!preserveTaskLifecycle) {
+        abortSubscription?.cancel();
+        _cleanupProgressHandler(messageId);
+        final state = taskRequestState;
+        if (state != null) {
+          _cleanupTaskAugmentedRequest(state, cleanupProgress: false);
+        }
+      }
     }).catchError((error) {
       throw capturedError ?? error;
     });

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -1256,7 +1256,7 @@ abstract class Protocol {
       _taskRequestsByMessageId[messageId] = taskRequestState;
     }
 
-    void cancel([Object? reason]) {
+    void cancel(Object? reason, {bool fromTimeout = false}) {
       final errorReason = reason ?? AbortError("Request cancelled");
       final activeTaskState = taskRequestState;
       if (activeTaskState != null) {
@@ -1272,8 +1272,7 @@ abstract class Protocol {
               activeTaskState.cancelReason ?? errorReason,
             );
           }
-        } else if (errorReason is McpError &&
-            errorReason.code == ErrorCode.requestTimeout.value) {
+        } else if (fromTimeout) {
           _responseCompleters.remove(messageId);
           _responseErrorHandlers.remove(messageId);
           _cleanupProgressHandler(messageId);
@@ -1356,6 +1355,7 @@ abstract class Protocol {
           "Request $messageId timed out after $timeoutDuration",
           {'timeout': timeoutDuration.inMilliseconds},
         ),
+        fromTimeout: true,
       );
     }
 
@@ -1385,6 +1385,9 @@ abstract class Protocol {
         ),
         _transport?.sessionId,
       ).catchError((e) {
+        _requestResolvers.remove(messageId);
+        _responseCompleters.remove(messageId);
+        _responseErrorHandlers.remove(messageId);
         _cleanupTimeout(messageId);
         _cleanupProgressHandler(messageId);
         final state = taskRequestState;
@@ -1404,6 +1407,8 @@ abstract class Protocol {
         relatedRequestId: relatedRequestId,
       )
           .catchError((error) {
+        _responseCompleters.remove(messageId);
+        _responseErrorHandlers.remove(messageId);
         _cleanupTimeout(messageId);
         _cleanupProgressHandler(messageId);
         final state = taskRequestState;

--- a/test/shared/protocol_test.dart
+++ b/test/shared/protocol_test.dart
@@ -1681,8 +1681,11 @@ void main() {
           .timeout(const Duration(seconds: 5));
 
       final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      final errorExpectation = expectLater(
+        requestFuture,
+        throwsA(equals('pre-error user abort')),
+      );
       controller.abort('pre-error user abort');
-      await Future<void>.delayed(const Duration(milliseconds: 20));
       transport.receiveMessage(
         JsonRpcError(
           id: sentRequest.id,
@@ -1693,7 +1696,7 @@ void main() {
         ),
       );
 
-      await expectLater(requestFuture, throwsA(equals('pre-error user abort')));
+      await errorExpectation;
       expect(transport.sentMessages.length, 1);
 
       final reuseFuture = protocol

--- a/test/shared/protocol_test.dart
+++ b/test/shared/protocol_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:mcp_dart/src/shared/protocol.dart';
+import 'package:mcp_dart/src/shared/task_interfaces.dart';
 import 'package:mcp_dart/src/shared/transport.dart';
 import 'package:mcp_dart/src/types.dart';
 import 'package:test/test.dart';
@@ -86,11 +87,21 @@ class MockTransport implements Transport, RequestIdAwareTransport {
     return sendWithRequestId(message, relatedRequestId: relatedRequestId);
   }
 
+  bool failSends = false;
+  Duration? failSendDelay;
+
   @override
   Future<void> sendWithRequestId(
     JsonRpcMessage message, {
     RequestId? relatedRequestId,
   }) async {
+    if (failSends) {
+      final delay = failSendDelay;
+      if (delay != null) {
+        await Future<void>.delayed(delay);
+      }
+      throw StateError('Transport send failed');
+    }
     if (_closed) {
       throw StateError('Transport is closed');
     }
@@ -205,6 +216,90 @@ class TestResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {'value': value};
 }
+
+class _StubTaskStore implements TaskStore {
+  @override
+  Future<Task> createTask(
+    TaskCreationParams taskParams,
+    RequestId requestId,
+    Map<String, dynamic> requestData,
+    String? sessionId,
+  ) async =>
+      const Task(
+        taskId: 'stub-task',
+        status: TaskStatus.working,
+        createdAt: '2026-05-16T00:00:00Z',
+        lastUpdatedAt: '2026-05-16T00:00:00Z',
+        ttl: null,
+      );
+
+  @override
+  Future<Task?> getTask(String taskId, [String? sessionId]) async => null;
+
+  @override
+  Future<BaseResultData> getTaskResult(
+    String taskId, [
+    String? sessionId,
+  ]) async =>
+      const EmptyResult();
+
+  @override
+  Future<ListTasksResult> listTasks(
+    String? cursor, [
+    String? sessionId,
+  ]) async =>
+      const ListTasksResult(tasks: []);
+
+  @override
+  Future<void> storeTaskResult(
+    String taskId,
+    TaskStatus status,
+    BaseResultData result, [
+    String? sessionId,
+  ]) async {}
+
+  @override
+  Future<void> updateTaskStatus(
+    String taskId,
+    TaskStatus status, [
+    String? statusMessage,
+    String? sessionId,
+  ]) async {}
+}
+
+class _FailingTaskMessageQueue implements TaskMessageQueue {
+  static const Duration _delay = Duration(milliseconds: 20);
+
+  @override
+  Future<void> enqueue(
+    String taskId,
+    QueuedMessage message,
+    String? sessionId, [
+    int? maxSize,
+  ]) async {
+    await Future<void>.delayed(_delay);
+    throw StateError('Task queue enqueue failed');
+  }
+
+  @override
+  Future<QueuedMessage?> dequeue(String taskId, [String? sessionId]) async =>
+      null;
+
+  @override
+  Future<List<QueuedMessage>> dequeueAll(
+    String taskId, [
+    String? sessionId,
+  ]) async =>
+      const [];
+}
+
+Map<String, dynamic> taskJson(String taskId, TaskStatus status) => {
+      'taskId': taskId,
+      'status': status.name,
+      'ttl': null,
+      'createdAt': '2026-05-16T00:00:00Z',
+      'lastUpdatedAt': '2026-05-16T00:00:01Z',
+    };
 
 void main() {
   group('Protocol tests', () {
@@ -520,6 +615,48 @@ void main() {
 
       final result = await requestFuture;
       expect(result.value, 'response-data');
+    });
+
+    test('task options serialize as task-augmented request params', () async {
+      await protocol.connect(transport);
+
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              params: {'original': 'value'},
+              meta: {'progressToken': 'task-shape-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              onprogress: (_) {},
+              task: const TaskCreation(ttl: 1234),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      expect(transport.sentMessages, hasLength(1));
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      expect(sentRequest.params?['original'], 'value');
+      expect(sentRequest.params?['task'], {'ttl': 1234});
+      expect(sentRequest.meta?['task'], isNull);
+      expect(sentRequest.meta?['progressToken'], 'task-shape-token');
+      expect(sentRequest.toJson()['params'], {
+        'original': 'value',
+        'task': {'ttl': 1234},
+        '_meta': {'progressToken': 'task-shape-token'},
+      });
+
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {
+            'task': taskJson('shape-task', TaskStatus.completed),
+          },
+        ),
+      );
+      expect((await requestFuture).task.taskId, 'shape-task');
     });
 
     test('progress notifications reset timeout for custom tokens', () async {
@@ -1007,6 +1144,1267 @@ void main() {
       );
 
       expect(transport.sentMessages, isEmpty);
+    });
+
+    test('keeps task-augmented progress tokens until terminal task status',
+        () async {
+      await protocol.connect(transport);
+
+      final progressUpdates = <Progress>[];
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'task-progress-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              onprogress: progressUpdates.add,
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      expect(transport.sentMessages, hasLength(1));
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {
+            'task': taskJson('task-progress-1', TaskStatus.working),
+          },
+        ),
+      );
+
+      final createResult = await requestFuture;
+      expect(createResult.task.taskId, 'task-progress-1');
+
+      transport.receiveMessage(
+        JsonRpcProgressNotification(
+          progressParams: const ProgressNotification(
+            progressToken: 'task-progress-token',
+            progress: 60,
+          ),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(progressUpdates, hasLength(1));
+      expect(progressUpdates.single.progress, 60);
+
+      transport.receiveMessage(
+        JsonRpcTaskStatusNotification(
+          statusParams: TaskStatusNotification.fromJson(
+            taskJson('task-progress-1', TaskStatus.completed),
+          ),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'task-progress-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-terminal'},
+        ),
+      );
+      expect((await reuseFuture).value, 'reused-after-terminal');
+    });
+
+    test('cleans preserved task progress when transport closes', () async {
+      await protocol.connect(transport);
+
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'close-cleanup-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {'task': taskJson('close-cleanup-task', TaskStatus.working)},
+        ),
+      );
+      expect((await requestFuture).task.taskId, 'close-cleanup-task');
+
+      await protocol.close();
+      final nextTransport = MockTransport();
+      await protocol.connect(nextTransport);
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'close-cleanup-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+      final reuseRequest = nextTransport.sentMessages.single as JsonRpcRequest;
+      nextTransport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-close'},
+        ),
+      );
+
+      expect((await reuseFuture).value, 'reused-after-close');
+    });
+
+    test(
+        'cleans task progress when terminal status arrives before awaiting task',
+        () async {
+      await protocol.connect(transport);
+
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'fast-terminal-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {
+            'task': taskJson('fast-terminal-task', TaskStatus.working),
+          },
+        ),
+      );
+      transport.receiveMessage(
+        JsonRpcTaskStatusNotification(
+          statusParams: TaskStatusNotification.fromJson(
+            taskJson('fast-terminal-task', TaskStatus.completed),
+          ),
+        ),
+      );
+
+      expect((await requestFuture).task.taskId, 'fast-terminal-task');
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'fast-terminal-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-fast-terminal'},
+        ),
+      );
+
+      expect((await reuseFuture).value, 'reused-after-fast-terminal');
+    });
+
+    test('does not let unrelated early terminal status poison later task',
+        () async {
+      await protocol.connect(transport);
+
+      final firstFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(id: 0, method: 'test/method'),
+            CreateTaskResult.fromJson,
+            const RequestOptions(task: TaskCreation()),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final firstRequest = transport.sentMessages.single as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcTaskStatusNotification(
+          statusParams: TaskStatusNotification.fromJson(
+            taskJson('unrelated-terminal-task', TaskStatus.completed),
+          ),
+        ),
+      );
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: firstRequest.id,
+          result: {'task': taskJson('first-task', TaskStatus.working)},
+        ),
+      );
+      expect((await firstFuture).task.taskId, 'first-task');
+
+      final progressUpdates = <Progress>[];
+      final secondFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'poison-check-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              onprogress: progressUpdates.add,
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final secondRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: secondRequest.id,
+          result: {
+            'task': taskJson('unrelated-terminal-task', TaskStatus.working),
+          },
+        ),
+      );
+      expect((await secondFuture).task.taskId, 'unrelated-terminal-task');
+
+      transport.receiveMessage(
+        JsonRpcProgressNotification(
+          progressParams: const ProgressNotification(
+            progressToken: 'poison-check-token',
+            progress: 40,
+          ),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(progressUpdates.single.progress, 40);
+    });
+
+    test('prunes unrelated terminal status after concurrent tasks identify',
+        () async {
+      await protocol.connect(transport);
+
+      final firstFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(id: 0, method: 'test/method'),
+            CreateTaskResult.fromJson,
+            const RequestOptions(task: TaskCreation()),
+          )
+          .timeout(const Duration(seconds: 5));
+      final secondFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(id: 0, method: 'test/method'),
+            CreateTaskResult.fromJson,
+            const RequestOptions(task: TaskCreation()),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final firstRequest = transport.sentMessages[0] as JsonRpcRequest;
+      final secondRequest = transport.sentMessages[1] as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcTaskStatusNotification(
+          statusParams: TaskStatusNotification.fromJson(
+            taskJson('concurrent-unrelated-task', TaskStatus.completed),
+          ),
+        ),
+      );
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: firstRequest.id,
+          result: {
+            'task': taskJson('concurrent-first-task', TaskStatus.working),
+          },
+        ),
+      );
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: secondRequest.id,
+          result: {
+            'task': taskJson('concurrent-second-task', TaskStatus.working),
+          },
+        ),
+      );
+      expect((await firstFuture).task.taskId, 'concurrent-first-task');
+      expect((await secondFuture).task.taskId, 'concurrent-second-task');
+
+      final progressUpdates = <Progress>[];
+      final thirdFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'concurrent-poison-check-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              onprogress: progressUpdates.add,
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+      final thirdRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: thirdRequest.id,
+          result: {
+            'task': taskJson('concurrent-unrelated-task', TaskStatus.working),
+          },
+        ),
+      );
+      expect((await thirdFuture).task.taskId, 'concurrent-unrelated-task');
+
+      transport.receiveMessage(
+        JsonRpcProgressNotification(
+          progressParams: const ProgressNotification(
+            progressToken: 'concurrent-poison-check-token',
+            progress: 30,
+          ),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(progressUpdates.single.progress, 30);
+    });
+
+    test('aborting task after response but before awaiting sends tasks/cancel',
+        () async {
+      await protocol.connect(transport);
+
+      final controller = BasicAbortController();
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'fast-cancel-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {
+            'task': taskJson('fast-cancel-task', TaskStatus.working),
+          },
+        ),
+      );
+      controller.abort('User cancelled task');
+
+      await expectLater(
+        requestFuture,
+        throwsA(equals('User cancelled task')),
+      );
+      await waitForSentMessages(transport, 2);
+
+      final cancelRequest =
+          transport.sentMessages.last as JsonRpcCancelTaskRequest;
+      expect(cancelRequest.method, Method.tasksCancel);
+      expect(cancelRequest.cancelParams.taskId, 'fast-cancel-task');
+
+      await expectLater(
+        protocol.request<TestResult>(
+          const JsonRpcRequest(
+            id: 0,
+            method: 'test/method',
+            meta: {'progressToken': 'fast-cancel-token'},
+          ),
+          (json) => TestResult(value: json['value'] as String),
+          RequestOptions(onprogress: (_) {}),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: cancelRequest.id,
+          result: taskJson('fast-cancel-task', TaskStatus.cancelled),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'fast-cancel-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-cancelled'},
+        ),
+      );
+      expect((await reuseFuture).value, 'reused-after-cancelled');
+    });
+
+    test(
+        'aborting task before creation waits for task id and sends tasks/cancel',
+        () async {
+      await protocol.connect(transport);
+
+      final controller = BasicAbortController();
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'pre-create-cancel-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      controller.abort('User cancelled before task id');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(transport.sentMessages, hasLength(1));
+      expect(
+        transport.sentMessages.whereType<JsonRpcNotification>().where(
+              (message) => message.method == Method.notificationsCancelled,
+            ),
+        isEmpty,
+      );
+
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {
+            'task': taskJson('pre-create-cancel-task', TaskStatus.working),
+          },
+        ),
+      );
+
+      await expectLater(
+        requestFuture,
+        throwsA(equals('User cancelled before task id')),
+      );
+      await waitForSentMessages(transport, 2);
+
+      final cancelRequest =
+          transport.sentMessages.last as JsonRpcCancelTaskRequest;
+      expect(cancelRequest.method, Method.tasksCancel);
+      expect(cancelRequest.cancelParams.taskId, 'pre-create-cancel-task');
+
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: cancelRequest.id,
+          result: taskJson('pre-create-cancel-task', TaskStatus.cancelled),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'pre-create-cancel-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-cancel-result'},
+        ),
+      );
+      expect((await reuseFuture).value, 'reused-after-cancel-result');
+    });
+
+    test('pre-task-id abort preserves cancellation reason over peer error',
+        () async {
+      await protocol.connect(transport);
+
+      final controller = BasicAbortController();
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'pre-error-cancel-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      controller.abort('pre-error user abort');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      transport.receiveMessage(
+        JsonRpcError(
+          id: sentRequest.id,
+          error: JsonRpcErrorData(
+            code: ErrorCode.internalError.value,
+            message: 'Peer failed after abort',
+          ),
+        ),
+      );
+
+      await expectLater(requestFuture, throwsA(equals('pre-error user abort')));
+      expect(transport.sentMessages.length, 1);
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/reuse',
+              meta: {'progressToken': 'pre-error-cancel-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-peer-error'},
+        ),
+      );
+      expect((await reuseFuture).value, 'reused-after-peer-error');
+    });
+
+    test(
+        'pre-task-id abort preserves cancellation reason over malformed result',
+        () async {
+      await protocol.connect(transport);
+
+      final controller = BasicAbortController();
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'pre-malformed-cancel-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      controller.abort('pre-malformed user abort');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {'unexpected': 'payload'},
+        ),
+      );
+
+      await expectLater(
+        requestFuture,
+        throwsA(equals('pre-malformed user abort')),
+      );
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/reuse',
+              meta: {'progressToken': 'pre-malformed-cancel-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-malformed-result'},
+        ),
+      );
+      expect((await reuseFuture).value, 'reused-after-malformed-result');
+    });
+
+    test('pre-task-id abort preserves cancellation reason over send failure',
+        () async {
+      await protocol.connect(transport);
+
+      final controller = BasicAbortController();
+      transport
+        ..failSends = true
+        ..failSendDelay = const Duration(milliseconds: 20);
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'pre-send-failure-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      controller.abort('pre-send user abort');
+
+      await expectLater(requestFuture, throwsA(equals('pre-send user abort')));
+      transport
+        ..failSends = false
+        ..failSendDelay = null;
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/reuse',
+              meta: {'progressToken': 'pre-send-failure-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-send-request-failure'},
+        ),
+      );
+      expect((await reuseFuture).value, 'reused-after-send-request-failure');
+    });
+
+    test(
+        'pre-task-id abort preserves cancellation reason over related enqueue failure',
+        () async {
+      protocol = TestProtocol(
+        ProtocolOptions(
+          taskStore: _StubTaskStore(),
+          taskMessageQueue: _FailingTaskMessageQueue(),
+        ),
+      );
+      await protocol.connect(transport);
+
+      final controller = BasicAbortController();
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'pre-enqueue-failure-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              onprogress: (_) {},
+              task: const TaskCreation(),
+              relatedTask: const RelatedTaskMetadata(taskId: 'parent-task'),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      controller.abort('pre-enqueue user abort');
+
+      await expectLater(
+        requestFuture,
+        throwsA(equals('pre-enqueue user abort')),
+      );
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/reuse',
+              meta: {'progressToken': 'pre-enqueue-failure-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-enqueue-failure'},
+        ),
+      );
+      expect((await reuseFuture).value, 'reused-after-enqueue-failure');
+    });
+
+    test(
+        'task creation timeout fails when task id never arrives and cleans state',
+        () async {
+      await protocol.connect(transport);
+
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'task-create-timeout-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              timeout: const Duration(milliseconds: 5),
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      await expectLater(
+        requestFuture,
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.code,
+            'code',
+            ErrorCode.requestTimeout.value,
+          ),
+        ),
+      );
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'task-create-timeout-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-task-create-timeout'},
+        ),
+      );
+      expect((await reuseFuture).value, 'reused-after-task-create-timeout');
+    });
+
+    test('pre-task-id abort preserves first cancellation reason across timeout',
+        () async {
+      await protocol.connect(transport);
+
+      final controller = BasicAbortController();
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'pre-timeout-cancel-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              timeout: const Duration(milliseconds: 5),
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      controller.abort('first user abort');
+
+      await expectLater(requestFuture, throwsA(equals('first user abort')));
+      expect(transport.sentMessages, hasLength(1));
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/reuse',
+              meta: {'progressToken': 'pre-timeout-cancel-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-pre-timeout-cancel'},
+        ),
+      );
+      expect((await reuseFuture).value, 'reused-after-pre-timeout-cancel');
+    });
+
+    test('aborted signal response race preserves caller cancellation reason',
+        () async {
+      await protocol.connect(transport);
+
+      final controller = BasicAbortController();
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(id: 0, method: 'test/method'),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      controller.abort('race user abort');
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {
+            'task': taskJson('abort-race-task', TaskStatus.working),
+          },
+        ),
+      );
+
+      await expectLater(requestFuture, throwsA(equals('race user abort')));
+      await waitForSentMessages(transport, 2);
+      final cancelRequest =
+          transport.sentMessages.last as JsonRpcCancelTaskRequest;
+      expect(cancelRequest.cancelParams.taskId, 'abort-race-task');
+    });
+
+    test('aborting before terminal task creation rejects without tasks/cancel',
+        () async {
+      await protocol.connect(transport);
+
+      final controller = BasicAbortController();
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'terminal-pre-cancel-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      controller.abort('terminal user abort');
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {
+            'task': taskJson('terminal-pre-cancel-task', TaskStatus.completed),
+          },
+        ),
+      );
+
+      await expectLater(requestFuture, throwsA(equals('terminal user abort')));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(transport.sentMessages, hasLength(1));
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'terminal-pre-cancel-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-terminal-pre-cancel'},
+        ),
+      );
+      expect((await reuseFuture).value, 'reused-after-terminal-pre-cancel');
+    });
+
+    test(
+        'aborting task-augmented request after task creation sends tasks/cancel',
+        () async {
+      await protocol.connect(transport);
+
+      final controller = BasicAbortController();
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(id: 0, method: 'test/method'),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {
+            'task': taskJson('task-cancel-1', TaskStatus.working),
+          },
+        ),
+      );
+      expect((await requestFuture).task.taskId, 'task-cancel-1');
+
+      controller.abort('User cancelled task');
+      await waitForSentMessages(transport, 2);
+
+      final cancellationMessages = transport.sentMessages.skip(1).toList();
+      expect(
+        cancellationMessages.whereType<JsonRpcNotification>().where(
+              (message) => message.method == Method.notificationsCancelled,
+            ),
+        isEmpty,
+      );
+      final cancelRequest =
+          cancellationMessages.single as JsonRpcCancelTaskRequest;
+      expect(cancelRequest.method, Method.tasksCancel);
+      expect(cancelRequest.cancelParams.taskId, 'task-cancel-1');
+    });
+
+    test('reports task cancellation response errors', () async {
+      await protocol.connect(transport);
+      final errors = <Error>[];
+      protocol.onerror = errors.add;
+
+      final controller = BasicAbortController();
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'cancel-error-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {'task': taskJson('cancel-error-task', TaskStatus.working)},
+        ),
+      );
+      expect((await requestFuture).task.taskId, 'cancel-error-task');
+
+      controller.abort('User cancelled task');
+      await waitForSentMessages(transport, 2);
+      final cancelRequest =
+          transport.sentMessages.last as JsonRpcCancelTaskRequest;
+      transport.receiveMessage(
+        JsonRpcError(
+          id: cancelRequest.id,
+          error: JsonRpcErrorData(
+            code: ErrorCode.invalidParams.value,
+            message: 'Cancellation rejected',
+          ),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(errors, hasLength(1));
+      expect(errors.single, isA<McpError>());
+      expect((errors.single as McpError).message, 'Cancellation rejected');
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'cancel-error-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-cancel-error'},
+        ),
+      );
+      expect((await reuseFuture).value, 'reused-after-cancel-error');
+    });
+
+    test('reports malformed task cancellation responses', () async {
+      await protocol.connect(transport);
+      final errors = <Error>[];
+      protocol.onerror = errors.add;
+
+      final controller = BasicAbortController();
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'malformed-cancel-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {
+            'task': taskJson('malformed-cancel-task', TaskStatus.working),
+          },
+        ),
+      );
+      expect((await requestFuture).task.taskId, 'malformed-cancel-task');
+
+      controller.abort('User cancelled task');
+      await waitForSentMessages(transport, 2);
+      final cancelRequest =
+          transport.sentMessages.last as JsonRpcCancelTaskRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: cancelRequest.id,
+          result: {'unexpected': 'payload'},
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(errors, hasLength(1));
+      expect(errors.single, isA<StateError>());
+      expect(
+        errors.single.toString(),
+        contains('Failed to parse task cancellation result'),
+      );
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'malformed-cancel-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-malformed'},
+        ),
+      );
+      expect((await reuseFuture).value, 'reused-after-malformed');
+    });
+
+    test('reports mismatched task cancellation responses and cleans state',
+        () async {
+      await protocol.connect(transport);
+      final errors = <Error>[];
+      protocol.onerror = errors.add;
+
+      final controller = BasicAbortController();
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'mismatched-cancel-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {
+            'task': taskJson('mismatched-cancel-task', TaskStatus.working),
+          },
+        ),
+      );
+      expect((await requestFuture).task.taskId, 'mismatched-cancel-task');
+
+      controller.abort('User cancelled task');
+      await waitForSentMessages(transport, 2);
+      final cancelRequest =
+          transport.sentMessages.last as JsonRpcCancelTaskRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: cancelRequest.id,
+          result: taskJson('wrong-cancel-task', TaskStatus.cancelled),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(errors, hasLength(1));
+      expect(errors.single, isA<StateError>());
+      expect(
+        errors.single.toString(),
+        contains('Task cancellation response taskId mismatch'),
+      );
+
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'mismatched-cancel-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-mismatch'},
+        ),
+      );
+      expect((await reuseFuture).value, 'reused-after-mismatch');
+    });
+
+    test('reports task cancellation send failures', () async {
+      await protocol.connect(transport);
+      final errors = <Error>[];
+      protocol.onerror = errors.add;
+
+      final controller = BasicAbortController();
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'send-failure-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {'task': taskJson('send-failure-task', TaskStatus.working)},
+        ),
+      );
+      expect((await requestFuture).task.taskId, 'send-failure-task');
+
+      transport.failSends = true;
+      controller.abort('User cancelled task');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(errors, hasLength(1));
+      expect(errors.single, isA<StateError>());
+      expect(
+        errors.single.toString(),
+        contains('Failed to send task cancellation for task send-failure-task'),
+      );
+
+      transport.failSends = false;
+      final reuseFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'send-failure-token'},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(onprogress: (_) {}),
+          )
+          .timeout(const Duration(seconds: 5));
+      final reuseRequest = transport.sentMessages.last as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: reuseRequest.id,
+          result: {'value': 'reused-after-send-failure'},
+        ),
+      );
+      expect((await reuseFuture).value, 'reused-after-send-failure');
     });
 
     test('handles outgoing request errors', () async {

--- a/test/shared/protocol_test.dart
+++ b/test/shared/protocol_test.dart
@@ -1719,6 +1719,55 @@ void main() {
     });
 
     test(
+        'pre-task-id abort distinguishes caller timeout-shaped reason from timeout',
+        () async {
+      await protocol.connect(transport);
+
+      final controller = BasicAbortController();
+      final callerReason = McpError(
+        ErrorCode.requestTimeout.value,
+        'caller supplied timeout-shaped abort',
+      );
+      final requestFuture = protocol
+          .request<CreateTaskResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 'caller-timeout-shaped-token'},
+            ),
+            CreateTaskResult.fromJson,
+            RequestOptions(
+              signal: controller.signal,
+              onprogress: (_) {},
+              task: const TaskCreation(),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      final errorExpectation = expectLater(
+        requestFuture,
+        throwsA(same(callerReason)),
+      );
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      controller.abort(callerReason);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {
+            'task': taskJson('caller-timeout-shaped-task', TaskStatus.working),
+          },
+        ),
+      );
+
+      await waitForSentMessages(transport, 2);
+      final cancelRequest = transport.sentMessages.last as JsonRpcRequest;
+      expect(cancelRequest.method, 'tasks/cancel');
+      expect(cancelRequest.params?['taskId'], 'caller-timeout-shaped-task');
+      await errorExpectation;
+    });
+
+    test(
         'pre-task-id abort preserves cancellation reason over malformed result',
         () async {
       await protocol.connect(transport);


### PR DESCRIPTION
## Summary
- Preserve progress callbacks for task-augmented requests after the initial `CreateTaskResult` until the task reaches a terminal status.
- Route task aborts through the MCP 2025-11-25 `tasks/cancel` request lifecycle instead of `notifications/cancelled` once a task id exists.
- Preserve cancellation intent when an abort happens before the task id is known, then issue `tasks/cancel` as soon as the `CreateTaskResult` identifies the task.
- Clean preserved task/progress state on terminal task status, terminal initial task result, terminal `tasks/cancel` result, transport close, send failures, and parse failures.
- Covers early terminal notification races and unrelated terminal-status pruning so stale terminal statuses do not poison later tasks.

Fixes #127.

## Spec compliance review
- MCP 2025-11-25 task-augmented requests augment the original request params with top-level `params.task` (`TaskAugmentedRequestParamsSchema`); `_meta` remains for `progressToken` and related-task metadata. The initial response is a `CreateTaskResult` and the task lifecycle continues after that response.
- MCP progress is keyed by `_meta.progressToken`; for task-augmented requests, progress may continue after the initial `CreateTaskResult`, so the token must not be freed until task terminal cleanup.
- MCP cancellation for tasks is `tasks/cancel` with `{ taskId }`; this PR avoids sending `notifications/cancelled` for task lifecycle cancellation.
- `tasks/cancel` returns the updated task. The client now processes that response and cleans preserved progress state when it is terminal.
- Independent strict review after the final amendment found no remaining task-progress/task-cancellation spec issues.

## Tests
- `dart analyze`
- `dart test test/shared/protocol_test.dart --name "task options serialize|pre-task-id abort preserves cancellation reason over peer error|aborted signal response race|task creation timeout|send failures|aborting before terminal|task cancellation|task-augmented"`
- `dart test`
- `dart test test/mcp_2025_11_25_test.dart test/client/task_client_test.dart test/server/tasks_test.dart test/shared/protocol_task_handlers_test.dart`
- `dart test test/interop/dart_client_with_ts_server_task_test.dart test/interop/ts_client_with_dart_server_test.dart --tags interop`

## Notes
- I did not manually request Copilot review; per repo workflow, this is ready for normal CI/review automation after opening.
