### PR TITLE
fix(tasks): enforce task subcapability negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Added MCP `completion/complete` wire support for
   `context.arguments` and `PromptReference.title`, including context-aware
   server completion callbacks for prompt and resource-template completions.
+- Enforced explicit task-augmented request negotiation via `tasks.requests.*`:
+  task-based tool calls require `tasks.requests.tools.call`, server-initiated
+  task sampling requires `tasks.requests.sampling.createMessage`, and
+  server-initiated task elicitation requires `tasks.requests.elicitation.create`.
 
 ### Compatibility Notes (Potentially Breaking)
 

--- a/doc/client-guide.md
+++ b/doc/client-guide.md
@@ -156,6 +156,35 @@ final result = await client.callTool(
 );
 ```
 
+### Task-Augmented Tool Calls
+
+For task-capable tools, use `TaskClient.callToolStream()` and pass task creation
+parameters through the `task` argument. The server must advertise
+`tasks.requests.tools.call`, and the target tool must be visible from
+`tools/list` with `execution.taskSupport` set to `optional` or `required`.
+`TaskClient` performs that `tools/list` preflight before it sends `tools/call`.
+
+```dart
+final taskClient = TaskClient(client);
+
+await for (final event in taskClient.callToolStream(
+  'slow-tool',
+  {'query': 'large job'},
+  task: {'ttl': 60000, 'pollInterval': 1000},
+)) {
+  switch (event) {
+    case TaskCreatedMessage(:final task):
+      print('Created task: ${task.taskId}');
+    case TaskStatusMessage(:final task):
+      print('Task status: ${task.status}');
+    case TaskResultMessage(:final result):
+      print('Tool result: ${result.content.length} content blocks');
+    case TaskErrorMessage(:final error):
+      print('Task error: $error');
+  }
+}
+```
+
 ### Handle Tool Errors
 
 ```dart

