### PR TITLE
Add MCP spec coverage conformance gate

### DIFF
--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Run tests
         run: dart test
 
+      - name: Run MCP spec conformance gate
+        run: dart run bin/mcp_dart.dart conformance --suite spec --json
+
       - name: Run pana (package analysis)
         run: |
           dart pub global activate pana

--- a/.github/workflows/test_core.yml
+++ b/.github/workflows/test_core.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Install dependencies
         run: dart pub get
 
+      - name: Install CLI dependencies
+        working-directory: packages/mcp_dart_cli
+        run: dart pub get
+
+      - name: Run MCP spec conformance gate
+        working-directory: packages/mcp_dart_cli
+        run: dart run bin/mcp_dart.dart conformance --suite spec --json
+
       - name: Run interop test suite
         run: dart test -t interop
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Documentation
 
 - Added interoperability, Flutter recipe, and migration cookbook guides, and expanded MCP Apps example guidance with host compatibility notes.
+- Added an MCP 2025-11-25 spec coverage matrix that maps high-risk
+  requirements to unit tests, TypeScript interop tests, CLI conformance cases,
+  and known follow-up gaps.
 
 ### Spec Alignment
 
@@ -114,6 +117,9 @@
 ### Tooling
 
 - Added `mcp_dart conformance` with built-in JSON-RPC and protocol-version fixture checks, deterministic JSON-RPC fuzz cases, exact-case filtering, and JSON output for CI/scripts.
