### PR TITLE
fix(protocol): tighten RequestId, ProgressToken, and sampling capability validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Spec Alignment
 
+- Tightened MCP/JSON-RPC boundary validation for request IDs, progress tokens,
+  cancellation request IDs, and sampling tool-use capability gating so malformed
+  wire values and unsupported `sampling.tools` requests fail before handler code
+  runs.
 - Added MCP `completion/complete` wire support for
   `context.arguments` and `PromptReference.title`, including context-aware
   server completion callbacks for prompt and resource-template completions.

--- a/doc/migration_2025_11_25_compat.md
+++ b/doc/migration_2025_11_25_compat.md
@@ -29,6 +29,9 @@ This guide helps update existing code that used older sampling/tool-choice APIs.
   so valid task instances serialize without throwing.
 - Streamable HTTP defaults are stricter for protocol-version headers, DNS
   rebinding protection, and batch request rejection.
+- MCP/JSON-RPC wire parsing now rejects malformed request IDs, progress tokens,
+  and sampling tool-use requests that were not negotiated via
+  `ClientCapabilities.sampling.tools`.
 
 ## Runtime compatibility toggles
 

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -161,6 +161,14 @@ class McpClient extends Protocol {
               "No sampling handler registered",
             );
           }
+          if ((request.createParams.tools != null ||
+                  request.createParams.toolChoice != null) &&
+              _capabilities.sampling?.tools != true) {
+            throw McpError(
+              ErrorCode.invalidRequest.value,
+              "Client does not support 'sampling.tools' capability required by sampling/createMessage request.",
+            );
+          }
           return await onSamplingRequest!(request.createParams);
         },
         (id, params, meta) => JsonRpcCreateMessageRequest(

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -348,7 +348,7 @@ abstract class Protocol {
     setRequestHandler<JsonRpcPingRequest>(
       "ping",
       (request, extra) async => const EmptyResult(),
-      (id, params, meta) => JsonRpcPingRequest(id: id),
+      (id, params, meta) => JsonRpcPingRequest(id: id, meta: meta),
     );
 
     if (_taskStore != null) {

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -3,7 +3,12 @@ export 'types/resources.dart';
 export 'types/prompts.dart';
 export 'types/tools.dart';
 export 'types/tasks.dart';
-export 'types/json_rpc.dart';
+export 'types/json_rpc.dart'
+    hide
+        extractRequestMeta,
+        parseProgressToken,
+        parseRequestId,
+        validateRequestMeta;
 export 'types/mcp_ui.dart';
 export 'types/misc.dart';
 export 'types/initialization.dart';

--- a/lib/src/types/completion.dart
+++ b/lib/src/types/completion.dart
@@ -165,9 +165,9 @@ class JsonRpcCompleteRequest extends JsonRpcRequest {
     if (paramsMap == null) {
       throw const FormatException("Missing params for complete request");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcCompleteRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       completeParams: CompleteRequest.fromJson(paramsMap),
       meta: meta,
     );

--- a/lib/src/types/elicitation.dart
+++ b/lib/src/types/elicitation.dart
@@ -117,9 +117,9 @@ class JsonRpcElicitRequest extends JsonRpcRequest {
     if (paramsMap == null) {
       throw const FormatException("Missing params for elicit request");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcElicitRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       elicitParams: ElicitRequest.fromJson(paramsMap),
       meta: meta,
     );

--- a/lib/src/types/initialization.dart
+++ b/lib/src/types/initialization.dart
@@ -482,9 +482,9 @@ class JsonRpcInitializeRequest extends JsonRpcRequest {
     if (paramsMap == null) {
       throw const FormatException("Missing params for initialize request");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcInitializeRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       initParams: InitializeRequest.fromJson(paramsMap),
       meta: meta,
     );

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -111,6 +111,15 @@ RequestId parseRequestId(Object? value, {String fieldName = 'id'}) {
   );
 }
 
+RequestId? _parseResponseId(Object? value) {
+  if (value == null || value is String || value is int) {
+    return value;
+  }
+  throw FormatException(
+    'Invalid id: expected string, integer, or null, got ${value.runtimeType}',
+  );
+}
+
 /// Validates request metadata that can affect protocol behavior.
 ///
 /// `_meta.progressToken` is an MCP wire token and must be a string or integer
@@ -238,7 +247,7 @@ sealed class JsonRpcMessage {
         };
       }
     } else if (json.containsKey('result')) {
-      final id = json['id'];
+      final id = _parseResponseId(json['id']);
       final resultData = json['result'] as Map<String, dynamic>;
       final meta = resultData['_meta'] as Map<String, dynamic>?;
       final actualResult = Map<String, dynamic>.from(resultData)
@@ -403,7 +412,7 @@ class JsonRpcError extends JsonRpcMessage {
   const JsonRpcError({required this.id, required this.error});
 
   factory JsonRpcError.fromJson(Map<String, dynamic> json) => JsonRpcError(
-        id: json['id'],
+        id: _parseResponseId(json['id']),
         error: JsonRpcErrorData.fromJson(json['error'] as Map<String, dynamic>),
       );
 

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -122,15 +122,26 @@ Map<String, dynamic>? validateRequestMeta(Map<String, dynamic>? meta) {
   return meta;
 }
 
+Map<String, dynamic>? _parseRequestMeta(Object? value) {
+  if (value == null) {
+    return null;
+  }
+  if (value is! Map) {
+    throw FormatException(
+      'Invalid _meta: expected object, got ${value.runtimeType}',
+    );
+  }
+  if (value.keys.any((key) => key is! String)) {
+    throw const FormatException('Invalid _meta: expected string keys');
+  }
+  return validateRequestMeta(Map<String, dynamic>.from(value));
+}
+
 /// Extracts request metadata from either top-level or params-nested `_meta`.
 Map<String, dynamic>? extractRequestMeta(Map<String, dynamic> json) {
-  final topLevelMeta = validateRequestMeta(
-    json['_meta'] as Map<String, dynamic>?,
-  );
+  final topLevelMeta = _parseRequestMeta(json['_meta']);
   final params = json['params'];
-  final paramsMeta = params is Map<String, dynamic>
-      ? validateRequestMeta(params['_meta'] as Map<String, dynamic>?)
-      : null;
+  final paramsMeta = params is Map ? _parseRequestMeta(params['_meta']) : null;
   return topLevelMeta ?? paramsMeta;
 }
 

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -126,7 +126,10 @@ RequestId? _parseResponseId(Object? value) {
 /// when present. Other `_meta` fields are preserved without interpretation.
 Map<String, dynamic>? validateRequestMeta(Map<String, dynamic>? meta) {
   if (meta != null && meta.containsKey('progressToken')) {
-    parseProgressToken(meta['progressToken']);
+    parseProgressToken(
+      meta['progressToken'],
+      fieldName: '_meta.progressToken',
+    );
   }
   return meta;
 }
@@ -171,7 +174,6 @@ sealed class JsonRpcMessage {
     if (json.containsKey('method')) {
       final method = json['method'] as String;
       final hasId = json.containsKey('id');
-      final id = hasId ? parseRequestId(json['id']) : null;
 
       if (hasId) {
         return switch (method) {
@@ -200,7 +202,7 @@ sealed class JsonRpcMessage {
           Method.tasksGet => JsonRpcGetTaskRequest.fromJson(json),
           Method.tasksResult => JsonRpcTaskResultRequest.fromJson(json),
           _ => JsonRpcRequest(
-              id: id,
+              id: parseRequestId(json['id']),
               method: method,
               params: json['params'] as Map<String, dynamic>?,
               meta: extractRequestMeta(json),

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -74,11 +74,65 @@ class Method {
 /// A progress token, used to associate progress notifications with the original request.
 typedef ProgressToken = dynamic;
 
+/// Parses a wire progress token.
+///
+/// MCP progress tokens are JSON strings or integers. Reject malformed wire
+/// shapes at decode boundaries instead of allowing dynamic values to leak into
+/// higher-level protocol code.
+ProgressToken parseProgressToken(
+  Object? value, {
+  String fieldName = 'progressToken',
+}) {
+  if (value is String || value is int) {
+    return value;
+  }
+  throw FormatException(
+    'Invalid $fieldName: expected string or integer, got ${value.runtimeType}',
+  );
+}
+
 /// An opaque token used to represent a cursor for pagination.
 typedef Cursor = String;
 
 /// A uniquely identifying ID for a request in JSON-RPC.
 typedef RequestId = dynamic;
+
+/// Parses a JSON-RPC request identifier.
+///
+/// JSON-RPC/MCP request IDs are JSON strings or integers for SDK request
+/// boundaries. Notifications omit the `id` member entirely, and responses may
+/// still carry `null` IDs for JSON-RPC error cases.
+RequestId parseRequestId(Object? value, {String fieldName = 'id'}) {
+  if (value is String || value is int) {
+    return value;
+  }
+  throw FormatException(
+    'Invalid $fieldName: expected string or integer, got ${value.runtimeType}',
+  );
+}
+
+/// Validates request metadata that can affect protocol behavior.
+///
+/// `_meta.progressToken` is an MCP wire token and must be a string or integer
+/// when present. Other `_meta` fields are preserved without interpretation.
+Map<String, dynamic>? validateRequestMeta(Map<String, dynamic>? meta) {
+  if (meta != null && meta.containsKey('progressToken')) {
+    parseProgressToken(meta['progressToken']);
+  }
+  return meta;
+}
+
+/// Extracts request metadata from either top-level or params-nested `_meta`.
+Map<String, dynamic>? extractRequestMeta(Map<String, dynamic> json) {
+  final topLevelMeta = validateRequestMeta(
+    json['_meta'] as Map<String, dynamic>?,
+  );
+  final params = json['params'];
+  final paramsMeta = params is Map<String, dynamic>
+      ? validateRequestMeta(params['_meta'] as Map<String, dynamic>?)
+      : null;
+  return topLevelMeta ?? paramsMeta;
+}
 
 /// Base class for all JSON-RPC messages (requests, notifications, responses, errors).
 sealed class JsonRpcMessage {
@@ -94,12 +148,12 @@ sealed class JsonRpcMessage {
       throw FormatException('Invalid JSON-RPC version: ${json['jsonrpc']}');
     }
 
-    final id = json['id'];
-
     if (json.containsKey('method')) {
       final method = json['method'] as String;
+      final hasId = json.containsKey('id');
+      final id = hasId ? parseRequestId(json['id']) : null;
 
-      if (id != null) {
+      if (hasId) {
         return switch (method) {
           Method.initialize => JsonRpcInitializeRequest.fromJson(json),
           Method.ping => JsonRpcPingRequest.fromJson(json),
@@ -129,9 +183,7 @@ sealed class JsonRpcMessage {
               id: id,
               method: method,
               params: json['params'] as Map<String, dynamic>?,
-              meta: json['_meta'] as Map<String, dynamic>? ??
-                  (json['params'] as Map<String, dynamic>?)?['_meta']
-                      as Map<String, dynamic>?,
+              meta: extractRequestMeta(json),
             ),
         };
       } else {
@@ -175,6 +227,7 @@ sealed class JsonRpcMessage {
         };
       }
     } else if (json.containsKey('result')) {
+      final id = json['id'];
       final resultData = json['result'] as Map<String, dynamic>;
       final meta = resultData['_meta'] as Map<String, dynamic>?;
       final actualResult = Map<String, dynamic>.from(resultData)
@@ -214,7 +267,10 @@ class JsonRpcRequest extends JsonRpcMessage {
   });
 
   /// The progress token for out-of-band progress notifications.
-  ProgressToken? get progressToken => meta?['progressToken'];
+  ProgressToken? get progressToken {
+    final token = meta?['progressToken'];
+    return token == null ? null : parseProgressToken(token);
+  }
 
   @override
   Map<String, dynamic> toJson() => {
@@ -400,9 +456,9 @@ class JsonRpcListToolsRequest extends JsonRpcRequest {
 
   factory JsonRpcListToolsRequest.fromJson(Map<String, dynamic> json) {
     return JsonRpcListToolsRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       params: json['params'] as Map<String, dynamic>?,
-      meta: json['_meta'] as Map<String, dynamic>?,
+      meta: extractRequestMeta(json),
     );
   }
 
@@ -425,11 +481,9 @@ class JsonRpcCallToolRequest extends JsonRpcRequest {
 
   factory JsonRpcCallToolRequest.fromJson(Map<String, dynamic> json) {
     return JsonRpcCallToolRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       params: json['params'] as Map<String, dynamic>? ?? {},
-      meta: json['_meta'] as Map<String, dynamic>? ??
-          (json['params'] as Map<String, dynamic>?)?['_meta']
-              as Map<String, dynamic>?,
+      meta: extractRequestMeta(json),
     );
   }
 

--- a/lib/src/types/logging.dart
+++ b/lib/src/types/logging.dart
@@ -43,9 +43,9 @@ class JsonRpcSetLevelRequest extends JsonRpcRequest {
     if (paramsMap == null) {
       throw const FormatException("Missing params for set level request");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcSetLevelRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       setParams: SetLevelRequest.fromJson(paramsMap),
       meta: meta,
     );

--- a/lib/src/types/misc.dart
+++ b/lib/src/types/misc.dart
@@ -23,7 +23,7 @@ class CancelledNotification {
 
   factory CancelledNotification.fromJson(Map<String, dynamic> json) =>
       CancelledNotification(
-        requestId: json['requestId'],
+        requestId: parseRequestId(json['requestId'], fieldName: 'requestId'),
         reason: json['reason'] as String?,
       );
 
@@ -59,10 +59,15 @@ class JsonRpcCancelledNotification extends JsonRpcNotification {
 
 /// A ping request, sent by either side to check liveness. Expects an empty result.
 class JsonRpcPingRequest extends JsonRpcRequest {
-  const JsonRpcPingRequest({required super.id}) : super(method: Method.ping);
+  const JsonRpcPingRequest({required super.id, super.meta})
+      : super(method: Method.ping);
 
-  factory JsonRpcPingRequest.fromJson(Map<String, dynamic> json) =>
-      JsonRpcPingRequest(id: json['id']);
+  factory JsonRpcPingRequest.fromJson(Map<String, dynamic> json) {
+    return JsonRpcPingRequest(
+      id: parseRequestId(json['id']),
+      meta: extractRequestMeta(json),
+    );
+  }
 }
 
 /// Represents progress information for a long-running request.
@@ -124,7 +129,7 @@ class ProgressNotification implements Progress {
   factory ProgressNotification.fromJson(Map<String, dynamic> json) {
     final progressData = Progress.fromJson(json);
     return ProgressNotification(
-      progressToken: json['progressToken'],
+      progressToken: parseProgressToken(json['progressToken']),
       progress: progressData.progress,
       total: progressData.total,
       message: progressData.message,

--- a/lib/src/types/prompts.dart
+++ b/lib/src/types/prompts.dart
@@ -1,4 +1,5 @@
 import '../types.dart';
+import 'json_rpc.dart';
 
 /// Describes an argument accepted by a prompt template.
 class PromptArgument {
@@ -129,9 +130,9 @@ class JsonRpcListPromptsRequest extends JsonRpcRequest {
 
   factory JsonRpcListPromptsRequest.fromJson(Map<String, dynamic> json) {
     final paramsMap = json['params'] as Map<String, dynamic>?;
-    final meta = paramsMap?['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcListPromptsRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       params: paramsMap == null ? null : ListPromptsRequest.fromJson(paramsMap),
       meta: meta,
     );
@@ -211,9 +212,9 @@ class JsonRpcGetPromptRequest extends JsonRpcRequest {
     if (paramsMap == null) {
       throw const FormatException("Missing params for get prompt request");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcGetPromptRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       getParams: GetPromptRequest.fromJson(paramsMap),
       meta: meta,
     );

--- a/lib/src/types/resources.dart
+++ b/lib/src/types/resources.dart
@@ -1,4 +1,5 @@
 import '../types.dart';
+import 'json_rpc.dart';
 
 /// Additional properties describing a Resource to clients.
 class ResourceAnnotations {
@@ -229,9 +230,9 @@ class JsonRpcListResourcesRequest extends JsonRpcRequest {
   /// Creates from JSON.
   factory JsonRpcListResourcesRequest.fromJson(Map<String, dynamic> json) {
     final paramsMap = json['params'] as Map<String, dynamic>?;
-    final meta = paramsMap?['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcListResourcesRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       params:
           paramsMap == null ? null : ListResourcesRequest.fromJson(paramsMap),
       meta: meta,
@@ -310,9 +311,9 @@ class JsonRpcListResourceTemplatesRequest extends JsonRpcRequest {
     Map<String, dynamic> json,
   ) {
     final paramsMap = json['params'] as Map<String, dynamic>?;
-    final meta = paramsMap?['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcListResourceTemplatesRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       params: paramsMap == null
           ? null
           : ListResourceTemplatesRequest.fromJson(paramsMap),
@@ -386,9 +387,9 @@ class JsonRpcReadResourceRequest extends JsonRpcRequest {
     if (paramsMap == null) {
       throw const FormatException("Missing params for read resource request");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcReadResourceRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       readParams: ReadResourceRequest.fromJson(paramsMap),
       meta: meta,
     );
@@ -462,9 +463,9 @@ class JsonRpcSubscribeRequest extends JsonRpcRequest {
     if (paramsMap == null) {
       throw const FormatException("Missing params for subscribe request");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcSubscribeRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       subParams: SubscribeRequest.fromJson(paramsMap),
       meta: meta,
     );
@@ -500,9 +501,9 @@ class JsonRpcUnsubscribeRequest extends JsonRpcRequest {
     if (paramsMap == null) {
       throw const FormatException("Missing params for unsubscribe request");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcUnsubscribeRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       unsubParams: UnsubscribeRequest.fromJson(paramsMap),
       meta: meta,
     );

--- a/lib/src/types/roots.dart
+++ b/lib/src/types/roots.dart
@@ -28,11 +28,15 @@ class Root {
 
 /// Request sent from server to client to get the list of root URIs.
 class JsonRpcListRootsRequest extends JsonRpcRequest {
-  const JsonRpcListRootsRequest({required super.id})
+  const JsonRpcListRootsRequest({required super.id, super.meta})
       : super(method: Method.rootsList);
 
-  factory JsonRpcListRootsRequest.fromJson(Map<String, dynamic> json) =>
-      JsonRpcListRootsRequest(id: json['id']);
+  factory JsonRpcListRootsRequest.fromJson(Map<String, dynamic> json) {
+    return JsonRpcListRootsRequest(
+      id: parseRequestId(json['id']),
+      meta: extractRequestMeta(json),
+    );
+  }
 }
 
 /// Result data for a successful `roots/list` request.

--- a/lib/src/types/sampling.dart
+++ b/lib/src/types/sampling.dart
@@ -632,9 +632,9 @@ class JsonRpcCreateMessageRequest extends JsonRpcRequest {
     if (paramsMap == null) {
       throw const FormatException("Missing params for create message request");
     }
-    final meta = _asJsonObjectOrNull(paramsMap['_meta']);
+    final meta = extractRequestMeta(json);
     return JsonRpcCreateMessageRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       createParams: CreateMessageRequest.fromJson(paramsMap),
       meta: meta,
     );

--- a/lib/src/types/tasks.dart
+++ b/lib/src/types/tasks.dart
@@ -1,4 +1,5 @@
 import '../types.dart';
+import 'json_rpc.dart';
 
 /// The current state of a task execution.
 enum TaskStatus {
@@ -203,9 +204,9 @@ class JsonRpcListTasksRequest extends JsonRpcRequest {
 
   factory JsonRpcListTasksRequest.fromJson(Map<String, dynamic> json) {
     final paramsMap = json['params'] as Map<String, dynamic>?;
-    final meta = paramsMap?['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcListTasksRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       params: paramsMap == null ? null : ListTasksRequest.fromJson(paramsMap),
       meta: meta,
     );
@@ -274,9 +275,9 @@ class JsonRpcCancelTaskRequest extends JsonRpcRequest {
     if (paramsMap == null) {
       throw const FormatException("Missing params for cancel task request");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcCancelTaskRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       cancelParams: CancelTaskRequest.fromJson(paramsMap),
       meta: meta,
     );
@@ -312,9 +313,9 @@ class JsonRpcGetTaskRequest extends JsonRpcRequest {
     if (paramsMap == null) {
       throw const FormatException("Missing params for get task request");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcGetTaskRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       getParams: GetTaskRequest.fromJson(paramsMap),
       meta: meta,
     );
@@ -350,9 +351,9 @@ class JsonRpcTaskResultRequest extends JsonRpcRequest {
     if (paramsMap == null) {
       throw const FormatException("Missing params for task result request");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = extractRequestMeta(json);
     return JsonRpcTaskResultRequest(
-      id: json['id'],
+      id: parseRequestId(json['id']),
       resultParams: TaskResultRequest.fromJson(paramsMap),
       meta: meta,
     );

--- a/test/client/client_test.dart
+++ b/test/client/client_test.dart
@@ -1105,6 +1105,169 @@ void _addCriticalPathTests() {
       );
     });
 
+    test('sampling tools request requires sampling.tools capability', () async {
+      final client = Client(
+        const Implementation(name: 'TestClient', version: '1.0.0'),
+        options: const McpClientOptions(
+          capabilities: ClientCapabilities(
+            sampling: ClientCapabilitiesSampling(),
+          ),
+        ),
+      );
+      final transport = MockTransport()
+        ..mockInitializeResponse = const InitializeResult(
+          protocolVersion: latestProtocolVersion,
+          capabilities: ServerCapabilities(),
+          serverInfo: Implementation(name: 'TestServer', version: '2.0.0'),
+        );
+      var handlerCalled = false;
+      client.onSamplingRequest = (params) async {
+        handlerCalled = true;
+        return const CreateMessageResult(
+          model: 'test-model',
+          role: SamplingMessageRole.assistant,
+          content: SamplingTextContent(text: 'response'),
+        );
+      };
+
+      await client.connect(transport);
+      transport.clearSentMessages();
+
+      transport.receiveMessage(
+        JsonRpcCreateMessageRequest(
+          id: 'sample-1',
+          createParams: const CreateMessageRequest(
+            messages: [
+              SamplingMessage(
+                role: SamplingMessageRole.user,
+                content: SamplingTextContent(text: 'Use a tool'),
+              ),
+            ],
+            maxTokens: 32,
+            tools: [
+              Tool(name: 'search', inputSchema: JsonObject()),
+            ],
+          ),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(handlerCalled, isFalse);
+      expect(transport.sentMessages.single, isA<JsonRpcError>());
+      final error = transport.sentMessages.single as JsonRpcError;
+      expect(error.id, 'sample-1');
+      expect(error.error.code, ErrorCode.invalidRequest.value);
+      expect(error.error.message, contains('sampling.tools'));
+    });
+
+    test('sampling toolChoice request requires sampling.tools capability',
+        () async {
+      final client = Client(
+        const Implementation(name: 'TestClient', version: '1.0.0'),
+        options: const McpClientOptions(
+          capabilities: ClientCapabilities(
+            sampling: ClientCapabilitiesSampling(),
+          ),
+        ),
+      );
+      final transport = MockTransport()
+        ..mockInitializeResponse = const InitializeResult(
+          protocolVersion: latestProtocolVersion,
+          capabilities: ServerCapabilities(),
+          serverInfo: Implementation(name: 'TestServer', version: '2.0.0'),
+        );
+      var handlerCalled = false;
+      client.onSamplingRequest = (params) async {
+        handlerCalled = true;
+        return const CreateMessageResult(
+          model: 'test-model',
+          role: SamplingMessageRole.assistant,
+          content: SamplingTextContent(text: 'response'),
+        );
+      };
+
+      await client.connect(transport);
+      transport.clearSentMessages();
+
+      transport.receiveMessage(
+        JsonRpcCreateMessageRequest(
+          id: 7,
+          createParams: const CreateMessageRequest(
+            messages: [
+              SamplingMessage(
+                role: SamplingMessageRole.user,
+                content: SamplingTextContent(text: 'Choose a tool'),
+              ),
+            ],
+            maxTokens: 32,
+            toolChoice: ToolChoice(mode: ToolChoiceMode.auto),
+          ),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(handlerCalled, isFalse);
+      expect(transport.sentMessages.single, isA<JsonRpcError>());
+      final error = transport.sentMessages.single as JsonRpcError;
+      expect(error.id, 7);
+      expect(error.error.code, ErrorCode.invalidRequest.value);
+      expect(error.error.message, contains('sampling.tools'));
+    });
+
+    test('sampling tools request succeeds when sampling.tools is declared',
+        () async {
+      final client = Client(
+        const Implementation(name: 'TestClient', version: '1.0.0'),
+        options: const McpClientOptions(
+          capabilities: ClientCapabilities(
+            sampling: ClientCapabilitiesSampling(tools: true),
+          ),
+        ),
+      );
+      final transport = MockTransport()
+        ..mockInitializeResponse = const InitializeResult(
+          protocolVersion: latestProtocolVersion,
+          capabilities: ServerCapabilities(),
+          serverInfo: Implementation(name: 'TestServer', version: '2.0.0'),
+        );
+      var handlerCalled = false;
+      client.onSamplingRequest = (params) async {
+        handlerCalled = true;
+        expect(params.tools?.single.name, 'search');
+        return const CreateMessageResult(
+          model: 'test-model',
+          role: SamplingMessageRole.assistant,
+          content: SamplingTextContent(text: 'response'),
+        );
+      };
+
+      await client.connect(transport);
+      transport.clearSentMessages();
+
+      transport.receiveMessage(
+        JsonRpcCreateMessageRequest(
+          id: 'sample-2',
+          createParams: const CreateMessageRequest(
+            messages: [
+              SamplingMessage(
+                role: SamplingMessageRole.user,
+                content: SamplingTextContent(text: 'Use a tool'),
+              ),
+            ],
+            maxTokens: 32,
+            tools: [
+              Tool(name: 'search', inputSchema: JsonObject()),
+            ],
+          ),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(handlerCalled, isTrue);
+      expect(transport.sentMessages.single, isA<JsonRpcResponse>());
+      expect((transport.sentMessages.single as JsonRpcResponse).id, 'sample-2');
+    });
+
     test('elicitation/create handler requires elicitation capability', () {
       final client = Client(
         const Implementation(name: 'TestClient', version: '1.0.0'),

--- a/test/server/stdio_test.dart
+++ b/test/server/stdio_test.dart
@@ -396,6 +396,25 @@ void main() {
             },
           },
         ),
+        (
+          field: 'id',
+          message: {
+            'jsonrpc': '2.0',
+            'id': false,
+            'result': <String, dynamic>{},
+          },
+        ),
+        (
+          field: 'id',
+          message: {
+            'jsonrpc': '2.0',
+            'id': <Object>[],
+            'error': {
+              'code': -32600,
+              'message': 'Invalid request',
+            },
+          },
+        ),
       ];
 
       for (final vector in vectors) {

--- a/test/server/stdio_test.dart
+++ b/test/server/stdio_test.dart
@@ -365,6 +365,17 @@ void main() {
           },
         ),
         (
+          field: '_meta',
+          message: {
+            'jsonrpc': '2.0',
+            'id': 'with-bad-meta-shape',
+            'method': 'ping',
+            'params': {
+              '_meta': false,
+            },
+          },
+        ),
+        (
           field: 'progressToken',
           message: {
             'jsonrpc': '2.0',

--- a/test/server/stdio_test.dart
+++ b/test/server/stdio_test.dart
@@ -333,6 +333,128 @@ void main() {
       expect(receivedError, isNotNull);
     });
 
+    test('rejects malformed MCP wire values from raw stdio input', () async {
+      final vectors = <({String field, Map<String, dynamic> message})>[
+        (
+          field: 'id',
+          message: {
+            'jsonrpc': '2.0',
+            'id': false,
+            'method': 'ping',
+          },
+        ),
+        (
+          field: 'id',
+          message: {
+            'jsonrpc': '2.0',
+            'id': null,
+            'method': 'ping',
+          },
+        ),
+        (
+          field: 'progressToken',
+          message: {
+            'jsonrpc': '2.0',
+            'id': 'with-bad-meta',
+            'method': 'ping',
+            'params': {
+              '_meta': {
+                'progressToken': <String, dynamic>{},
+              },
+            },
+          },
+        ),
+        (
+          field: 'progressToken',
+          message: {
+            'jsonrpc': '2.0',
+            'method': 'notifications/progress',
+            'params': {
+              'progressToken': <Object>[],
+              'progress': 0,
+            },
+          },
+        ),
+        (
+          field: 'requestId',
+          message: {
+            'jsonrpc': '2.0',
+            'method': 'notifications/cancelled',
+            'params': {
+              'requestId': true,
+            },
+          },
+        ),
+      ];
+
+      for (final vector in vectors) {
+        final localStdin = MockStdin();
+        final localStdout = MockStdout();
+        final localTransport = StdioServerTransport(
+          stdin: localStdin,
+          stdout: localStdout,
+        );
+        final receivedMessages = <JsonRpcMessage>[];
+        final receivedErrors = <Error>[];
+        localTransport
+          ..onmessage = receivedMessages.add
+          ..onerror = receivedErrors.add;
+
+        await localTransport.start();
+        localStdin.addString('${jsonEncode(vector.message)}\n');
+        await Future.delayed(const Duration(milliseconds: 50));
+        await localTransport.close();
+
+        expect(
+          receivedMessages,
+          isEmpty,
+          reason: 'Malformed ${vector.field} should not reach handlers',
+        );
+        expect(receivedErrors, hasLength(1));
+        expect(receivedErrors.single.toString(), contains(vector.field));
+      }
+    });
+
+    test('preserves valid MCP wire IDs and tokens from raw stdio input',
+        () async {
+      final receivedMessages = <JsonRpcMessage>[];
+      transport.onmessage = receivedMessages.add;
+
+      await transport.start();
+
+      stdin.addString(
+        '${jsonEncode({
+              'jsonrpc': '2.0',
+              'id': 'request-1',
+              'method': 'ping',
+              'params': {
+                '_meta': {'progressToken': 'progress-1'},
+              },
+            })}\n',
+      );
+      stdin.addString(
+        '${jsonEncode({
+              'jsonrpc': '2.0',
+              'id': 2,
+              'method': 'ping',
+              'params': {
+                '_meta': {'progressToken': 3},
+              },
+            })}\n',
+      );
+
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      expect(receivedMessages, hasLength(2));
+      expect((receivedMessages[0] as JsonRpcPingRequest).id, 'request-1');
+      expect(
+        (receivedMessages[0] as JsonRpcPingRequest).progressToken,
+        'progress-1',
+      );
+      expect((receivedMessages[1] as JsonRpcPingRequest).id, 2);
+      expect((receivedMessages[1] as JsonRpcPingRequest).progressToken, 3);
+    });
+
     test('calls onclose when stdin closes', () async {
       var oncloseCalled = false;
       transport.onclose = () {

--- a/test/shared/protocol_advanced_scenarios_test.dart
+++ b/test/shared/protocol_advanced_scenarios_test.dart
@@ -114,9 +114,10 @@ void main() {
 
       await Future.delayed(const Duration(milliseconds: 50));
 
-      // Should have received an error
+      // Should have received a protocol decode error at the boundary.
       expect(errors.length, greaterThan(0));
-      expect(errors.first, isA<ArgumentError>());
+      expect(errors.first, isA<StateError>());
+      expect(errors.first.toString(), contains('progressToken'));
     });
 
     test('request with timeout times out correctly', () async {

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -337,6 +337,38 @@ void main() {
       }
     });
 
+    test('rejects malformed request _meta wire values', () {
+      for (final meta in [false, 1, 'not-meta', <Object>[]]) {
+        expect(
+          () => JsonRpcMessage.fromJson({
+            'jsonrpc': '2.0',
+            'id': 'request-1',
+            'method': 'unknown/request',
+            'params': {
+              '_meta': meta,
+            },
+          }),
+          throwsA(
+            isA<FormatException>()
+                .having((e) => e.message, 'message', contains('_meta')),
+          ),
+        );
+      }
+
+      expect(
+        () => JsonRpcMessage.fromJson({
+          'jsonrpc': '2.0',
+          'id': 'request-1',
+          'method': 'unknown/request',
+          '_meta': false,
+        }),
+        throwsA(
+          isA<FormatException>()
+              .having((e) => e.message, 'message', contains('_meta')),
+        ),
+      );
+    });
+
     test('preserves string and integer request progressToken wire values', () {
       for (final token in <Object>[123, 'progress-123']) {
         final message = JsonRpcMessage.fromJson({

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -89,6 +89,39 @@ void main() {
       expect(json.containsKey('reason'), isFalse);
     });
 
+    test('rejects malformed requestId wire values', () {
+      for (final requestId in [null, true, <String, dynamic>{}, <Object>[]]) {
+        expect(
+          () => JsonRpcCancelledNotification.fromJson({
+            'jsonrpc': '2.0',
+            'method': 'notifications/cancelled',
+            'params': {
+              'requestId': requestId,
+            },
+          }),
+          throwsA(
+            isA<FormatException>()
+                .having((e) => e.message, 'message', contains('requestId')),
+          ),
+        );
+      }
+    });
+
+    test('preserves string and integer requestId wire values', () {
+      for (final requestId in <Object>[123, 'request-123']) {
+        final notification = JsonRpcCancelledNotification.fromJson({
+          'jsonrpc': '2.0',
+          'method': 'notifications/cancelled',
+          'params': {
+            'requestId': requestId,
+          },
+        });
+
+        expect(notification.cancelParams.requestId, requestId);
+        expect(notification.toJson()['params']['requestId'], requestId);
+      }
+    });
+
     test('handles meta field in cancelled notification', () {
       final json = {
         'jsonrpc': '2.0',
@@ -178,6 +211,49 @@ void main() {
       expect(json.containsKey('total'), isFalse);
     });
 
+    test('rejects malformed progressToken wire values', () {
+      for (final progressToken in [
+        null,
+        false,
+        <String, dynamic>{},
+        <Object>[],
+      ]) {
+        expect(
+          () => JsonRpcProgressNotification.fromJson({
+            'jsonrpc': '2.0',
+            'method': 'notifications/progress',
+            'params': {
+              'progressToken': progressToken,
+              'progress': 1,
+            },
+          }),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('progressToken'),
+            ),
+          ),
+        );
+      }
+    });
+
+    test('preserves string and integer progressToken wire values', () {
+      for (final progressToken in <Object>[123, 'progress-123']) {
+        final notification = JsonRpcProgressNotification.fromJson({
+          'jsonrpc': '2.0',
+          'method': 'notifications/progress',
+          'params': {
+            'progressToken': progressToken,
+            'progress': 1,
+          },
+        });
+
+        expect(notification.progressParams.progressToken, progressToken);
+        expect(notification.toJson()['params']['progressToken'], progressToken);
+      }
+    });
+
     test('handles meta field in progress notification', () {
       final json = {
         'jsonrpc': '2.0',
@@ -210,6 +286,96 @@ void main() {
         (message as JsonRpcNotification).method,
         equals('notifications/unknown'),
       );
+    });
+
+    test('rejects malformed request id wire values', () {
+      for (final id in [null, false, 1.5, <String, dynamic>{}, <Object>[]]) {
+        expect(
+          () => JsonRpcMessage.fromJson({
+            'jsonrpc': '2.0',
+            'id': id,
+            'method': 'unknown/request',
+          }),
+          throwsA(
+            isA<FormatException>()
+                .having((e) => e.message, 'message', contains('id')),
+          ),
+        );
+      }
+    });
+
+    test('preserves string and integer request ids', () {
+      for (final id in <Object>[123, 'request-123']) {
+        final message = JsonRpcMessage.fromJson({
+          'jsonrpc': '2.0',
+          'id': id,
+          'method': 'unknown/request',
+        });
+
+        expect(message, isA<JsonRpcRequest>());
+        expect((message as JsonRpcRequest).id, id);
+        expect(message.toJson()['id'], id);
+      }
+    });
+
+    test('rejects malformed request progressToken wire values', () {
+      for (final token in [null, false, 1.5, <String, dynamic>{}, <Object>[]]) {
+        expect(
+          () => JsonRpcMessage.fromJson({
+            'jsonrpc': '2.0',
+            'id': 'request-1',
+            'method': 'unknown/request',
+            'params': {
+              '_meta': {'progressToken': token},
+            },
+          }),
+          throwsA(
+            isA<FormatException>()
+                .having((e) => e.message, 'message', contains('progressToken')),
+          ),
+        );
+      }
+    });
+
+    test('preserves string and integer request progressToken wire values', () {
+      for (final token in <Object>[123, 'progress-123']) {
+        final message = JsonRpcMessage.fromJson({
+          'jsonrpc': '2.0',
+          'id': 'request-1',
+          'method': 'unknown/request',
+          'params': {
+            '_meta': {'progressToken': token},
+          },
+        });
+
+        expect(message, isA<JsonRpcRequest>());
+        expect((message as JsonRpcRequest).progressToken, token);
+        expect(message.toJson()['params']['_meta']['progressToken'], token);
+      }
+    });
+
+    test('preserves request progressToken on typed no-params requests', () {
+      for (final entry in <String, Type>{
+        Method.ping: JsonRpcPingRequest,
+        Method.rootsList: JsonRpcListRootsRequest,
+      }.entries) {
+        final message = JsonRpcMessage.fromJson({
+          'jsonrpc': '2.0',
+          'id': 'request-1',
+          'method': entry.key,
+          'params': {
+            '_meta': {'progressToken': 'progress-123'},
+          },
+        });
+
+        expect(message, isA<JsonRpcRequest>());
+        expect(message.runtimeType, entry.value);
+        expect((message as JsonRpcRequest).progressToken, 'progress-123');
+        expect(
+          message.toJson()['params']['_meta']['progressToken'],
+          'progress-123',
+        );
+      }
     });
 
     test('handles response with null id', () {

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -330,8 +330,11 @@ void main() {
             },
           }),
           throwsA(
-            isA<FormatException>()
-                .having((e) => e.message, 'message', contains('progressToken')),
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('_meta.progressToken'),
+            ),
           ),
         );
       }

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -422,6 +422,22 @@ void main() {
       expect((message as JsonRpcResponse).id, isNull);
     });
 
+    test('rejects malformed response id wire values', () {
+      for (final id in [false, 1.5, <String, dynamic>{}, <Object>[]]) {
+        expect(
+          () => JsonRpcMessage.fromJson({
+            'jsonrpc': '2.0',
+            'id': id,
+            'result': {'data': 'test'},
+          }),
+          throwsA(
+            isA<FormatException>()
+                .having((e) => e.message, 'message', contains('id')),
+          ),
+        );
+      }
+    });
+
     test('handles error with null id', () {
       final json = {
         'jsonrpc': '2.0',
@@ -432,6 +448,22 @@ void main() {
       final message = JsonRpcMessage.fromJson(json);
       expect(message, isA<JsonRpcError>());
       expect((message as JsonRpcError).id, isNull);
+    });
+
+    test('rejects malformed error id wire values', () {
+      for (final id in [false, 1.5, <String, dynamic>{}, <Object>[]]) {
+        expect(
+          () => JsonRpcMessage.fromJson({
+            'jsonrpc': '2.0',
+            'id': id,
+            'error': {'code': -32600, 'message': 'Error'},
+          }),
+          throwsA(
+            isA<FormatException>()
+                .having((e) => e.message, 'message', contains('id')),
+          ),
+        );
+      }
     });
 
     test('handles response with nested _meta in result', () {


### PR DESCRIPTION
## Summary
- Validate MCP/JSON-RPC wire request IDs, cancellation request IDs, progress tokens, and request `_meta.progressToken` as string/integer values.
- Preserve valid string/integer IDs and tokens while keeping JSON-RPC response/error `id: null` behavior intact.
- Reject tool-enabled `sampling/createMessage` requests unless the client declared `sampling.tools`.
- Add parser/protocol/client regressions plus raw stdio wire tests for malformed JSON-RPC payloads.
- Document the compatibility-sensitive stricter parsing behavior in changelog and migration notes.

Fixes #129

## Public API / compatibility
- No intentional breaking public API signature/type changes.
- Two optional `meta` constructor parameters were added for no-params request types (`ping`, `roots/list`) to preserve request metadata; existing calls remain source-compatible.
- Runtime parsing is intentionally stricter for spec-invalid wire values. Malformed request IDs/progress tokens now fail earlier instead of reaching handlers.
- Validation helper functions are hidden from the public `types.dart` barrel export.

## Test Plan
- [x] `dart analyze`
- [x] `dart test test/types_edge_cases_test.dart test/client/client_test.dart test/shared/protocol_advanced_scenarios_test.dart test/server/stdio_test.dart --reporter expanded`
- [x] `dart test`
- [x] `cd test/interop/ts && npm run build`
- [x] `dart test --tags interop --reporter expanded`
- [x] `git diff --check origin/main...HEAD`
- [x] GitHub Actions checks: Analyze (actions), Analyze (javascript-typescript), test, CodeQL
- [x] Codecov patch/project checks

## Review notes
- Checked implementation against MCP 2025-11-25 schema/docs and JSON-RPC 2.0 ID semantics.
- Existing official TypeScript SDK interop covers valid cross-SDK behavior; added raw stdio tests cover malformed wire values that typed SDK constructors do not normally generate.
- Independent local diff review found no blockers.
- Post-create CI was green on head `7f4626d`.
- Addressed Copilot review comments:
  - Malformed `_meta` shapes now fail with explicit `FormatException`s, with parser/raw-stdio regressions.
  - Response/error IDs now accept only `string | int | null`, preserving `id: null` compatibility.
  - Malformed `_meta.progressToken` errors now name the nested field.
  - Generic request dispatch no longer double-parses IDs for typed request factories.
- All Copilot review threads are resolved; GraphQL review-thread query reports no unresolved threads.
- Post-review CI is green on latest head `753905b` (Analyze actions, Analyze JS/TS, test, CodeQL, Codecov patch/project).
- A fresh Copilot review was requested after latest head `753905b` and polled; GitHub did not post a new current-head review, but there are no unresolved Copilot threads.


