### PR TITLE
fix: enforce task terminal status fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,14 @@
     `lastUpdatedAt`, and `ttl`), and the `Task` constructor now requires
     `ttl`, `createdAt`, and `lastUpdatedAt` so serialization is non-throwing
     for valid task instances.
+  - `TaskStatusNotification.fromJson()` likewise requires the full MCP
+    `NotificationParams & Task` shape (`taskId`, `status`, `ttl`, `createdAt`,
+    and `lastUpdatedAt`), and task status notifications always serialize the
+    required `ttl` key even when it is `null`.
   - `Task.toJson()` continues to serialize required `ttl` even when it is
     `null`, and now omits optional `pollInterval` when it is not set.
+  - Task stores now treat terminal tasks (`completed`, `failed`, `cancelled`) as
+    immutable, preventing later status or result overwrites.
 
 ### Compatibility Notes
 

--- a/doc/migration_2025_11_25_compat.md
+++ b/doc/migration_2025_11_25_compat.md
@@ -18,6 +18,13 @@ This guide helps update existing code that used older sampling/tool-choice APIs.
   one release window.
 - Task serialization keeps the MCP-required `ttl` field even when it is `null`,
   while omitting optional `pollInterval` when it is not set.
+- Task status notifications now serialize and parse the full MCP
+  `NotificationParams & Task` shape. The `ttl`, `createdAt`, and
+  `lastUpdatedAt` fields are required at the wire boundary, even when `ttl` is
+  `null`.
+- Task stores treat terminal tasks (`completed`, `failed`, `cancelled`) as
+  immutable. Later status or result writes are ignored instead of overwriting
+  the terminal state.
 - The `Task` constructor now requires `ttl`, `createdAt`, and `lastUpdatedAt`,
   so valid task instances serialize without throwing.
 - Streamable HTTP defaults are stricter for protocol-version headers, DNS