+- Added a `mcp_dart conformance --suite spec` gate for MCP 2025-11-25
+  lifecycle, capability, elicitation, task-metadata, and progress-token
+  raw-wire checks.
 
 ## 2.1.1
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ It's also backward compatible with previous versions including `2025-06-18`, `20
 ### Recipes and Compatibility
 
 - 🧪 **[SDK Interoperability Matrix](https://github.com/leehack/mcp_dart/blob/main/doc/interoperability.md)** - Verified Dart/TypeScript and documented cross-SDK scenarios
+- ✅ **[MCP 2025-11-25 Spec Coverage Matrix](https://github.com/leehack/mcp_dart/blob/main/doc/spec-coverage-2025-11-25.md)** - Auditable coverage map with CLI conformance cases and known gaps
 - 📱 **[Flutter Recipes](https://github.com/leehack/mcp_dart/blob/main/doc/flutter-recipes.md)** - Flutter Web, mobile, and desktop host/client guidance
 - 🔁 **[Migration Cookbooks](https://github.com/leehack/mcp_dart/blob/main/doc/migration-cookbooks.md)** - TypeScript SDK, `dart_mcp`, stdio-to-HTTP, and version migration paths
 

--- a/doc/interoperability.md
+++ b/doc/interoperability.md
@@ -2,6 +2,9 @@
 
 This page tracks the interoperability evidence that `mcp_dart` currently carries against other MCP SDKs and hosts. It is intentionally conservative: a row is marked as verified only when it links to a test, example, or reproducible command in this repository.
 
+For requirement-level MCP 2025-11-25 coverage, see the
+[`spec-coverage-2025-11-25.md`](spec-coverage-2025-11-25.md) matrix.
+
 ## How to read the matrix
 
 - **Verified** means the scenario is covered by an automated test or checked-in runnable example.
@@ -38,6 +41,15 @@ dart test --tags interop
 ```
 
 If the compiled fixtures are missing, local test runs skip the interop groups; CI should fail when required fixtures are unavailable.
+
+The CLI spec conformance gate covers raw-wire negative cases that do not need a
+cross-SDK fixture:
+
+```bash
+cd packages/mcp_dart_cli
+dart pub get
+dart run bin/mcp_dart.dart conformance --suite spec --json
+```
 
 ## Adding a new matrix row
 

--- a/doc/spec-coverage-2025-11-25.md
+++ b/doc/spec-coverage-2025-11-25.md
@@ -1,0 +1,76 @@
+# MCP 2025-11-25 Spec Coverage Matrix
+
+This matrix maps high-risk MCP 2025-11-25 requirements to checked-in
+`mcp_dart` coverage. It is intentionally conservative: a row is marked
+`Verified` only when the repository has executable tests or a CI command for
+the behavior.
+
+## Conformance Gate
+
+Run the matrix-critical local gate from the repository root:
+
+```bash
+cd packages/mcp_dart_cli
+dart pub get
+dart run bin/mcp_dart.dart conformance --suite spec --json
+```
+
+Run the cross-SDK interop gate from the repository root:
+
+```bash
+cd test/interop/ts
+npm ci
+npm run build
+cd ../../..
+dart test -t interop
+```
+
+CI runs both gates: the core workflow runs the TypeScript interop suite and the
+CLI spec conformance gate, while the CLI workflow runs the conformance gate with
+the CLI test suite.
+
+## Matrix
+
+| Spec area | Spec source | Requirement tracked here | Local coverage | Interop coverage | Conformance case or gap | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| Lifecycle initialization ordering | [Lifecycle](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle) | `initialize` is first, peers do not run normal operations before lifecycle readiness, and `notifications/initialized` transitions the session into normal operation. | [`test/lifecycle_test.dart`](../test/lifecycle_test.dart) | [`test/interop/ts_client_with_dart_server_test.dart`](../test/interop/ts_client_with_dart_server_test.dart), [`test/interop/ts/src/lifecycle_client.ts`](../test/interop/ts/src/lifecycle_client.ts) | `lifecycle.rejects-pre-initialize-request` | Verified |
+| Protocol version negotiation and HTTP header behavior | [Lifecycle](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle), [Transports](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports) | Peers negotiate a supported protocol version, and Streamable HTTP requests carry valid `MCP-Protocol-Version` after initialization. | [`test/client/client_test.dart`](../test/client/client_test.dart), [`test/server/server_test.dart`](../test/server/server_test.dart), [`test/mcp_2025_11_25_test.dart`](../test/mcp_2025_11_25_test.dart), [`test/server/streamable_https_test.dart`](../test/server/streamable_https_test.dart) | [`test/interop/dart_client_with_ts_server_test.dart`](../test/interop/dart_client_with_ts_server_test.dart), [`test/interop/ts_client_with_dart_server_test.dart`](../test/interop/ts_client_with_dart_server_test.dart) | `protocol-version.advertises-latest-2025-11-25` | Verified |
+| Negotiated capability enforcement | [Lifecycle capability negotiation](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#capability-negotiation), [Sampling](https://modelcontextprotocol.io/specification/2025-11-25/client/sampling) | Requests that require an unadvertised feature are rejected before handler code observes them. | [`test/client/client_tool_validation_test.dart`](../test/client/client_tool_validation_test.dart), [`test/client/client_test.dart`](../test/client/client_test.dart), [`test/server/server_test.dart`](../test/server/server_test.dart) | [`test/interop/dart_client_with_ts_server_features_test.dart`](../test/interop/dart_client_with_ts_server_features_test.dart) | `capabilities.rejects-unnegotiated-sampling-tools` | Verified |
+| Elicitation form/URL variant validation | [Elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation) | `elicitation/create` is treated as a discriminated form/URL shape and invalid mixed payloads are rejected. | [`test/elicitation_test.dart`](../test/elicitation_test.dart), [`test/client/client_elicitation_defaults_test.dart`](../test/client/client_elicitation_defaults_test.dart), [`test/server/server_validation_test.dart`](../test/server/server_validation_test.dart) | [`test/interop/dart_client_with_ts_server_features_test.dart`](../test/interop/dart_client_with_ts_server_features_test.dart) | `elicitation.rejects-invalid-form-url-union` | Verified |
+| Task metadata and related-task propagation | [Schema reference tasks](https://modelcontextprotocol.io/specification/2025-11-25/schema#tasks) | Task-augmented requests require negotiated task support, and related-task metadata is preserved only where task association is valid. | [`test/server/tasks_test.dart`](../test/server/tasks_test.dart), [`test/client/task_client_test.dart`](../test/client/task_client_test.dart), [`test/shared/protocol_task_handlers_test.dart`](../test/shared/protocol_task_handlers_test.dart), [`test/server/mcp_test.dart`](../test/server/mcp_test.dart) | [`test/interop/dart_client_with_ts_server_task_test.dart`](../test/interop/dart_client_with_ts_server_task_test.dart) | `tasks.strips-unnegotiated-related-task-metadata`; related-task metadata insertion and monotonic task progress are tracked by [#139](https://github.com/leehack/mcp_dart/issues/139). | Partial |
+| Progress token preservation and progress stream validation | [Progress](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress) | Progress tokens preserve string-or-integer wire shape, malformed token shapes fail at decode boundaries, and progress values should advance monotonically for a request. | [`test/types_edge_cases_test.dart`](../test/types_edge_cases_test.dart), [`test/shared/progress_test.dart`](../test/shared/progress_test.dart), [`test/shared/protocol_test.dart`](../test/shared/protocol_test.dart) | [`test/interop/dart_client_with_ts_server_features_test.dart`](../test/interop/dart_client_with_ts_server_features_test.dart), [`test/interop/test_dart_server.dart`](../test/interop/test_dart_server.dart) | `jsonrpc.preserves-string-progress-token`, `progress.rejects-malformed-progress-token`; repeated/decreasing progress is tracked by [#139](https://github.com/leehack/mcp_dart/issues/139). | Partial |
+| Streamable HTTP sessions, stale recovery, SSE replay, and batch rejection | [Transports](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports) | Session IDs, stale-session retry, `Last-Event-ID` replay, protocol-version headers, and JSON-RPC batch rejection follow Streamable HTTP semantics. | [`test/client/streamable_https_test.dart`](../test/client/streamable_https_test.dart), [`test/server/streamable_https_test.dart`](../test/server/streamable_https_test.dart) | [`test/interop/dart_client_with_ts_server_test.dart`](../test/interop/dart_client_with_ts_server_test.dart), [`test/interop/ts_client_with_dart_server_test.dart`](../test/interop/ts_client_with_dart_server_test.dart), [`test/interop/ts/src/replay_client.ts`](../test/interop/ts/src/replay_client.ts) | Covered by `dart test -t interop` and unit tests; no separate CLI raw-wire case yet because this requires HTTP server fixtures. | Verified |
+| Auth/security deployment behavior | [Authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization), [Transports security notes](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning) | OAuth, DNS rebinding, Origin/Host restrictions, and production deployment toggles are covered by executable harnesses where practical. | [`example/authentication/`](../example/authentication/), [`doc/transports.md`](transports.md) | None automated. | Deeper security harness is tracked by [#98](https://github.com/leehack/mcp_dart/issues/98). | Planned |
+
+## Stable Conformance Case Names
+
+The CLI exposes exact names so CI and downstream SDK checks can select one case
+without relying on output text:
+
+- `jsonrpc.rejects-invalid-version`
+- `jsonrpc.rejects-malformed-message`
+- `jsonrpc.preserves-string-response-id`
+- `jsonrpc.preserves-string-progress-token`
+- `protocol-version.advertises-latest-2025-11-25`
+- `lifecycle.rejects-pre-initialize-request`
+- `capabilities.rejects-unnegotiated-sampling-tools`
+- `elicitation.rejects-invalid-form-url-union`
+- `tasks.strips-unnegotiated-related-task-metadata`
+- `progress.rejects-malformed-progress-token`
+
+Use exact-case filtering when diagnosing one row:
+
+```bash
+cd packages/mcp_dart_cli
+dart run bin/mcp_dart.dart conformance --suite spec --case lifecycle.rejects-pre-initialize-request
+```
+
+## Known Gaps
+
+- [#139](https://github.com/leehack/mcp_dart/issues/139): related-task metadata
+  insertion on task-associated responses and repeated/decreasing progress
+  enforcement. The matrix marks these rows partial until that issue lands.
+- [#98](https://github.com/leehack/mcp_dart/issues/98): OAuth/security harness
+  and deployment-oriented security recipes.
+- [#96](https://github.com/leehack/mcp_dart/issues/96): broader CLI debugging
+  commands such as replay/proxy/validate flows.

--- a/packages/mcp_dart_cli/CHANGELOG.md
+++ b/packages/mcp_dart_cli/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 - Add `mcp_dart conformance` with built-in JSON-RPC and protocol-version fixture checks, deterministic JSON-RPC fuzz cases, exact-case filtering, and JSON output for CI/scripts.
+- Add `mcp_dart conformance --suite spec` for MCP 2025-11-25 lifecycle,
+  capability, elicitation, task-metadata, and progress-token raw-wire checks.
 
 ## 0.1.7
 

--- a/packages/mcp_dart_cli/README.md
+++ b/packages/mcp_dart_cli/README.md
@@ -126,11 +126,17 @@ The CLI supports `sampling/createMessage` requests from the server (often used b
 
 ### Conformance
 
-Run built-in fixture checks and deterministic fuzz checks for MCP protocol edge cases. The initial suite covers JSON-RPC malformed-message handling, string request IDs, string progress tokens, and advertised protocol-version support.
+Run built-in fixture checks, MCP 2025-11-25 spec-critical checks, and deterministic fuzz checks for MCP protocol edge cases. The fixture suite covers JSON-RPC malformed-message handling, string request IDs, string progress tokens, and advertised protocol-version support. The spec suite covers raw-wire lifecycle, capability, elicitation, task-metadata, and progress-token negative cases.
 
 ```bash
 # Run all built-in fixture cases
 mcp_dart conformance
+
+# Run MCP 2025-11-25 spec-critical cases
+mcp_dart conformance --suite spec
+
+# Run all non-fuzz suites
+mcp_dart conformance --suite all
 
 # Run one case by exact name
 mcp_dart conformance --case jsonrpc.preserves-string-response-id
@@ -176,4 +182,3 @@ dart test
 ## Contributing
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to this project.
-

--- a/packages/mcp_dart_cli/lib/src/conformance_command.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_command.dart
@@ -23,6 +23,17 @@ class ConformanceCommand extends Command<int> {
         _runner = runner ?? ConformanceRunner() {
     argParser
       ..addOption(
+        'suite',
+        help: 'Conformance suite to run.',
+        defaultsTo: 'fixture',
+        allowed: conformanceSuiteNames,
+        allowedHelp: const <String, String>{
+          'fixture': 'JSON-RPC and protocol-version fixture checks.',
+          'spec': 'MCP 2025-11-25 spec-critical raw-wire checks.',
+          'all': 'All non-fuzz conformance checks.',
+        },
+      )
+      ..addOption(
         'case',
         help: 'Run one built-in conformance case by exact name.',
       )
@@ -45,6 +56,7 @@ class ConformanceCommand extends Command<int> {
 
   @override
   Future<int> run() async {
+    final suite = argResults?['suite'] as String? ?? 'fixture';
     final filter = argResults?['case'] as String?;
     final fuzz = argResults?['fuzz'] as bool? ?? false;
     final iterations = int.tryParse(argResults?['iterations'] as String? ?? '');
@@ -58,18 +70,22 @@ class ConformanceCommand extends Command<int> {
       _logger.err('--case cannot be combined with --fuzz.');
       return ExitCode.usage.code;
     }
+    if (fuzz && (argResults?.wasParsed('suite') ?? false)) {
+      _logger.err('--suite cannot be combined with --fuzz.');
+      return ExitCode.usage.code;
+    }
 
     if (!json) {
       _logger.info(
         fuzz
             ? 'Running MCP conformance fuzz suite...'
-            : 'Running MCP conformance fixture suite...',
+            : 'Running MCP conformance $suite suite...',
       );
     }
 
     final result = fuzz
         ? await _runner.runFuzzSuite(iterations: iterations)
-        : await _runner.runFixtureSuite(filter: filter);
+        : await _runner.runSuite(suite: suite, filter: filter);
     if (result.total == 0) {
       _logger.err('No conformance cases matched: $filter');
       return ExitCode.usage.code;

--- a/packages/mcp_dart_cli/lib/src/conformance_runner.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_runner.dart
@@ -1,15 +1,28 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:mcp_dart/mcp_dart.dart';
 
+const String _fixtureSuite = 'fixture';
+const String _specSuite = 'spec';
+const String _allSuites = 'all';
+
+const List<String> conformanceSuiteNames = <String>[
+  _fixtureSuite,
+  _specSuite,
+  _allSuites,
+];
+
 /// Result of running one conformance case.
 class ConformanceCaseResult {
+  final String suite;
   final String name;
   final String description;
   final bool passed;
   final String? diagnostic;
 
   const ConformanceCaseResult({
+    required this.suite,
     required this.name,
     required this.description,
     required this.passed,
@@ -17,6 +30,7 @@ class ConformanceCaseResult {
   });
 
   Map<String, dynamic> toJson() => {
+        'suite': suite,
         'name': name,
         'description': description,
         'passed': passed,
@@ -48,11 +62,13 @@ class ConformanceSuiteResult {
 typedef _ConformanceCheck = Future<void> Function();
 
 class _ConformanceCase {
+  final String suite;
   final String name;
   final String description;
   final _ConformanceCheck check;
 
   const _ConformanceCase({
+    required this.suite,
     required this.name,
     required this.description,
     required this.check,
@@ -62,49 +78,126 @@ class _ConformanceCase {
 /// Runs the built-in MCP conformance fixture checks.
 class ConformanceRunner {
   final List<_ConformanceCase> _fixtureCases;
+  final List<_ConformanceCase> _specCases;
 
   ConformanceRunner()
       : _fixtureCases = <_ConformanceCase>[
           _ConformanceCase(
+            suite: _fixtureSuite,
             name: 'jsonrpc.rejects-invalid-version',
             description:
                 'Rejects JSON-RPC messages whose jsonrpc version is not 2.0.',
             check: _rejectsInvalidJsonRpcVersion,
           ),
           _ConformanceCase(
+            suite: _fixtureSuite,
             name: 'jsonrpc.rejects-malformed-message',
             description:
                 'Rejects JSON-RPC envelopes without a method, result, or error member.',
             check: _rejectsMalformedJsonRpcMessage,
           ),
           _ConformanceCase(
+            suite: _fixtureSuite,
             name: 'jsonrpc.preserves-string-response-id',
             description:
                 'Parses and serializes successful responses with string JSON-RPC IDs.',
             check: _preservesStringResponseId,
           ),
           _ConformanceCase(
+            suite: _fixtureSuite,
             name: 'jsonrpc.preserves-string-progress-token',
             description:
                 'Parses and serializes progress notifications with string progress tokens.',
             check: _preservesStringProgressToken,
           ),
           _ConformanceCase(
+            suite: _fixtureSuite,
             name: 'protocol-version.advertises-latest-2025-11-25',
             description:
                 'Advertises MCP 2025-11-25 as the latest supported protocol version.',
             check: _advertisesLatestProtocolVersion,
           ),
+        ],
+        _specCases = <_ConformanceCase>[
+          _ConformanceCase(
+            suite: _specSuite,
+            name: 'lifecycle.rejects-pre-initialize-request',
+            description:
+                'Rejects operation requests before the initialize handshake.',
+            check: _rejectsPreInitializeRequest,
+          ),
+          _ConformanceCase(
+            suite: _specSuite,
+            name: 'capabilities.rejects-unnegotiated-sampling-tools',
+            description:
+                'Rejects sampling/createMessage tool-use when sampling.tools was not negotiated.',
+            check: _rejectsUnnegotiatedSamplingTools,
+          ),
+          _ConformanceCase(
+            suite: _specSuite,
+            name: 'elicitation.rejects-invalid-form-url-union',
+            description:
+                'Rejects elicitation/create payloads that mix form and URL variants.',
+            check: _rejectsInvalidElicitationVariantPayload,
+          ),
+          _ConformanceCase(
+            suite: _specSuite,
+            name: 'tasks.strips-unnegotiated-related-task-metadata',
+            description:
+                'Strips related-task metadata from non-task tool calls when task augmentation was not negotiated.',
+            check: _stripsUnnegotiatedRelatedTaskMetadata,
+          ),
+          _ConformanceCase(
+            suite: _specSuite,
+            name: 'progress.rejects-malformed-progress-token',
+            description:
+                'Rejects progress notifications whose progressToken is not a string or integer.',
+            check: _rejectsMalformedProgressToken,
+          ),
         ];
+
+  /// Runs one named conformance suite.
+  Future<ConformanceSuiteResult> runSuite({
+    required String suite,
+    String? filter,
+  }) {
+    return switch (suite) {
+      _fixtureSuite => runFixtureSuite(filter: filter),
+      _specSuite => runSpecSuite(filter: filter),
+      _allSuites => runAllSuites(filter: filter),
+      _ => throw ArgumentError.value(
+          suite,
+          'suite',
+          'Expected one of: ${conformanceSuiteNames.join(', ')}',
+        ),
+    };
+  }
 
   /// Runs the built-in fixture suite.
   ///
   /// When [filter] is provided, only exact case-name matches run. Exact matching
   /// keeps CI diagnostics deterministic and prevents accidental broad filters.
   Future<ConformanceSuiteResult> runFixtureSuite({String? filter}) async {
+    return _runCases(_fixtureCases, filter: filter);
+  }
+
+  /// Runs MCP 2025-11-25 spec-critical raw-wire behavior checks.
+  Future<ConformanceSuiteResult> runSpecSuite({String? filter}) {
+    return _runCases(_specCases, filter: filter);
+  }
+
+  /// Runs all non-fuzz conformance cases.
+  Future<ConformanceSuiteResult> runAllSuites({String? filter}) {
+    return _runCases([..._fixtureCases, ..._specCases], filter: filter);
+  }
+
+  Future<ConformanceSuiteResult> _runCases(
+    List<_ConformanceCase> cases, {
+    String? filter,
+  }) async {
     final selectedCases = filter == null
-        ? _fixtureCases
-        : _fixtureCases.where((testCase) => testCase.name == filter).toList();
+        ? cases
+        : cases.where((testCase) => testCase.name == filter).toList();
 
     final results = <ConformanceCaseResult>[];
     for (final testCase in selectedCases) {
@@ -112,6 +205,7 @@ class ConformanceRunner {
         await testCase.check();
         results.add(
           ConformanceCaseResult(
+            suite: testCase.suite,
             name: testCase.name,
             description: testCase.description,
             passed: true,
@@ -120,6 +214,7 @@ class ConformanceRunner {
       } catch (error) {
         results.add(
           ConformanceCaseResult(
+            suite: testCase.suite,
             name: testCase.name,
             description: testCase.description,
             passed: false,
@@ -149,6 +244,7 @@ class ConformanceRunner {
         fixture.expectation(fixture.message);
         results.add(
           ConformanceCaseResult(
+            suite: 'fuzz',
             name: fixture.name,
             description: fixture.description,
             passed: true,
@@ -157,6 +253,7 @@ class ConformanceRunner {
       } catch (error) {
         results.add(
           ConformanceCaseResult(
+            suite: 'fuzz',
             name: fixture.name,
             description: fixture.description,
             passed: false,
@@ -264,6 +361,270 @@ _GeneratedJsonRpcFixture _generatedJsonRpcFixture(Random random, int index) {
   };
 }
 
+class _ConformanceTransport extends Transport {
+  final List<JsonRpcMessage> sentMessages = <JsonRpcMessage>[];
+  bool closed = false;
+  bool started = false;
+
+  @override
+  String? get sessionId => null;
+
+  @override
+  Future<void> start() async {
+    started = true;
+  }
+
+  @override
+  Future<void> send(JsonRpcMessage message, {int? relatedRequestId}) async {
+    sentMessages.add(message);
+  }
+
+  @override
+  Future<void> close() async {
+    closed = true;
+    onclose?.call();
+  }
+
+  void emit(JsonRpcMessage message) {
+    onmessage?.call(message);
+  }
+}
+
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+JsonRpcInitializeRequest _initializeRequest({
+  RequestId id = 1,
+  ClientCapabilities capabilities = const ClientCapabilities(),
+}) {
+  return JsonRpcInitializeRequest(
+    id: id,
+    initParams: InitializeRequest(
+      protocolVersion: latestProtocolVersion,
+      capabilities: capabilities,
+      clientInfo: const Implementation(
+        name: 'conformance-client',
+        version: '1.0.0',
+      ),
+    ),
+  );
+}
+
+JsonRpcResponse _initializeResponse({
+  required RequestId id,
+  ServerCapabilities capabilities = const ServerCapabilities(),
+}) {
+  return JsonRpcResponse(
+    id: id,
+    result: InitializeResult(
+      protocolVersion: latestProtocolVersion,
+      capabilities: capabilities,
+      serverInfo: const Implementation(
+        name: 'conformance-server',
+        version: '1.0.0',
+      ),
+    ).toJson(),
+  );
+}
+
+Future<void> _initializeMcpServer(
+  McpServer server,
+  _ConformanceTransport transport, {
+  ClientCapabilities clientCapabilities = const ClientCapabilities(),
+}) async {
+  await server.connect(transport);
+  transport.emit(_initializeRequest(capabilities: clientCapabilities));
+  await _settle();
+  _expectSingleErrorFreeResponse(transport.sentMessages, id: 1);
+  transport.sentMessages.clear();
+  transport.emit(const JsonRpcInitializedNotification());
+  await _settle();
+  transport.sentMessages.clear();
+}
+
+Future<void> _initializeClient(
+  McpClient client,
+  _ConformanceTransport transport,
+) async {
+  final connectFuture = client.connect(transport);
+  await _settle();
+
+  final initializeRequests = transport.sentMessages
+      .whereType<JsonRpcRequest>()
+      .where((request) => request.method == Method.initialize)
+      .toList();
+  if (initializeRequests.length != 1) {
+    throw StateError('Expected client to send exactly one initialize request.');
+  }
+  final initializeRequest = initializeRequests.single;
+
+  transport.emit(_initializeResponse(id: initializeRequest.id));
+  await connectFuture.timeout(const Duration(seconds: 1));
+  transport.sentMessages.clear();
+}
+
+Future<void> _rejectsPreInitializeRequest() async {
+  final transport = _ConformanceTransport();
+  final server = McpServer(
+    const Implementation(name: 'server', version: '1.0.0'),
+    options: const McpServerOptions(
+      capabilities: ServerCapabilities(tools: ServerCapabilitiesTools()),
+    ),
+  );
+  server.registerTool(
+    'probe',
+    callback: (args, extra) async {
+      throw StateError('tools/list reached normal operation handlers.');
+    },
+  );
+
+  await server.connect(transport);
+  transport.emit(const JsonRpcListToolsRequest(id: 100));
+  await _settle();
+
+  _expectSingleError(
+    transport.sentMessages,
+    id: 100,
+    code: ErrorCode.invalidRequest.value,
+    messageContains: 'before initialize',
+  );
+  await server.close();
+}
+
+Future<void> _rejectsUnnegotiatedSamplingTools() async {
+  final transport = _ConformanceTransport();
+  final client = McpClient(
+    const Implementation(name: 'client', version: '1.0.0'),
+    options: const McpClientOptions(
+      capabilities: ClientCapabilities(
+        sampling: ClientCapabilitiesSampling(),
+      ),
+    ),
+  );
+  var handlerCalled = false;
+  client.onSamplingRequest = (params) async {
+    handlerCalled = true;
+    return const CreateMessageResult(
+      model: 'conformance-model',
+      role: SamplingMessageRole.assistant,
+      content: SamplingTextContent(text: 'unexpected'),
+    );
+  };
+
+  await _initializeClient(client, transport);
+  transport.emit(
+    JsonRpcCreateMessageRequest(
+      id: 101,
+      createParams: const CreateMessageRequest(
+        messages: <SamplingMessage>[
+          SamplingMessage(
+            role: SamplingMessageRole.user,
+            content: SamplingTextContent(text: 'Use a tool'),
+          ),
+        ],
+        maxTokens: 4,
+        tools: <Tool>[
+          Tool(name: 'search', inputSchema: JsonObject()),
+        ],
+      ),
+    ),
+  );
+  await _settle();
+
+  if (handlerCalled) {
+    throw StateError('sampling handler ran without sampling.tools capability.');
+  }
+  _expectSingleError(
+    transport.sentMessages,
+    id: 101,
+    code: ErrorCode.invalidRequest.value,
+    messageContains: 'sampling.tools',
+  );
+  await client.close();
+}
+
+Future<void> _rejectsInvalidElicitationVariantPayload() async {
+  _expectThrowsFormatException(
+    () => JsonRpcMessage.fromJson(const <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 102,
+      'method': Method.elicitationCreate,
+      'params': <String, dynamic>{
+        'mode': 'form',
+        'message': 'Choose an account',
+        'requestedSchema': <String, dynamic>{'type': 'object'},
+        'url': 'https://example.com/collect',
+      },
+    }),
+  );
+}
+
+Future<void> _stripsUnnegotiatedRelatedTaskMetadata() async {
+  final transport = _ConformanceTransport();
+  final server = McpServer(
+    const Implementation(name: 'server', version: '1.0.0'),
+    options: const McpServerOptions(
+      capabilities: ServerCapabilities(tools: ServerCapabilitiesTools()),
+    ),
+  );
+  RequestHandlerExtra? receivedExtra;
+  server.registerTool(
+    'metadata_probe',
+    callback: (args, extra) async {
+      receivedExtra = extra;
+      return const CallToolResult(
+        content: <Content>[TextContent(text: 'ok')],
+      );
+    },
+  );
+
+  await _initializeMcpServer(server, transport);
+  transport.emit(
+    const JsonRpcCallToolRequest(
+      id: 103,
+      params: <String, dynamic>{
+        'name': 'metadata_probe',
+        'arguments': <String, dynamic>{},
+        '_meta': <String, dynamic>{
+          relatedTaskMetadataKey: <String, dynamic>{'taskId': 'task-1'},
+          'progressToken': 'progress-1',
+        },
+      },
+    ),
+  );
+  await _settle();
+
+  if (receivedExtra == null) {
+    throw StateError('Expected metadata_probe handler to run.');
+  }
+  if (receivedExtra!.taskId != null ||
+      receivedExtra!.taskRequestedTtl != null) {
+    throw StateError('Unnegotiated task metadata affected handler task state.');
+  }
+  if (receivedExtra!.meta?[relatedTaskMetadataKey] != null ||
+      receivedExtra!.meta?.containsKey('relatedTask') == true) {
+    throw StateError(
+        'Unnegotiated related-task metadata reached handler meta.');
+  }
+  if (receivedExtra!.meta?['progressToken'] != 'progress-1') {
+    throw StateError('Non-task request metadata was not preserved.');
+  }
+  _expectSingleErrorFreeResponse(transport.sentMessages, id: 103);
+  await server.close();
+}
+
+Future<void> _rejectsMalformedProgressToken() async {
+  _expectThrowsFormatException(
+    () => JsonRpcMessage.fromJson(const <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'method': Method.notificationsProgress,
+      'params': <String, dynamic>{
+        'progressToken': <String, dynamic>{'bad': true},
+        'progress': 1,
+      },
+    }),
+  );
+}
+
 Future<void> _rejectsInvalidJsonRpcVersion() async {
   _expectThrowsFormatException(
     () => JsonRpcMessage.fromJson(const <String, dynamic>{
@@ -299,6 +660,51 @@ Future<void> _preservesStringResponseId() async {
   if (message.toJson()['id'] != 'request-1') {
     throw StateError('Expected serialized response ID to stay a string.');
   }
+}
+
+JsonRpcResponse _expectSingleErrorFreeResponse(
+  List<JsonRpcMessage> messages, {
+  required RequestId id,
+}) {
+  if (messages.length != 1) {
+    throw StateError('Expected one response, got ${messages.length}.');
+  }
+  final message = messages.single;
+  if (message is! JsonRpcResponse) {
+    throw StateError('Expected JsonRpcResponse, got ${message.runtimeType}.');
+  }
+  if (message.id != id) {
+    throw StateError('Expected response ID $id, got ${message.id}.');
+  }
+  return message;
+}
+
+JsonRpcError _expectSingleError(
+  List<JsonRpcMessage> messages, {
+  required RequestId id,
+  required int code,
+  required String messageContains,
+}) {
+  if (messages.length != 1) {
+    throw StateError('Expected one error response, got ${messages.length}.');
+  }
+  final message = messages.single;
+  if (message is! JsonRpcError) {
+    throw StateError('Expected JsonRpcError, got ${message.runtimeType}.');
+  }
+  if (message.id != id) {
+    throw StateError('Expected error ID $id, got ${message.id}.');
+  }
+  if (message.error.code != code) {
+    throw StateError('Expected error code $code, got ${message.error.code}.');
+  }
+  if (!message.error.message.contains(messageContains)) {
+    throw StateError(
+      "Expected error message to contain '$messageContains', got "
+      "'${message.error.message}'.",
+    );
+  }
+  return message;
 }
 
 Future<void> _preservesStringProgressToken() async {

--- a/packages/mcp_dart_cli/test/src/conformance_command_test.dart
+++ b/packages/mcp_dart_cli/test/src/conformance_command_test.dart
@@ -27,6 +27,38 @@ void main() {
       );
     });
 
+    test('spec suite covers MCP 2025-11-25 high-risk wire cases', () async {
+      final result = await ConformanceRunner().runSpecSuite();
+
+      expect(result.passed, isTrue);
+      expect(result.total, greaterThanOrEqualTo(5));
+      expect(
+        result.caseNames,
+        containsAll(<String>[
+          'lifecycle.rejects-pre-initialize-request',
+          'capabilities.rejects-unnegotiated-sampling-tools',
+          'elicitation.rejects-invalid-form-url-union',
+          'tasks.strips-unnegotiated-related-task-metadata',
+          'progress.rejects-malformed-progress-token',
+        ]),
+      );
+      expect(
+        result.cases.map((testCase) => testCase.suite),
+        everyElement('spec'),
+      );
+    });
+
+    test('all suite combines fixture and spec cases', () async {
+      final result = await ConformanceRunner().runAllSuites();
+
+      expect(result.passed, isTrue);
+      expect(result.caseNames, contains('jsonrpc.rejects-invalid-version'));
+      expect(
+        result.caseNames,
+        contains('lifecycle.rejects-pre-initialize-request'),
+      );
+    });
+
     test('can filter fixture cases by exact name', () async {
       final result = await ConformanceRunner().runFixtureSuite(
         filter: 'jsonrpc.preserves-string-response-id',
@@ -61,6 +93,7 @@ void main() {
 
     test('has expected name and options', () {
       expect(command.name, 'conformance');
+      expect(command.argParser.options.containsKey('suite'), isTrue);
       expect(command.argParser.options.containsKey('case'), isTrue);
       expect(command.argParser.options.containsKey('fuzz'), isTrue);
       expect(command.argParser.options.containsKey('iterations'), isTrue);
@@ -75,6 +108,20 @@ void main() {
       expect(exitCode, ExitCode.success.code);
       verify(
         () => logger.info('Running MCP conformance fixture suite...'),
+      ).called(1);
+      verify(
+        () => logger.success(any(that: contains('Conformance passed:'))),
+      ).called(1);
+    });
+
+    test('runs spec suite and reports success summary', () async {
+      final runner = CommandRunner<int>('mcp_dart', 'CLI')..addCommand(command);
+
+      final exitCode = await runner.run(['conformance', '--suite', 'spec']);
+
+      expect(exitCode, ExitCode.success.code);
+      verify(
+        () => logger.info('Running MCP conformance spec suite...'),
       ).called(1);
       verify(
         () => logger.success(any(that: contains('Conformance passed:'))),
@@ -122,6 +169,22 @@ void main() {
 
       expect(exitCode, ExitCode.usage.code);
       verify(() => logger.err('--case cannot be combined with --fuzz.'))
+          .called(1);
+    });
+
+    test('returns usage code when --suite is combined with fuzz mode',
+        () async {
+      final runner = CommandRunner<int>('mcp_dart', 'CLI')..addCommand(command);
+
+      final exitCode = await runner.run([
+        'conformance',
+        '--fuzz',
+        '--suite',
+        'spec',
+      ]);
+
+      expect(exitCode, ExitCode.usage.code);
+      verify(() => logger.err('--suite cannot be combined with --fuzz.'))
           .called(1);
     });
 


### PR DESCRIPTION
## Summary
- add a checked-in MCP 2025-11-25 spec coverage matrix with stable case names and explicit #139/#98/#96 gaps
- add `mcp_dart conformance --suite spec|all` with raw-wire checks for lifecycle, capability negotiation, elicitation variants, task metadata stripping, and progress token validation
- wire the spec conformance gate into core and CLI CI, and update README/changelog/docs references

## Verification
- `dart format .`
- `dart analyze`
- `(cd packages/mcp_dart_cli && dart analyze)`
- `(cd packages/mcp_dart_cli && dart test)`
- `dart test`
- `dart test -t interop`
- `(cd packages/mcp_dart_cli && dart run bin/mcp_dart.dart conformance --suite spec --json)`

Refs #146
Refs #139
Refs #98
Refs #96