--- a/doc/migration-cookbooks.md
+++ b/doc/migration-cookbooks.md
@@ -131,6 +131,7 @@ For code already using `mcp_dart`, start with [`doc/migration_2025_11_25_compat.
 
 - `tasks/cancel` now returns the final cancelled task object on the wire.
 - Task and task-status wire shapes require `taskId`, `status`, `ttl`, `createdAt`, and `lastUpdatedAt`.
+- Task-augmented requests require explicit `tasks.requests.*` subcapabilities, such as `tasks.requests.tools.call` for task-based tools.
 - Streamable HTTP has stricter protocol-version and security validation defaults.
 - JSON-RPC request IDs, cancellation request IDs, and progress tokens preserve the MCP string-or-integer wire shape.
 - Sampling tool-use requests must be negotiated via `ClientCapabilities.sampling.tools`.

--- a/doc/migration_2025_11_25_compat.md
+++ b/doc/migration_2025_11_25_compat.md
@@ -25,8 +25,13 @@ This guide helps update existing code that used older sampling/tool-choice APIs.
 - Task stores treat terminal tasks (`completed`, `failed`, `cancelled`) as
   immutable. Later status or result writes are ignored instead of overwriting
   the terminal state.
-- The `Task` constructor now requires `ttl`, `createdAt`, and `lastUpdatedAt`,
+- `Task` constructor now requires `ttl`, `createdAt`, and `lastUpdatedAt`,
   so valid task instances serialize without throwing.
+- Task-augmented requests require explicit `tasks.requests.*` negotiation. A
+  top-level `tasks` capability is not enough: task-based tool calls require
+  `tasks.requests.tools.call`, task sampling handlers require
+  `tasks.requests.sampling.createMessage`, and task elicitation handlers require
+  `tasks.requests.elicitation.create`.
 - Streamable HTTP defaults are stricter for protocol-version headers, DNS
   rebinding protection, and batch request rejection.
 - MCP/JSON-RPC wire parsing now rejects malformed request IDs, progress tokens,
@@ -161,3 +166,63 @@ final cancelledTask = await taskClient.cancelTaskWithResult(taskId);
 Returned cancelled tasks should include the MCP-required task fields:
 `taskId`, `status`, `createdAt`, `lastUpdatedAt`, and `ttl` (`null` is valid
 for `ttl`).
+
+### Task request capability negotiation
+
+MCP 2025-11-25 treats `tasks.requests` as an exhaustive list of request methods
+that may be task-augmented. Advertising top-level `tasks` alone no longer allows
+every task-related request shape.
+
+For task-based tools, register task tools before `connect()` so the server can
+auto-advertise `tasks.requests.tools.call`:
+
+```dart
+server.experimental.registerToolTask(
+  'slow-tool',
+  inputSchema: const ToolInputSchema(),
+  handler: SlowToolTaskHandler(),
+);
+```
+
+If task tools are registered after `connect()`, pre-advertise the capability in
+server options before connecting:
+
+```dart
+final server = McpServer(
+  const Implementation(name: 'server', version: '1.0.0'),
+  options: const ServerOptions(
+    capabilities: ServerCapabilities(
+      tasks: ServerCapabilitiesTasks(
+        requests: ServerCapabilitiesTasksRequests(
+          tools: ServerCapabilitiesTasksTools(
+            call: ServerCapabilitiesTasksToolsCall(),
+          ),
+        ),
+      ),
+    ),
+  ),
+);
+```
+
+For server-initiated task interactions, clients must advertise the exact task
+request handlers they register:
+
+```dart
+final client = McpClient(
+  const Implementation(name: 'client', version: '1.0.0'),
+  options: const McpClientOptions(
+    capabilities: ClientCapabilities(
+      tasks: ClientCapabilitiesTasks(
+        requests: ClientCapabilitiesTasksRequests(
+          sampling: ClientCapabilitiesTasksSampling(
+            createMessage: ClientCapabilitiesTasksSamplingCreateMessage(),
+          ),
+          elicitation: ClientCapabilitiesTasksElicitation(
+            create: ClientCapabilitiesTasksElicitationCreate(),
+          ),
+        ),
+      ),
+    ),
+  ),
+);
+```

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -457,6 +457,69 @@ server.registerTool(
 );
 ```
 
+## Task-Augmented Tools
+
+MCP 2025-11-25 requires task-augmented requests to be negotiated explicitly.
+For tools, the server must advertise `tasks.requests.tools.call`; a top-level
+`tasks` capability is not enough. `registerToolTask()` advertises that
+subcapability automatically when it is called before `connect()`.
+
+```dart
+final server = McpServer(
+  const Implementation(name: 'task-server', version: '1.0.0'),
+);
+
+server.experimental.registerToolTask(
+  'slow-tool',
+  description: 'Runs asynchronously and returns a task first',
+  inputSchema: const ToolInputSchema(),
+  // Defaults to ToolExecution(taskSupport: 'required'). Use 'optional' if the
+  // same tool can also return an immediate CallToolResult.
+  execution: const ToolExecution(taskSupport: 'required'),
+  handler: SlowToolTaskHandler(),
+);
+
+await server.connect(transport);
+```
+
+If a task-based tool must be registered after `connect()`, pre-advertise the
+capability in `ServerOptions` before connecting:
+
+```dart
+final server = McpServer(
+  const Implementation(name: 'task-server', version: '1.0.0'),
+  options: const ServerOptions(
+    capabilities: ServerCapabilities(
+      tasks: ServerCapabilitiesTasks(
+        requests: ServerCapabilitiesTasksRequests(
+          tools: ServerCapabilitiesTasksTools(
+            call: ServerCapabilitiesTasksToolsCall(),
+          ),
+        ),
+      ),
+    ),
+  ),
+);
+```
+
+Clients that call task-augmented tools can use `TaskClient.callToolStream()`.
+When the `task` argument is supplied, `TaskClient` first verifies that the server
+advertised `tasks.requests.tools.call`, then lists tools to confirm the target
+tool advertises `execution.taskSupport` as `optional` or `required`.
+
+```dart
+final taskClient = TaskClient(client);
+
+await for (final message in taskClient.callToolStream(
+  'slow-tool',
+  {'input': 'value'},
+  task: {'ttl': 60000, 'pollInterval': 1000},
+)) {
+  // Handle TaskCreatedMessage, TaskStatusMessage, TaskResultMessage,
+  // or TaskErrorMessage.
+}
+```
+
 ## Real-World Examples
 
 ### API Integration

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -421,19 +421,39 @@ class McpClient extends Protocol {
 
   @override
   void assertTaskCapability(String method) {
-    if (_serverCapabilities?.tasks == null) {
+    final missingCapability = switch (method) {
+      Method.toolsCall =>
+        _serverCapabilities?.tasks?.requests?.tools?.call == null
+            ? 'tasks.requests.tools.call'
+            : null,
+      _ => _serverCapabilities?.tasks == null ? 'tasks' : null,
+    };
+
+    if (missingCapability != null) {
       throw McpError(
         ErrorCode.invalidRequest.value,
-        "Server does not support tasks capability (required for task-based '$method')",
+        "Server does not support capability '$missingCapability' required for task-based '$method'",
       );
     }
   }
 
   @override
   void assertTaskHandlerCapability(String method) {
-    if (_capabilities.tasks == null) {
+    final missingCapability = switch (method) {
+      Method.samplingCreateMessage =>
+        _capabilities.tasks?.requests?.sampling?.createMessage == null
+            ? 'tasks.requests.sampling.createMessage'
+            : null,
+      Method.elicitationCreate =>
+        _capabilities.tasks?.requests?.elicitation?.create == null
+            ? 'tasks.requests.elicitation.create'
+            : null,
+      _ => _capabilities.tasks == null ? 'tasks' : null,
+    };
+
+    if (missingCapability != null) {
       throw StateError(
-        "Client setup error: Cannot handle task-based '$method' without 'tasks' capability registered.",
+        "Client setup error: Cannot handle task-based '$method' without '$missingCapability' capability registered.",
       );
     }
   }

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -426,7 +426,8 @@ class McpClient extends Protocol {
         _serverCapabilities?.tasks?.requests?.tools?.call == null
             ? 'tasks.requests.tools.call'
             : null,
-      _ => _serverCapabilities?.tasks == null ? 'tasks' : null,
+      _ =>
+        _serverCapabilities?.tasks == null ? 'tasks' : 'tasks.requests.$method',
     };
 
     if (missingCapability != null) {
@@ -448,7 +449,7 @@ class McpClient extends Protocol {
         _capabilities.tasks?.requests?.elicitation?.create == null
             ? 'tasks.requests.elicitation.create'
             : null,
-      _ => _capabilities.tasks == null ? 'tasks' : null,
+      _ => _capabilities.tasks == null ? 'tasks' : 'tasks.requests.$method',
     };
 
     if (missingCapability != null) {

--- a/lib/src/client/task_client.dart
+++ b/lib/src/client/task_client.dart
@@ -21,7 +21,7 @@ class _RawResult implements BaseResultData {
 /// which may either return an immediate result or create a long-running task.
 /// It handles polling for task status and retrieving the final result.
 class TaskClient {
-  final Client client;
+  final McpClient client;
 
   TaskClient(this.client);
 

--- a/lib/src/client/task_client.dart
+++ b/lib/src/client/task_client.dart
@@ -50,6 +50,12 @@ class TaskClient {
   /// The [task] parameter is used for task augmentation. Pass task creation
   /// parameters (e.g., `{'ttl': 60000, 'pollInterval': 50}`) to request
   /// task-based execution from tools that support it.
+  ///
+  /// When [task] is provided, the connected server must advertise
+  /// `tasks.requests.tools.call`, and the target tool must be discoverable from
+  /// `tools/list` with `execution.taskSupport` set to `optional` or `required`.
+  /// This method performs a `tools/list` preflight before sending `tools/call`
+  /// so it can fail locally before creating a task the server did not advertise.
   Stream<TaskStreamMessage> callToolStream(
     String name,
     Map<String, dynamic> arguments, {
@@ -59,7 +65,13 @@ class TaskClient {
       if (task != null) {
         client.assertTaskCapability(Method.toolsCall);
         final tool = await _findTool(name);
-        final taskSupport = tool?.execution?.taskSupport ?? 'forbidden';
+        if (tool == null) {
+          throw McpError(
+            ErrorCode.invalidRequest.value,
+            "Tool '$name' was not advertised by tools/list; cannot verify task augmentation support",
+          );
+        }
+        final taskSupport = tool.execution?.taskSupport ?? 'forbidden';
         if (taskSupport == 'forbidden') {
           throw McpError(
             ErrorCode.invalidRequest.value,

--- a/lib/src/client/task_client.dart
+++ b/lib/src/client/task_client.dart
@@ -21,12 +21,28 @@ class _RawResult implements BaseResultData {
 /// which may either return an immediate result or create a long-running task.
 /// It handles polling for task status and retrieving the final result.
 class TaskClient {
-  final McpClient client;
+  final Client client;
 
   TaskClient(this.client);
 
-  /// Calls a tool and returns a stream of status updates and the final result.
-  ///
+  Future<Tool?> _findTool(String name) async {
+    String? cursor;
+    do {
+      final result = await client.listTools(
+        params: cursor == null ? null : ListToolsRequest(cursor: cursor),
+      );
+      for (final tool in result.tools) {
+        if (tool.name == name) {
+          return tool;
+        }
+      }
+      cursor = result.nextCursor;
+    } while (cursor != null);
+    return null;
+  }
+
+  /// Calls a tool and streams the result, handling task-based execution.
+
   /// This handles both immediate results (yielding a single [TaskResultMessage])
   /// and long-running tasks (yielding [TaskCreatedMessage], multiple
   /// [TaskStatusMessage]s, and finally [TaskResultMessage]).
@@ -40,6 +56,18 @@ class TaskClient {
     Map<String, dynamic>? task,
   }) async* {
     try {
+      if (task != null) {
+        client.assertTaskCapability(Method.toolsCall);
+        final tool = await _findTool(name);
+        final taskSupport = tool?.execution?.taskSupport ?? 'forbidden';
+        if (taskSupport == 'forbidden') {
+          throw McpError(
+            ErrorCode.invalidRequest.value,
+            "Tool '$name' does not support task augmentation (taskSupport: 'forbidden')",
+          );
+        }
+      }
+
       // 1. Call the tool using generic request to capture 'task' field if present.
       // We cannot use client.callTool() because it forces CallToolResult return type
       // which ignores the 'task' field.

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -772,9 +772,31 @@ class ExperimentalMcpServerTasks {
     final effectiveExecution = ToolExecution(
       taskSupport: execution?.taskSupport ?? 'required',
     );
+    // Validate against the spec-defined wire values before advertising the tool.
+    effectiveExecution.toJson();
     if (effectiveExecution.taskSupport == 'forbidden') {
       throw ArgumentError(
         "Cannot register task-based tool '$name' with taskSupport 'forbidden'. Use registerTool() instead.",
+      );
+    }
+    if (_server._registeredTools.containsKey(name)) {
+      throw ArgumentError("Tool name '$name' already registered.");
+    }
+    validateAndWarnToolName(name);
+
+    final hasTaskToolCallCapability =
+        _server.server.getCapabilities().tasks?.requests?.tools?.call != null;
+    if (!hasTaskToolCallCapability) {
+      _server.server.registerCapabilities(
+        const ServerCapabilities(
+          tasks: ServerCapabilitiesTasks(
+            requests: ServerCapabilitiesTasksRequests(
+              tools: ServerCapabilitiesTasksTools(
+                call: ServerCapabilitiesTasksToolsCall(),
+              ),
+            ),
+          ),
+        ),
       );
     }
 

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -782,11 +782,18 @@ class ExperimentalMcpServerTasks {
     if (_server._registeredTools.containsKey(name)) {
       throw ArgumentError("Tool name '$name' already registered.");
     }
-    validateAndWarnToolName(name);
 
     final hasTaskToolCallCapability =
         _server.server.getCapabilities().tasks?.requests?.tools?.call != null;
     if (!hasTaskToolCallCapability) {
+      if (_server.isConnected) {
+        throw StateError(
+          "Cannot register task-based tool '$name' after connect() unless "
+          "server capabilities already include 'tasks.requests.tools.call'. "
+          "Configure ServerCapabilities.tasks.requests.tools.call before "
+          "connect() or register task-based tools before connecting.",
+        );
+      }
       _server.server.registerCapabilities(
         const ServerCapabilities(
           tasks: ServerCapabilitiesTasks(

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -397,7 +397,8 @@ class Server extends Protocol {
         _clientCapabilities?.tasks?.requests?.elicitation?.create == null
             ? 'tasks.requests.elicitation.create'
             : null,
-      _ => _clientCapabilities?.tasks == null ? 'tasks' : null,
+      _ =>
+        _clientCapabilities?.tasks == null ? 'tasks' : 'tasks.requests.$method',
     };
 
     if (missingCapability != null) {
@@ -414,7 +415,7 @@ class Server extends Protocol {
       Method.toolsCall => _capabilities.tasks?.requests?.tools?.call == null
           ? 'tasks.requests.tools.call'
           : null,
-      _ => _capabilities.tasks == null ? 'tasks' : null,
+      _ => _capabilities.tasks == null ? 'tasks' : 'tasks.requests.$method',
     };
 
     if (missingCapability != null) {

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -388,19 +388,38 @@ class Server extends Protocol {
 
   @override
   void assertTaskCapability(String method) {
-    if (_clientCapabilities?.tasks == null) {
+    final missingCapability = switch (method) {
+      Method.samplingCreateMessage =>
+        _clientCapabilities?.tasks?.requests?.sampling?.createMessage == null
+            ? 'tasks.requests.sampling.createMessage'
+            : null,
+      Method.elicitationCreate =>
+        _clientCapabilities?.tasks?.requests?.elicitation?.create == null
+            ? 'tasks.requests.elicitation.create'
+            : null,
+      _ => _clientCapabilities?.tasks == null ? 'tasks' : null,
+    };
+
+    if (missingCapability != null) {
       throw McpError(
         ErrorCode.invalidRequest.value,
-        "Client does not support tasks capability (required for task-based '$method')",
+        "Client does not support capability '$missingCapability' required for task-based '$method'",
       );
     }
   }
 
   @override
   void assertTaskHandlerCapability(String method) {
-    if (_capabilities.tasks == null) {
+    final missingCapability = switch (method) {
+      Method.toolsCall => _capabilities.tasks?.requests?.tools?.call == null
+          ? 'tasks.requests.tools.call'
+          : null,
+      _ => _capabilities.tasks == null ? 'tasks' : null,
+    };
+
+    if (missingCapability != null) {
       throw StateError(
-        "Server setup error: Cannot handle task-based '$method' without 'tasks' capability registered.",
+        "Server setup error: Cannot handle task-based '$method' without '$missingCapability' capability registered.",
       );
     }
   }

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -845,17 +845,62 @@ abstract class Protocol {
         request.params?.containsKey('task') == true;
   }
 
-  Map<String, dynamic>? _withoutTaskKey(Map<String, dynamic>? value) {
-    if (value == null || !value.containsKey('task')) {
+  Map<String, dynamic>? _withoutTaskMetadata(
+    Map<String, dynamic>? value, {
+    required bool removeRelatedTask,
+  }) {
+    if (value == null) {
+      return null;
+    }
+
+    final hasTask = value.containsKey('task');
+    final hasRelatedTask = removeRelatedTask &&
+        (value.containsKey(relatedTaskMetadataKey) ||
+            value.containsKey(legacyRelatedTaskMetadataKey));
+    if (!hasTask && !hasRelatedTask) {
       return value;
     }
+
     final copy = Map<String, dynamic>.from(value)..remove('task');
-    return copy;
+    if (removeRelatedTask) {
+      copy
+        ..remove(relatedTaskMetadataKey)
+        ..remove(legacyRelatedTaskMetadataKey);
+    }
+    return copy.isEmpty ? null : copy;
+  }
+
+  Map<String, dynamic>? _withoutTaskAugmentedParams(
+    Map<String, dynamic>? params,
+  ) {
+    if (params == null) {
+      return null;
+    }
+
+    Map<String, dynamic>? copy;
+    if (params.containsKey('task')) {
+      copy = Map<String, dynamic>.from(params)..remove('task');
+    }
+
+    final meta = (copy ?? params)['_meta'];
+    if (meta is Map<String, dynamic>) {
+      final strippedMeta = _withoutTaskMetadata(meta, removeRelatedTask: true);
+      if (!identical(strippedMeta, meta)) {
+        copy ??= Map<String, dynamic>.from(params);
+        if (strippedMeta == null) {
+          copy.remove('_meta');
+        } else {
+          copy['_meta'] = strippedMeta;
+        }
+      }
+    }
+
+    return copy?.isEmpty == true ? null : copy ?? params;
   }
 
   JsonRpcRequest _withoutTaskAugmentation(JsonRpcRequest request) {
-    final params = _withoutTaskKey(request.params);
-    final meta = _withoutTaskKey(request.meta);
+    final params = _withoutTaskAugmentedParams(request.params);
+    final meta = _withoutTaskMetadata(request.meta, removeRelatedTask: true);
     final json = <String, dynamic>{
       'jsonrpc': '2.0',
       'id': request.id,

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -840,9 +840,17 @@ abstract class Protocol {
     });
   }
 
+  bool _containsTaskMetadata(Map<dynamic, dynamic>? value) {
+    return value?.containsKey('task') == true ||
+        value?.containsKey(relatedTaskMetadataKey) == true ||
+        value?.containsKey(legacyRelatedTaskMetadataKey) == true;
+  }
+
   bool _hasTaskAugmentation(JsonRpcRequest request) {
-    return request.meta?.containsKey('task') == true ||
-        request.params?.containsKey('task') == true;
+    final paramsMeta = request.params?['_meta'];
+    return _containsTaskMetadata(request.meta) ||
+        request.params?.containsKey('task') == true ||
+        (paramsMeta is Map && _containsTaskMetadata(paramsMeta));
   }
 
   Map<String, dynamic>? _withoutTaskMetadata(

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -840,9 +840,52 @@ abstract class Protocol {
     });
   }
 
+  bool _hasTaskAugmentation(JsonRpcRequest request) {
+    return request.meta?.containsKey('task') == true ||
+        request.params?.containsKey('task') == true;
+  }
+
+  Map<String, dynamic>? _withoutTaskKey(Map<String, dynamic>? value) {
+    if (value == null || !value.containsKey('task')) {
+      return value;
+    }
+    final copy = Map<String, dynamic>.from(value)..remove('task');
+    return copy;
+  }
+
+  JsonRpcRequest _withoutTaskAugmentation(JsonRpcRequest request) {
+    final params = _withoutTaskKey(request.params);
+    final meta = _withoutTaskKey(request.meta);
+    final json = <String, dynamic>{
+      'jsonrpc': '2.0',
+      'id': request.id,
+      'method': request.method,
+      if (params != null || meta != null)
+        'params': <String, dynamic>{
+          ...?params,
+          if (meta != null) '_meta': meta,
+        },
+    };
+    return JsonRpcMessage.fromJson(json) as JsonRpcRequest;
+  }
+
+  bool _canHandleTaskAugmentation(String method) {
+    try {
+      assertTaskHandlerCapability(method);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
   /// Handles incoming JSON-RPC requests.
   void _onrequest(JsonRpcRequest request) {
     final handler = _requestHandlers[request.method] ?? fallbackRequestHandler;
+
+    if (_hasTaskAugmentation(request) &&
+        !_canHandleTaskAugmentation(request.method)) {
+      request = _withoutTaskAugmentation(request);
+    }
 
     // Check for related task ID in metadata
     final meta =

--- a/lib/src/types/tools.dart
+++ b/lib/src/types/tools.dart
@@ -87,6 +87,12 @@ class ToolAnnotations {
 
 /// Describes how the tool should be executed.
 class ToolExecution {
+  static const Set<String> allowedTaskSupportValues = {
+    'forbidden',
+    'optional',
+    'required',
+  };
+
   /// Describes how the tool supports task augmentation.
   ///
   /// * `forbidden`: The tool does not support tasks.
@@ -97,14 +103,25 @@ class ToolExecution {
   const ToolExecution({this.taskSupport = 'forbidden'});
 
   factory ToolExecution.fromJson(Map<String, dynamic> json) {
-    return ToolExecution(
-      taskSupport: json['taskSupport'] as String? ?? 'forbidden',
-    );
+    final taskSupport = json['taskSupport'] as String? ?? 'forbidden';
+    if (!allowedTaskSupportValues.contains(taskSupport)) {
+      throw FormatException(
+        "Invalid tool execution taskSupport '$taskSupport'. Expected one of: ${allowedTaskSupportValues.join(', ')}",
+      );
+    }
+    return ToolExecution(taskSupport: taskSupport);
   }
 
-  Map<String, dynamic> toJson() => {
-        'taskSupport': taskSupport,
-      };
+  Map<String, dynamic> toJson() {
+    if (!allowedTaskSupportValues.contains(taskSupport)) {
+      throw ArgumentError.value(
+        taskSupport,
+        'taskSupport',
+        "Expected one of: ${allowedTaskSupportValues.join(', ')}",
+      );
+    }
+    return {'taskSupport': taskSupport};
+  }
 }
 
 /// Definition for a tool that the client can call.
@@ -270,9 +287,12 @@ class CallToolRequest {
   });
 
   factory CallToolRequest.fromJson(Map<String, dynamic> json) {
+    final arguments = json['arguments'];
     return CallToolRequest(
       name: json['name'] as String,
-      arguments: json['arguments'] as Map<String, dynamic>? ?? const {},
+      arguments: arguments == null
+          ? const {}
+          : (arguments as Map).cast<String, dynamic>(),
     );
   }
 

--- a/test/client/client_tool_validation_test.dart
+++ b/test/client/client_tool_validation_test.dart
@@ -5,6 +5,13 @@ import 'package:test/test.dart';
 
 class MockTransport extends Transport {
   final List<JsonRpcMessage> sentMessages = [];
+  ServerCapabilities serverCapabilities;
+
+  MockTransport({
+    this.serverCapabilities = const ServerCapabilities(
+      tools: ServerCapabilitiesTools(),
+    ),
+  });
 
   @override
   String? get sessionId => null;
@@ -21,12 +28,11 @@ class MockTransport extends Transport {
       _respond(
         JsonRpcResponse(
           id: message.id,
-          result: const InitializeResult(
+          result: InitializeResult(
             protocolVersion: latestProtocolVersion,
-            capabilities: ServerCapabilities(
-              tools: ServerCapabilitiesTools(),
-            ),
-            serverInfo: Implementation(name: 'MockServer', version: '1.0.0'),
+            capabilities: serverCapabilities,
+            serverInfo:
+                const Implementation(name: 'MockServer', version: '1.0.0'),
           ).toJson(),
         ),
       );
@@ -156,6 +162,49 @@ void main() {
             contains('requires task-based execution'),
           ),
         ),
+      );
+    });
+    test('assertTaskCapability requires tools/call task subcapability',
+        () async {
+      transport = MockTransport(
+        serverCapabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(),
+          tasks: ServerCapabilitiesTasks(),
+        ),
+      );
+      await client.connect(transport);
+
+      expect(
+        () => client.assertTaskCapability(Method.toolsCall),
+        throwsA(
+          isA<McpError>().having(
+            (e) => e.message,
+            'message',
+            contains('tasks.requests.tools.call'),
+          ),
+        ),
+      );
+    });
+
+    test('assertTaskCapability allows declared tools/call task subcapability',
+        () async {
+      transport = MockTransport(
+        serverCapabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(),
+          tasks: ServerCapabilitiesTasks(
+            requests: ServerCapabilitiesTasksRequests(
+              tools: ServerCapabilitiesTasksTools(
+                call: ServerCapabilitiesTasksToolsCall(),
+              ),
+            ),
+          ),
+        ),
+      );
+      await client.connect(transport);
+
+      expect(
+        () => client.assertTaskCapability(Method.toolsCall),
+        returnsNormally,
       );
     });
   });

--- a/test/client/client_tool_validation_test.dart
+++ b/test/client/client_tool_validation_test.dart
@@ -186,6 +186,27 @@ void main() {
       );
     });
 
+    test('assertTaskCapability rejects unsupported task-augmented methods',
+        () async {
+      transport = MockTransport(
+        serverCapabilities: const ServerCapabilities(
+          tasks: ServerCapabilitiesTasks(),
+        ),
+      );
+      await client.connect(transport);
+
+      expect(
+        () => client.assertTaskCapability(Method.completionComplete),
+        throwsA(
+          isA<McpError>().having(
+            (e) => e.message,
+            'message',
+            contains('tasks.requests.completion/complete'),
+          ),
+        ),
+      );
+    });
+
     test('assertTaskCapability allows declared tools/call task subcapability',
         () async {
       transport = MockTransport(
@@ -205,6 +226,28 @@ void main() {
       expect(
         () => client.assertTaskCapability(Method.toolsCall),
         returnsNormally,
+      );
+    });
+
+    test('assertTaskHandlerCapability rejects unsupported task handlers', () {
+      client = Client(
+        const Implementation(name: 'TestClient', version: '1.0.0'),
+        options: const McpClientOptions(
+          capabilities: ClientCapabilities(
+            tasks: ClientCapabilitiesTasks(),
+          ),
+        ),
+      );
+
+      expect(
+        () => client.assertTaskHandlerCapability(Method.rootsList),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('tasks.requests.roots/list'),
+          ),
+        ),
       );
     });
   });

--- a/test/client/task_client_test.dart
+++ b/test/client/task_client_test.dart
@@ -262,6 +262,31 @@ void main() {
       expect(mockClient.requests.map((r) => r.method), [Method.toolsList]);
     });
 
+    test('callToolStream rejects task augmentation when tool is not advertised',
+        () async {
+      mockClient.listedTools = const [
+        Tool(
+          name: 'other-tool',
+          inputSchema: ToolInputSchema(),
+          execution: ToolExecution(taskSupport: 'optional'),
+        ),
+      ];
+
+      final events = await taskClient.callToolStream(
+        'missing-tool',
+        {},
+        task: {'ttl': 1000},
+      ).toList();
+
+      expect(events, hasLength(1));
+      expect(events.single, isA<TaskErrorMessage>());
+      expect(
+        (events.single as TaskErrorMessage).error.toString(),
+        contains('was not advertised by tools/list'),
+      );
+      expect(mockClient.requests.map((r) => r.method), [Method.toolsList]);
+    });
+
     test(
         'callToolStream allows task augmentation when server and tool permit it',
         () async {

--- a/test/client/task_client_test.dart
+++ b/test/client/task_client_test.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:mcp_dart/mcp_dart.dart';
 import 'package:test/test.dart';
 
-class MockClient implements Client {
+class MockClient implements McpClient {
   final Map<String, dynamic> _responses = {};
   final List<JsonRpcRequest> requests = [];
   bool supportsTaskAugmentedTools = true;

--- a/test/client/task_client_test.dart
+++ b/test/client/task_client_test.dart
@@ -5,6 +5,9 @@ import 'package:test/test.dart';
 class MockClient implements Client {
   final Map<String, dynamic> _responses = {};
   final List<JsonRpcRequest> requests = [];
+  bool supportsTaskAugmentedTools = true;
+  List<Tool> listedTools = const [];
+  Map<String?, ListToolsResult> listedToolPages = const {};
 
   void mockResponse(String method, dynamic response) {
     _responses[method] = response;
@@ -58,6 +61,29 @@ class MockClient implements Client {
     }
 
     throw Exception('Mock response not found for ${request.method}');
+  }
+
+  @override
+  void assertTaskCapability(String method) {
+    if (!supportsTaskAugmentedTools) {
+      throw McpError(
+        ErrorCode.invalidRequest.value,
+        "Server does not support capability 'tasks.requests.tools.call' required for task-based '$method'",
+      );
+    }
+  }
+
+  @override
+  Future<ListToolsResult> listTools({
+    ListToolsRequest? params,
+    RequestOptions? options,
+  }) async {
+    requests.add(JsonRpcListToolsRequest(id: -1, params: params?.toJson()));
+    if (listedToolPages.isNotEmpty) {
+      return listedToolPages[params?.cursor] ??
+          const ListToolsResult(tools: []);
+    }
+    return ListToolsResult(tools: listedTools);
   }
 
   @override
@@ -190,6 +216,122 @@ void main() {
           'tasks/get',
         ]),
       );
+    });
+
+    test(
+        'callToolStream rejects task augmentation without negotiated server support',
+        () async {
+      mockClient.supportsTaskAugmentedTools = false;
+
+      final events = await taskClient.callToolStream(
+        'task-tool',
+        {},
+        task: {'ttl': 1000},
+      ).toList();
+
+      expect(events, hasLength(1));
+      expect(events.single, isA<TaskErrorMessage>());
+      final error = (events.single as TaskErrorMessage).error;
+      expect(error, isA<McpError>());
+      expect(error.toString(), contains('tasks.requests.tools.call'));
+      expect(mockClient.requests, isEmpty);
+    });
+
+    test('callToolStream rejects task augmentation when tool forbids tasks',
+        () async {
+      mockClient.listedTools = const [
+        Tool(
+          name: 'sync-tool',
+          inputSchema: ToolInputSchema(),
+          execution: ToolExecution(taskSupport: 'forbidden'),
+        ),
+      ];
+
+      final events = await taskClient.callToolStream(
+        'sync-tool',
+        {},
+        task: {'ttl': 1000},
+      ).toList();
+
+      expect(events, hasLength(1));
+      expect(events.single, isA<TaskErrorMessage>());
+      expect(
+        (events.single as TaskErrorMessage).error.toString(),
+        contains("does not support task augmentation"),
+      );
+      expect(mockClient.requests.map((r) => r.method), [Method.toolsList]);
+    });
+
+    test(
+        'callToolStream allows task augmentation when server and tool permit it',
+        () async {
+      mockClient.listedTools = const [
+        Tool(
+          name: 'task-tool',
+          inputSchema: ToolInputSchema(),
+          execution: ToolExecution(taskSupport: 'optional'),
+        ),
+      ];
+      mockClient.mockResponse('tools/call', {
+        'content': [
+          {'type': 'text', 'text': 'Task-capable immediate result'},
+        ],
+      });
+
+      final events = await taskClient.callToolStream(
+        'task-tool',
+        {},
+        task: {'ttl': 1000},
+      ).toList();
+
+      expect(events, hasLength(1));
+      expect(events.single, isA<TaskResultMessage>());
+      expect(mockClient.requests.map((r) => r.method), [
+        Method.toolsList,
+        Method.toolsCall,
+      ]);
+      expect(mockClient.requests.last.params?['task'], {'ttl': 1000});
+    });
+
+    test('callToolStream finds task-capable tools on later list pages',
+        () async {
+      mockClient.listedToolPages = const {
+        null: ListToolsResult(
+          tools: [
+            Tool(name: 'other-tool', inputSchema: ToolInputSchema()),
+          ],
+          nextCursor: 'page-2',
+        ),
+        'page-2': ListToolsResult(
+          tools: [
+            Tool(
+              name: 'task-tool',
+              inputSchema: ToolInputSchema(),
+              execution: ToolExecution(taskSupport: 'optional'),
+            ),
+          ],
+        ),
+      };
+      mockClient.mockResponse('tools/call', {
+        'content': [
+          {'type': 'text', 'text': 'Task-capable paged result'},
+        ],
+      });
+
+      final events = await taskClient.callToolStream(
+        'task-tool',
+        {},
+        task: {'ttl': 1000},
+      ).toList();
+
+      expect(events, hasLength(1));
+      expect(events.single, isA<TaskResultMessage>());
+      expect(mockClient.requests.map((r) => r.method), [
+        Method.toolsList,
+        Method.toolsList,
+        Method.toolsCall,
+      ]);
+      expect(mockClient.requests[1].params?['cursor'], 'page-2');
     });
 
     test('listTasks returns list of tasks', () async {

--- a/test/server/mcp_test.dart
+++ b/test/server/mcp_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:mcp_dart/src/server/server.dart';
 import 'package:mcp_dart/src/server/mcp_server.dart';
 import 'package:mcp_dart/src/shared/protocol.dart';
+import 'package:mcp_dart/src/shared/task_interfaces.dart';
 import 'package:mcp_dart/src/shared/transport.dart';
 import 'package:mcp_dart/src/types.dart';
 import 'package:test/test.dart';
@@ -117,6 +118,10 @@ void main() {
         callback: (args, extra) async {
           callbackInvoked = true;
           expect(extra.taskRequestedTtl, isNull);
+          expect(extra.taskId, isNull);
+          expect(extra.meta?[relatedTaskMetadataKey], isNull);
+          expect(extra.meta?[legacyRelatedTaskMetadataKey], isNull);
+          expect(extra.meta?['progressToken'], 'keep-progress-token');
           return const CallToolResult(
             content: [TextContent(text: 'normal result')],
           );
@@ -144,6 +149,11 @@ void main() {
             'name': 'normal_tool',
             'arguments': {},
             'task': {'ttl': 1000},
+            '_meta': {
+              relatedTaskMetadataKey: {'taskId': 'unsupported-task'},
+              legacyRelatedTaskMetadataKey: {'taskId': 'unsupported-task'},
+              'progressToken': 'keep-progress-token',
+            },
           },
         ),
       );

--- a/test/server/mcp_test.dart
+++ b/test/server/mcp_test.dart
@@ -167,6 +167,59 @@ void main() {
       ]);
     });
 
+    test(
+        'ignores related-task metadata without task key when task capability is not advertised',
+        () async {
+      RequestHandlerExtra? receivedExtra;
+
+      mcpServer.registerTool(
+        'related_only_tool',
+        callback: (args, extra) async {
+          receivedExtra = extra;
+          return const CallToolResult(
+            content: [TextContent(text: 'related only result')],
+          );
+        },
+      );
+
+      await mcpServer.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcInitializeRequest(
+          id: 1,
+          initParams: const InitializeRequestParams(
+            protocolVersion: latestProtocolVersion,
+            capabilities: ClientCapabilities(),
+            clientInfo: Implementation(name: 'TestClient', version: '1.0.0'),
+          ),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      transport.receiveMessage(
+        const JsonRpcCallToolRequest(
+          id: 2,
+          params: {
+            'name': 'related_only_tool',
+            'arguments': {},
+            '_meta': {
+              relatedTaskMetadataKey: {'taskId': 'unsupported-task'},
+              legacyRelatedTaskMetadataKey: {'taskId': 'unsupported-task'},
+              'progressToken': 'keep-progress-token',
+            },
+          },
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      expect(receivedExtra, isNotNull);
+      expect(receivedExtra!.taskRequestedTtl, isNull);
+      expect(receivedExtra!.taskId, isNull);
+      expect(receivedExtra!.meta?[relatedTaskMetadataKey], isNull);
+      expect(receivedExtra!.meta?[legacyRelatedTaskMetadataKey], isNull);
+      expect(receivedExtra!.meta?['progressToken'], 'keep-progress-token');
+    });
+
     test('tool callback receives RequestHandlerExtra', () async {
       RequestHandlerExtra? receivedExtra;
 

--- a/test/server/mcp_test.dart
+++ b/test/server/mcp_test.dart
@@ -107,6 +107,56 @@ void main() {
       expect(receivedArgs['input'], equals('test value'));
     });
 
+    test(
+        'ignores task metadata for normal tools when tool task capability is not advertised',
+        () async {
+      var callbackInvoked = false;
+
+      mcpServer.registerTool(
+        'normal_tool',
+        callback: (args, extra) async {
+          callbackInvoked = true;
+          expect(extra.taskRequestedTtl, isNull);
+          return const CallToolResult(
+            content: [TextContent(text: 'normal result')],
+          );
+        },
+      );
+
+      await mcpServer.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcInitializeRequest(
+          id: 1,
+          initParams: const InitializeRequestParams(
+            protocolVersion: latestProtocolVersion,
+            capabilities: ClientCapabilities(),
+            clientInfo: Implementation(name: 'TestClient', version: '1.0.0'),
+          ),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      transport.receiveMessage(
+        const JsonRpcCallToolRequest(
+          id: 2,
+          params: {
+            'name': 'normal_tool',
+            'arguments': {},
+            'task': {'ttl': 1000},
+          },
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      expect(callbackInvoked, isTrue);
+      final response = transport.sentMessages.last;
+      expect(response, isA<JsonRpcResponse>());
+      expect((response as JsonRpcResponse).result['content'], [
+        {'type': 'text', 'text': 'normal result'},
+      ]);
+    });
+
     test('tool callback receives RequestHandlerExtra', () async {
       RequestHandlerExtra? receivedExtra;
 

--- a/test/server/server_test.dart
+++ b/test/server/server_test.dart
@@ -267,6 +267,68 @@ void main() {
       expect(result['protocolVersion'], isNot(equals("999.999")));
     });
 
+    test('assertTaskCapability requires sampling task subcapability', () async {
+      await server.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcInitializeRequest(
+          id: 1,
+          initParams: const InitializeRequest(
+            protocolVersion: latestProtocolVersion,
+            capabilities: ClientCapabilities(
+              sampling: ClientCapabilitiesSampling(),
+              tasks: ClientCapabilitiesTasks(),
+            ),
+            clientInfo: Implementation(name: 'TestClient', version: '1.0.0'),
+          ),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      expect(
+        () => server.assertTaskCapability(Method.samplingCreateMessage),
+        throwsA(
+          isA<McpError>().having(
+            (e) => e.message,
+            'message',
+            contains('tasks.requests.sampling.createMessage'),
+          ),
+        ),
+      );
+    });
+
+    test('assertTaskCapability allows declared sampling task subcapability',
+        () async {
+      await server.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcInitializeRequest(
+          id: 1,
+          initParams: const InitializeRequest(
+            protocolVersion: latestProtocolVersion,
+            capabilities: ClientCapabilities(
+              sampling: ClientCapabilitiesSampling(),
+              tasks: ClientCapabilitiesTasks(
+                requests: ClientCapabilitiesTasksRequests(
+                  sampling: ClientCapabilitiesTasksSampling(
+                    createMessage:
+                        ClientCapabilitiesTasksSamplingCreateMessage(),
+                  ),
+                ),
+              ),
+            ),
+            clientInfo: Implementation(name: 'TestClient', version: '1.0.0'),
+          ),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      expect(
+        () => server.assertTaskCapability(Method.samplingCreateMessage),
+        returnsNormally,
+      );
+    });
+
     test('Can send ping requests to client', () async {
       await server.connect(transport);
 

--- a/test/server/server_test.dart
+++ b/test/server/server_test.dart
@@ -329,6 +329,58 @@ void main() {
       );
     });
 
+    test('assertTaskCapability rejects unsupported task-augmented methods',
+        () async {
+      await server.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcInitializeRequest(
+          id: 1,
+          initParams: const InitializeRequest(
+            protocolVersion: latestProtocolVersion,
+            capabilities: ClientCapabilities(
+              tasks: ClientCapabilitiesTasks(),
+            ),
+            clientInfo: Implementation(name: 'TestClient', version: '1.0.0'),
+          ),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      expect(
+        () => server.assertTaskCapability(Method.rootsList),
+        throwsA(
+          isA<McpError>().having(
+            (e) => e.message,
+            'message',
+            contains('tasks.requests.roots/list'),
+          ),
+        ),
+      );
+    });
+
+    test('assertTaskHandlerCapability rejects unsupported task handlers', () {
+      server = Server(
+        serverInfo,
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            tasks: ServerCapabilitiesTasks(),
+          ),
+        ),
+      );
+
+      expect(
+        () => server.assertTaskHandlerCapability(Method.promptsGet),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('tasks.requests.prompts/get'),
+          ),
+        ),
+      );
+    });
+
     test('Can send ping requests to client', () async {
       await server.connect(transport);
 

--- a/test/server/tasks_test.dart
+++ b/test/server/tasks_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:mcp_dart/src/server/mcp_server.dart';
+import 'package:mcp_dart/src/server/server.dart';
 import 'package:mcp_dart/src/server/tasks/handler.dart';
 import 'package:mcp_dart/src/shared/protocol.dart';
 import 'package:mcp_dart/src/shared/transport.dart';
@@ -145,6 +146,72 @@ void main() {
       final result = ListTasksResult.fromJson(response.result);
       expect(result.tasks.length, 1);
       expect(result.tasks.first.taskId, 'task1');
+    });
+
+    test('registerToolTask advertises tasks.requests.tools.call', () {
+      mcpServer.experimental.registerToolTask(
+        'task_tool',
+        inputSchema: const ToolInputSchema(),
+        handler: _ResultHandler(),
+      );
+
+      final taskCapabilities = mcpServer.server.getCapabilities().tasks;
+      expect(taskCapabilities, isNotNull);
+      expect(taskCapabilities!.requests?.tools?.call, isNotNull);
+    });
+
+    test('registerToolTask duplicate does not mutate capabilities', () {
+      mcpServer.registerTool(
+        'duplicate_tool',
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+
+      expect(
+        () => mcpServer.experimental.registerToolTask(
+          'duplicate_tool',
+          inputSchema: const ToolInputSchema(),
+          handler: _ResultHandler(),
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        mcpServer.server.getCapabilities().tasks?.requests?.tools?.call,
+        isNull,
+      );
+    });
+
+    test('registerToolTask reuses pre-advertised capability after connect',
+        () async {
+      final connectedServer = McpServer(
+        const Implementation(name: 'TestServer', version: '1.0.0'),
+        options: const ServerOptions(
+          capabilities: ServerCapabilities(
+            tools: ServerCapabilitiesTools(listChanged: true),
+            tasks: ServerCapabilitiesTasks(
+              requests: ServerCapabilitiesTasksRequests(
+                tools: ServerCapabilitiesTasksTools(
+                  call: ServerCapabilitiesTasksToolsCall(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      connectedServer.experimental.registerToolTask(
+        'initial_task_tool',
+        inputSchema: const ToolInputSchema(),
+        handler: _ResultHandler(),
+      );
+      await connectedServer.connect(transport);
+
+      expect(
+        () => connectedServer.experimental.registerToolTask(
+          'late_task_tool',
+          inputSchema: const ToolInputSchema(),
+          handler: _ResultHandler(),
+        ),
+        returnsNormally,
+      );
     });
 
     test('handles cancel task request with final task result', () async {

--- a/test/server/tasks_test.dart
+++ b/test/server/tasks_test.dart
@@ -214,6 +214,29 @@ void main() {
       );
     });
 
+    test('registerToolTask after connect requires pre-advertised capability',
+        () async {
+      await mcpServer.connect(transport);
+
+      expect(
+        () => mcpServer.experimental.registerToolTask(
+          'late_task_tool',
+          inputSchema: const ToolInputSchema(),
+          handler: _ResultHandler(),
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.toString(),
+            'message',
+            allOf(
+              contains('tasks.requests.tools.call'),
+              contains('before connect()'),
+            ),
+          ),
+        ),
+      );
+    });
+
     test('handles cancel task request with final task result', () async {
       var cancelledTaskId = '';
 

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -73,6 +73,22 @@ void main() {
     });
   });
 
+  group('ToolExecution Tests', () {
+    test('rejects invalid taskSupport while parsing wire JSON', () {
+      expect(
+        () => ToolExecution.fromJson({'taskSupport': 'sometimes'}),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects invalid taskSupport while serializing wire JSON', () {
+      expect(
+        () => const ToolExecution(taskSupport: 'sometimes').toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
   group('Capabilities Tests', () {
     test('ServerCapabilitiesCompletions serialization and deserialization', () {
       final completions =


### PR DESCRIPTION
## Summary
- enforce MCP 2025-11-25 task subcapabilities for task-augmented tools/call, sampling/createMessage, and elicitation/create paths
- make registerToolTask advertise tasks.requests.tools.call safely, while avoiding duplicate-registration capability mutation and reusing pre-advertised support after connect
- gate TaskClient task augmentation on negotiated server support plus paginated tool execution.taskSupport lookup
- ignore unsupported task augmentation metadata and process requests normally when the receiver did not advertise that request-type task support
- validate ToolExecution.taskSupport wire values on parse/serialize
- document task request negotiation in the migration guide, tools guide, client guide, migration cookbooks, and changelog

## Tests
- dart analyze
- dart test test/client/task_client_test.dart test/server/tasks_test.dart test/client/client_tool_validation_test.dart test/server/server_test.dart
- dart test

Closes #138