--- a/lib/src/server/tasks/store.dart
+++ b/lib/src/server/tasks/store.dart
@@ -137,19 +137,21 @@ class InMemoryTaskStore implements TaskStore {
     String? sessionId,
   ]) async {
     final task = _tasks[taskId];
-    if (task != null) {
-      _tasks[taskId] = Task(
-        taskId: task.taskId,
-        status: status,
-        statusMessage: message ?? task.statusMessage,
-        ttl: task.ttl,
-        pollInterval: task.pollInterval,
-        createdAt: task.createdAt,
-        lastUpdatedAt: DateTime.now().toIso8601String(),
-        meta: task.meta,
-      );
-      _notifyUpdate(taskId);
+    if (task == null || task.status.isTerminal) {
+      return;
     }
+
+    _tasks[taskId] = Task(
+      taskId: task.taskId,
+      status: status,
+      statusMessage: message ?? task.statusMessage,
+      ttl: task.ttl,
+      pollInterval: task.pollInterval,
+      createdAt: task.createdAt,
+      lastUpdatedAt: DateTime.now().toIso8601String(),
+      meta: task.meta,
+    );
+    _notifyUpdate(taskId);
   }
 
   @override
@@ -159,6 +161,11 @@ class InMemoryTaskStore implements TaskStore {
     BaseResultData result, [
     String? sessionId,
   ]) async {
+    final task = _tasks[taskId];
+    if (task == null || task.status.isTerminal) {
+      return;
+    }
+
     _results[taskId] = result;
     await updateTaskStatus(taskId, status, null, sessionId);
   }

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -1933,6 +1933,17 @@ class _RequestTaskStoreImpl implements RequestTaskStore {
     TaskStatus status,
     BaseResultData result,
   ) async {
+    final currentTask = await _store.getTask(taskId, _sessionId);
+    if (currentTask == null) {
+      throw McpError(
+        ErrorCode.invalidParams.value,
+        'Failed to store task result: Task not found',
+      );
+    }
+    if (currentTask.status.isTerminal) {
+      return;
+    }
+
     await _store.storeTaskResult(taskId, status, result, _sessionId);
     final task = await _store.getTask(taskId, _sessionId);
     if (task != null) {

--- a/lib/src/shared/task_interfaces.dart
+++ b/lib/src/shared/task_interfaces.dart
@@ -26,6 +26,10 @@ abstract class TaskStore {
   Future<Task?> getTask(String taskId, [String? sessionId]);
 
   /// Stores the result of a task and sets its final status.
+  ///
+  /// Implementations must treat terminal tasks (`completed`, `failed`, or
+  /// `cancelled`) as immutable and ignore attempts to replace their status or
+  /// result.
   Future<void> storeTaskResult(
     String taskId,
     TaskStatus status,
@@ -37,6 +41,10 @@ abstract class TaskStore {
   Future<BaseResultData> getTaskResult(String taskId, [String? sessionId]);
 
   /// Updates a task's status.
+  ///
+  /// Implementations must treat terminal tasks (`completed`, `failed`, or
+  /// `cancelled`) as immutable and ignore attempts to transition them to any
+  /// later status.
   Future<void> updateTaskStatus(
     String taskId,
     TaskStatus status, [

--- a/lib/src/types/tasks.dart
+++ b/lib/src/types/tasks.dart
@@ -99,9 +99,11 @@ class Task implements BaseResultData {
 
     final meta = json['_meta'] as Map<String, dynamic>?;
     return Task(
-      taskId: json['taskId'] as String,
-      status: TaskStatusName.fromString(json['status'] as String),
-      statusMessage: json['statusMessage'] as String?,
+      taskId: _readRequiredTaskString(json, 'taskId'),
+      status: TaskStatusName.fromString(
+        _readRequiredTaskString(json, 'status'),
+      ),
+      statusMessage: _readOptionalTaskString(json, 'statusMessage'),
       ttl: _readTaskInt(json, 'ttl', requiredField: true),
       pollInterval: _readTaskInt(json, 'pollInterval'),
       createdAt: createdAt,
@@ -123,25 +125,45 @@ class Task implements BaseResultData {
       };
 }
 
-String _readRequiredTaskString(Map<String, dynamic> json, String field) {
+String _readRequiredTaskString(
+  Map<String, dynamic> json,
+  String field, {
+  String owner = 'Task',
+}) {
   if (!json.containsKey(field)) {
-    throw FormatException('Task.$field is required');
+    throw FormatException('$owner.$field is required');
   }
   final value = json[field];
   if (value is! String) {
-    throw FormatException('Task.$field must be a string');
+    throw FormatException('$owner.$field must be a string');
   }
   return value;
+}
+
+String? _readOptionalTaskString(
+  Map<String, dynamic> json,
+  String field, {
+  String owner = 'Task',
+}) {
+  if (!json.containsKey(field)) {
+    return null;
+  }
+  final value = json[field];
+  if (value == null || value is String) {
+    return value as String?;
+  }
+  throw FormatException('$owner.$field must be a string');
 }
 
 int? _readTaskInt(
   Map<String, dynamic> json,
   String field, {
   bool requiredField = false,
+  String owner = 'Task',
 }) {
   if (!json.containsKey(field)) {
     if (requiredField) {
-      throw FormatException('Task.$field is required');
+      throw FormatException('$owner.$field is required');
     }
     return null;
   }
@@ -151,7 +173,7 @@ int? _readTaskInt(
     return value as int?;
   }
 
-  throw FormatException('Task.$field must be an integer or null');
+  throw FormatException('$owner.$field must be an integer or null');
 }
 
 /// Parameters for the `tasks/list` request. Includes pagination.
@@ -415,15 +437,24 @@ class TaskStatusNotification {
   final String? statusMessage;
 
   /// Time in milliseconds from creation before task may be deleted.
+  ///
+  /// Required by the MCP schema. A null value is serialized explicitly as
+  /// `"ttl": null` when the task has no expiry.
   final int? ttl;
 
   /// Suggested time in milliseconds between status checks.
   final int? pollInterval;
 
   /// ISO 8601 timestamp when the task was created.
+  ///
+  /// Required by the MCP schema and required for serialization. The constructor
+  /// keeps this nullable for source compatibility with earlier SDK versions.
   final String? createdAt;
 
   /// ISO 8601 timestamp when the task status was last updated.
+  ///
+  /// Required by the MCP schema and required for serialization. The constructor
+  /// keeps this nullable for source compatibility with earlier SDK versions.
   final String? lastUpdatedAt;
 
   const TaskStatusNotification({
@@ -438,13 +469,44 @@ class TaskStatusNotification {
 
   factory TaskStatusNotification.fromJson(Map<String, dynamic> json) {
     return TaskStatusNotification(
-      taskId: json['taskId'] as String,
-      status: TaskStatusName.fromString(json['status'] as String),
-      statusMessage: json['statusMessage'] as String?,
-      ttl: json['ttl'] as int?,
-      pollInterval: json['pollInterval'] as int?,
-      createdAt: json['createdAt'] as String?,
-      lastUpdatedAt: json['lastUpdatedAt'] as String?,
+      taskId: _readRequiredTaskString(
+        json,
+        'taskId',
+        owner: 'TaskStatusNotification',
+      ),
+      status: TaskStatusName.fromString(
+        _readRequiredTaskString(
+          json,
+          'status',
+          owner: 'TaskStatusNotification',
+        ),
+      ),
+      statusMessage: _readOptionalTaskString(
+        json,
+        'statusMessage',
+        owner: 'TaskStatusNotification',
+      ),
+      ttl: _readTaskInt(
+        json,
+        'ttl',
+        requiredField: true,
+        owner: 'TaskStatusNotification',
+      ),
+      pollInterval: _readTaskInt(
+        json,
+        'pollInterval',
+        owner: 'TaskStatusNotification',
+      ),
+      createdAt: _readRequiredTaskString(
+        json,
+        'createdAt',
+        owner: 'TaskStatusNotification',
+      ),
+      lastUpdatedAt: _readRequiredTaskString(
+        json,
+        'lastUpdatedAt',
+        owner: 'TaskStatusNotification',
+      ),
     );
   }
 
@@ -452,11 +514,24 @@ class TaskStatusNotification {
         'taskId': taskId,
         'status': status.name,
         if (statusMessage != null) 'statusMessage': statusMessage,
-        if (ttl != null) 'ttl': ttl,
+        'ttl': ttl,
         if (pollInterval != null) 'pollInterval': pollInterval,
-        if (createdAt != null) 'createdAt': createdAt,
-        if (lastUpdatedAt != null) 'lastUpdatedAt': lastUpdatedAt,
+        'createdAt': _requireTaskStatusNotificationString(
+          createdAt,
+          'createdAt',
+        ),
+        'lastUpdatedAt': _requireTaskStatusNotificationString(
+          lastUpdatedAt,
+          'lastUpdatedAt',
+        ),
       };
+}
+
+String _requireTaskStatusNotificationString(String? value, String field) {
+  if (value == null) {
+    throw StateError('TaskStatusNotification.$field is required');
+  }
+  return value;
 }
 
 /// Notification from receiver indicating a task status has changed.

--- a/test/interop/ts/src/client.ts
+++ b/test/interop/ts/src/client.ts
@@ -9,6 +9,55 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import type { Progress } from '@modelcontextprotocol/sdk/types.js';
 
+type TaskWireShape = {
+  taskId?: unknown;
+  status?: unknown;
+  ttl?: unknown;
+  pollInterval?: unknown;
+  createdAt?: unknown;
+  lastUpdatedAt?: unknown;
+};
+
+function assertTaskWireShape(task: unknown, label: string): void {
+  if (typeof task !== 'object' || task === null) {
+    throw new Error(`${label} was not an object: ${JSON.stringify(task)}`);
+  }
+
+  const taskShape = task as TaskWireShape;
+  if (typeof taskShape.taskId !== 'string' || taskShape.taskId.length === 0) {
+    throw new Error(`${label} missing string taskId: ${JSON.stringify(task)}`);
+  }
+  if (typeof taskShape.status !== 'string' || taskShape.status.length === 0) {
+    throw new Error(`${label} missing string status: ${JSON.stringify(task)}`);
+  }
+  if (!Object.prototype.hasOwnProperty.call(taskShape, 'ttl')) {
+    throw new Error(
+      `${label} missing required ttl key: ${JSON.stringify(task)}`
+    );
+  }
+  if (taskShape.ttl !== null && typeof taskShape.ttl !== 'number') {
+    throw new Error(`${label} has invalid ttl: ${JSON.stringify(task)}`);
+  }
+  if (
+    taskShape.pollInterval !== undefined &&
+    typeof taskShape.pollInterval !== 'number'
+  ) {
+    throw new Error(
+      `${label} has invalid pollInterval: ${JSON.stringify(task)}`
+    );
+  }
+  if (typeof taskShape.createdAt !== 'string') {
+    throw new Error(
+      `${label} missing string createdAt: ${JSON.stringify(task)}`
+    );
+  }
+  if (typeof taskShape.lastUpdatedAt !== 'string') {
+    throw new Error(
+      `${label} missing string lastUpdatedAt: ${JSON.stringify(task)}`
+    );
+  }
+}
+
 async function main() {
   const args = process.argv.slice(2);
   let transportType = 'stdio';
@@ -91,7 +140,9 @@ async function main() {
         }
 
         const maybeBlock = item as { type?: unknown; text?: unknown };
-        return maybeBlock.type === 'text' && typeof maybeBlock.text === 'string';
+        return (
+          maybeBlock.type === 'text' && typeof maybeBlock.text === 'string'
+        );
       }) as { text?: string } | undefined;
 
       if (typeof firstTextBlock?.text === 'string') {
@@ -221,6 +272,9 @@ async function main() {
     if (!listTasksResult.tasks) {
       throw new Error("tasks/list response missing 'tasks' array");
     }
+    listTasksResult.tasks.forEach((task, index) => {
+      assertTaskWireShape(task, `tasks/list task ${index}`);
+    });
     console.log(`Tasks listed: ${listTasksResult.tasks.length}`);
 
     // Call delayed_echo using callToolStream
@@ -238,9 +292,11 @@ async function main() {
     for await (const message of stream) {
       switch (message.type) {
         case 'taskCreated':
+          assertTaskWireShape(message.task, 'taskCreated message task');
           console.log(`Task created: ${message.task.taskId}`);
           break;
         case 'taskStatus':
+          assertTaskWireShape(message.task, 'taskStatus message task');
           console.log(
             `Task status: ${message.task.status} (${message.task.statusMessage})`
           );

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -625,6 +625,110 @@ void main() {
         expect(deserialized.status, TaskStatus.completed);
       });
 
+      test('TaskStatusNotificationParams requires full Task fields', () {
+        final params = const TaskStatusNotificationParams(
+          taskId: 'task-no-expiry',
+          status: TaskStatus.working,
+          ttl: null,
+          createdAt: '2025-01-15T10:00:00Z',
+          lastUpdatedAt: '2025-01-15T10:01:00Z',
+        );
+
+        final json = params.toJson();
+        expect(json, containsPair('ttl', null));
+        expect(json['createdAt'], '2025-01-15T10:00:00Z');
+        expect(json['lastUpdatedAt'], '2025-01-15T10:01:00Z');
+
+        expect(
+          () => const TaskStatusNotificationParams(
+            taskId: 'task-missing-created',
+            status: TaskStatus.working,
+            ttl: null,
+            lastUpdatedAt: '2025-01-15T10:01:00Z',
+          ).toJson(),
+          throwsA(isA<StateError>()),
+        );
+        expect(
+          () => const TaskStatusNotificationParams(
+            taskId: 'task-missing-updated',
+            status: TaskStatus.working,
+            ttl: null,
+            createdAt: '2025-01-15T10:00:00Z',
+          ).toJson(),
+          throwsA(isA<StateError>()),
+        );
+
+        for (final field in ['ttl', 'createdAt', 'lastUpdatedAt']) {
+          final malformed = Map<String, dynamic>.from(json)..remove(field);
+          expect(
+            () => TaskStatusNotificationParams.fromJson(malformed),
+            throwsA(isA<FormatException>()),
+            reason: 'missing $field should be rejected',
+          );
+          expect(
+            () => JsonRpcMessage.fromJson({
+              'jsonrpc': '2.0',
+              'method': 'notifications/tasks/status',
+              'params': malformed,
+            }),
+            throwsA(isA<FormatException>()),
+            reason: 'missing $field should fail at the JSON-RPC boundary',
+          );
+        }
+
+        expect(
+          () => TaskStatusNotificationParams.fromJson(
+            Map<String, dynamic>.from(json)..remove('ttl'),
+          ),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              'TaskStatusNotification.ttl is required',
+            ),
+          ),
+        );
+        expect(
+          () => TaskStatusNotificationParams.fromJson({
+            ...json,
+            'createdAt': 42,
+          }),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              'TaskStatusNotification.createdAt must be a string',
+            ),
+          ),
+        );
+        expect(
+          () => TaskStatusNotificationParams.fromJson({
+            ...json,
+            'pollInterval': '1000',
+          }),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              'TaskStatusNotification.pollInterval must be an integer or null',
+            ),
+          ),
+        );
+        expect(
+          () => TaskStatusNotificationParams.fromJson({
+            ...json,
+            'statusMessage': 42,
+          }),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              'TaskStatusNotification.statusMessage must be a string',
+            ),
+          ),
+        );
+      });
+
       test('JsonRpcTaskStatusNotification serialization', () {
         final notification = JsonRpcTaskStatusNotification(
           statusParams: const TaskStatusNotificationParams(
@@ -645,6 +749,9 @@ void main() {
         expect(json['method'], 'notifications/tasks/status');
         expect(json['params']['taskId'], 'task-status-456');
         expect(json['params']['status'], 'failed');
+        expect(json['params'], containsPair('ttl', null));
+        expect(json['params']['createdAt'], '2025-01-15T10:00:00Z');
+        expect(json['params']['lastUpdatedAt'], '2025-01-15T10:05:00Z');
 
         final deserialized = JsonRpcTaskStatusNotification.fromJson(json);
         expect(deserialized.statusParams.taskId, 'task-status-456');
@@ -806,6 +913,46 @@ void main() {
           ),
         );
         expect(
+          () => Task.fromJson({...validJson, 'taskId': 42}),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              'Task.taskId must be a string',
+            ),
+          ),
+        );
+        expect(
+          () => Task.fromJson({...validJson, 'status': false}),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              'Task.status must be a string',
+            ),
+          ),
+        );
+        expect(
+          () => Task.fromJson({...validJson}..remove('taskId')),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              'Task.taskId is required',
+            ),
+          ),
+        );
+        expect(
+          () => Task.fromJson({...validJson}..remove('status')),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              'Task.status is required',
+            ),
+          ),
+        );
+        expect(
           () => Task.fromJson({...validJson, 'lastUpdatedAt': false}),
           throwsA(
             isA<FormatException>().having(
@@ -832,6 +979,16 @@ void main() {
               (error) => error.message,
               'message',
               'Task.pollInterval must be an integer or null',
+            ),
+          ),
+        );
+        expect(
+          () => Task.fromJson({...validJson, 'statusMessage': 42}),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              'Task.statusMessage must be a string',
             ),
           ),
         );

--- a/test/server/in_memory_task_store_test.dart
+++ b/test/server/in_memory_task_store_test.dart
@@ -152,6 +152,39 @@ void main() {
         // Should not throw
         await store.updateTaskStatus('non-existent', TaskStatus.completed);
       });
+
+      test('does not transition terminal tasks', () async {
+        for (final terminalStatus in [
+          TaskStatus.completed,
+          TaskStatus.failed,
+          TaskStatus.cancelled,
+        ]) {
+          final task = await store.createTask(
+            const TaskCreationParams(),
+            terminalStatus.name,
+            {},
+            null,
+          );
+
+          await store.updateTaskStatus(
+            task.taskId,
+            terminalStatus,
+            'terminal ${terminalStatus.name}',
+          );
+          final terminalTask = await store.getTask(task.taskId);
+
+          await store.updateTaskStatus(
+            task.taskId,
+            TaskStatus.working,
+            'should not reopen',
+          );
+          final reopened = await store.getTask(task.taskId);
+
+          expect(reopened!.status, terminalStatus);
+          expect(reopened.statusMessage, terminalTask!.statusMessage);
+          expect(reopened.lastUpdatedAt, terminalTask.lastUpdatedAt);
+        }
+      });
     });
 
     group('storeTaskResult', () {
@@ -173,6 +206,57 @@ void main() {
 
         final storedResult = await store.getTaskResult(task.taskId);
         expect(storedResult, isNotNull);
+      });
+
+      test('does not overwrite terminal task status or result', () async {
+        final task = await store.createTask(
+          const TaskCreationParams(),
+          1,
+          {},
+          null,
+        );
+
+        final firstResult = CallToolResult.fromContent([
+          const TextContent(text: 'first result'),
+        ]);
+        await store.storeTaskResult(
+          task.taskId,
+          TaskStatus.completed,
+          firstResult,
+        );
+
+        final terminalTask = await store.getTask(task.taskId);
+        final secondResult = CallToolResult.fromContent([
+          const TextContent(text: 'second result'),
+        ]);
+        await store.storeTaskResult(
+          task.taskId,
+          TaskStatus.failed,
+          secondResult,
+        );
+
+        final afterSecondResult = await store.getTask(task.taskId);
+        expect(afterSecondResult!.status, TaskStatus.completed);
+        expect(afterSecondResult.lastUpdatedAt, terminalTask!.lastUpdatedAt);
+        expect(await store.getTaskResult(task.taskId), same(firstResult));
+      });
+
+      test('does not store orphaned results for non-existent tasks', () async {
+        final result = CallToolResult.fromContent([
+          const TextContent(text: 'orphan result'),
+        ]);
+
+        await store.storeTaskResult(
+          'non-existent-task',
+          TaskStatus.completed,
+          result,
+        );
+
+        expect(await store.getTask('non-existent-task'), isNull);
+        await expectLater(
+          store.getTaskResult('non-existent-task'),
+          throwsA(isA<McpError>()),
+        );
       });
     });
 

--- a/test/shared/protocol_task_handlers_test.dart
+++ b/test/shared/protocol_task_handlers_test.dart
@@ -382,6 +382,98 @@ void main() {
       expect(errorResponse.error.message, contains('terminal status'));
     });
 
+    test('request task store ignores terminal result updates', () async {
+      await protocol.connect(transport);
+
+      final firstResult = CallToolResult.fromContent([
+        const TextContent(text: 'first result'),
+      ]);
+      taskStore.tasks['task-1'] = const Task(
+        taskId: 'task-1',
+        status: TaskStatus.completed,
+        createdAt: _taskCreatedAt,
+        lastUpdatedAt: _taskUpdatedAt,
+        ttl: null,
+      );
+      taskStore.results['task-1'] = firstResult;
+
+      protocol.setRequestHandler<JsonRpcRequest>(
+        'test/store-terminal-result',
+        (request, extra) async {
+          await extra.taskStore!.storeTaskResult(
+            'task-1',
+            TaskStatus.failed,
+            CallToolResult.fromContent([
+              const TextContent(text: 'second result'),
+            ]),
+          );
+          return const EmptyResult();
+        },
+        (id, params, meta) => JsonRpcRequest(
+          id: id,
+          method: 'test/store-terminal-result',
+          params: params,
+          meta: meta,
+        ),
+      );
+
+      transport.receiveMessage(
+        const JsonRpcRequest(id: 5, method: 'test/store-terminal-result'),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      expect(taskStore.tasks['task-1']?.status, TaskStatus.completed);
+      expect(taskStore.tasks['task-1']?.lastUpdatedAt, _taskUpdatedAt);
+      expect(taskStore.results['task-1'], same(firstResult));
+      expect(
+        transport.sentMessages.whereType<JsonRpcTaskStatusNotification>(),
+        isEmpty,
+      );
+      expect(transport.sentMessages.last, isA<JsonRpcResponse>());
+    });
+
+    test('request task store rejects result updates for missing tasks',
+        () async {
+      await protocol.connect(transport);
+
+      protocol.setRequestHandler<JsonRpcRequest>(
+        'test/store-missing-result',
+        (request, extra) async {
+          await extra.taskStore!.storeTaskResult(
+            'missing-task',
+            TaskStatus.completed,
+            CallToolResult.fromContent([
+              const TextContent(text: 'orphan result'),
+            ]),
+          );
+          return const EmptyResult();
+        },
+        (id, params, meta) => JsonRpcRequest(
+          id: id,
+          method: 'test/store-missing-result',
+          params: params,
+          meta: meta,
+        ),
+      );
+
+      transport.receiveMessage(
+        const JsonRpcRequest(id: 6, method: 'test/store-missing-result'),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      expect(taskStore.results.containsKey('missing-task'), isFalse);
+      final response = transport.sentMessages.last;
+      expect(response, isA<JsonRpcError>());
+      final errorResponse = response as JsonRpcError;
+      expect(errorResponse.error.code, ErrorCode.invalidParams.value);
+      expect(
+        errorResponse.error.message,
+        'Failed to store task result: Task not found',
+      );
+    });
+
     test('tasks/cancel handler clears message queue', () async {
       await protocol.connect(transport);
 


### PR DESCRIPTION
## Summary
- Enforce terminal task immutability so completed/failed/cancelled tasks ignore later status or result overwrites.
- Make `notifications/tasks/status` serialize/parse the full MCP `NotificationParams & Task` shape, including required `ttl`, `createdAt`, and `lastUpdatedAt` fields.
- Add TS-client ↔ Dart-server interop assertions for task wire shape and update migration/changelog docs.
- Address Copilot review feedback by using notification-specific parse error labels, task/status/statusMessage type validation, and preventing orphaned task results for missing task IDs.

Fixes #128

## Spec / compatibility notes
- Keeps task status notification wire shape aligned with the official TS SDK `TaskStatusNotificationSchema` (`NotificationParams & Task`).
- Preserves legacy Dart source construction for `TaskStatusNotificationParams`, but wire serialization now fails clearly if required task fields are missing.
- `ttl` remains required on the wire even when its value is `null`; `pollInterval` remains optional.
- Result writes for missing task IDs are rejected/ignored before they can create orphaned task result entries.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed lib/src/types/tasks.dart lib/src/server/tasks/store.dart lib/src/shared/protocol.dart test/mcp_2025_11_25_test.dart test/server/in_memory_task_store_test.dart test/shared/protocol_task_handlers_test.dart`
- [x] `dart analyze`
- [x] Focused #128 task/status regression tests
- [x] `dart test test/mcp_2025_11_25_test.dart test/server/in_memory_task_store_test.dart test/shared/protocol_task_handlers_test.dart --reporter compact`
- [x] `dart test test/interop/ts_client_with_dart_server_test.dart --tags interop`
- [x] `(cd test/interop/ts && npm run build)`
- [x] `npx --prefix test/interop/ts prettier --check test/interop/ts/src/client.ts`
- [x] Official TS SDK `TaskStatusNotificationSchema` required-field check
- [x] Full `dart test --reporter compact` (`+957 All tests passed`, before review-follow-up patch)
- [x] `git diff --check`

## Review notes
- Initial independent review found no blockers after the e2e/docs follow-up.
- Copilot review comments were addressed in the latest head: notification-specific `FormatException` labels (including task/status/statusMessage), `_RequestTaskStoreImpl` contextual missing-task rejection, and `InMemoryTaskStore` orphan-result prevention.
- Existing issue check: dedicated issue #128 covers this task terminal-state/status-field gap.
