### PR TITLE
Address MCP 2025-11-25 spec gaps

### DIFF
--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -41,7 +41,7 @@ jobs:
         run: dart test
 
       - name: Run MCP spec conformance gate
-        run: dart run bin/mcp_dart.dart conformance --suite spec --json
+        run: dart run bin/mcp_dart.dart conformance --suite all --json
 
       - name: Run pana (package analysis)
         run: |

--- a/.github/workflows/test_core.yml
+++ b/.github/workflows/test_core.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run MCP spec conformance gate
         working-directory: packages/mcp_dart_cli
-        run: dart run bin/mcp_dart.dart conformance --suite spec --json
+        run: dart run bin/mcp_dart.dart conformance --suite all --json
 
       - name: Run interop test suite
         run: dart test -t interop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,32 @@
 
 ### Spec Alignment
 
+- Preserved the MCP `Result._meta` field across typed result serializers,
+  including initialization, roots, resources, prompts, completion, elicitation,
+  tools, tasks, sampling, and empty results.
+- Aligned stable completions support with MCP 2025-11-25 by advertising
+  `{"completions": {}}` and moving the old completion list-changed helper to an
+  explicit experimental notification namespace.
+- Aligned URL-mode elicitation responses with MCP 2025-11-25: URL accept
+  results now serialize only the user `action`, while completion still uses
+  `notifications/elicitation/complete`. `ElicitResult.fromJson()` now rejects
+  actions outside `accept`, `decline`, and `cancel`.
+- Changed titled `JsonEnum` output to JSON Schema 2020-12-native `oneOf` or
+  array-item `anyOf` const/title entries while continuing to parse legacy
+  `enumNames` payloads.
+- Added first-class MCP OAuth client discovery for
+  `StreamableHttpClientTransport` through optional
+  `OAuthAuthorizationCodeProvider` support: bearer challenge parsing,
+  protected-resource metadata discovery, authorization-server/OIDC metadata
+  discovery, PKCE S256 authorization URLs with `resource`, and token exchange
+  with `code_verifier` and `resource`.
+- Added `OAuthAuthorizationCodeTokens` for token response metadata returned by
+  the authorization-code exchange path without changing the base `OAuthTokens`
+  API shape used by existing providers and subclasses.
+- Added `StreamableMcpAuthenticationResult` for high-level Streamable HTTP
+  servers that need to distinguish allow, unauthorized, and OAuth
+  `insufficient_scope` 403 responses while preserving the existing bool
+  `authenticator` path.
 - Tightened MCP/JSON-RPC boundary validation for request IDs, progress tokens,
   cancellation request IDs, and sampling tool-use capability gating so malformed
   wire values and unsupported `sampling.tools` requests fail before handler code
@@ -45,6 +71,17 @@
 
 ### Compatibility Notes (Potentially Breaking)
 
+- **Stable completion list-changed wire behavior is removed**:
+  - `ServerCapabilitiesCompletions(listChanged: true)` remains source-compatible
+    and still parses legacy payloads, but serializes as the stable MCP
+    `completions: {}` capability.
+  - `sendCompletionListChanged()` is deprecated and emits
+    `notifications/experimental/completions/list_changed` instead of the
+    non-spec stable method.
+- **URL-mode elicitation result echoes are no longer emitted**:
+  - Deprecated `ElicitResult.url` and `ElicitResult.elicitationId` fields remain
+    parse-compatible for legacy payloads, but `toJson()` omits them.
+  - Invalid `ElicitResult.action` values now fail during parsing.
 - **Lifecycle and elicitation validation are stricter**:
   - Peers that send operation requests before initialization completes now
     receive `invalidRequest` errors instead of reaching request handlers.
@@ -135,6 +172,8 @@
 - Added a `mcp_dart conformance --suite spec` gate for MCP 2025-11-25
   lifecycle, capability, elicitation, task-metadata, and progress-token
   raw-wire checks.
+- CI now runs `mcp_dart conformance --suite all --json` so JSON-RPC and
+  protocol-version fixtures are checked with the spec suite.
 
 ## 2.1.1
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ dart pub get
 - ✅ **All Capabilities** - Tools, Resources, Prompts, Sampling, Roots, Completions, Elicitation, Tasks
 - ✅ **Extension Support** - Generic `extensions` negotiation with typed MCP Apps helpers and TypeScript-style `registerAppTool` / `registerAppResource`
 - ✅ **Latest Content/Metadata Types** - `resource_link`, themed `icons`, and `annotations.lastModified`
-- ✅ **OAuth Authentication Hooks** - `OAuthClientProvider`, server authenticators, and OAuth2/PKCE examples
+- ✅ **OAuth Authentication Hooks** - `OAuthClientProvider`, MCP OAuth discovery helpers, server authenticators, and OAuth2/PKCE examples
 - ✅ **Transport Security Controls** - DNS rebinding protection and strict Streamable HTTP validation with compatibility toggles
 - ✅ **Type-Safe** - Comprehensive type definitions with null safety
 - ✅ **Cross-Platform** - Works on Linux, Windows, macOS, Web, and Flutter
@@ -172,7 +172,7 @@ Configure your server with AI hosts like Claude Desktop:
 
 ## Authentication
 
-This library provides OAuth-aware client and server authentication hooks, including `OAuthClientProvider` for StreamableHTTP clients and server-side `authenticator` callbacks. For OAuth2/PKCE guides and examples, see the [OAuth Authentication documentation](https://github.com/leehack/mcp_dart/tree/main/example/authentication).
+This library provides OAuth-aware client and server authentication hooks, including `OAuthClientProvider` for StreamableHTTP clients, optional `OAuthAuthorizationCodeProvider` discovery support, and server-side `authenticator` / `authenticationHandler` callbacks. For OAuth2/PKCE guides and examples, see the [OAuth Authentication documentation](https://github.com/leehack/mcp_dart/tree/main/example/authentication) and [transport authentication docs](https://github.com/leehack/mcp_dart/blob/main/doc/transports.md#streamable-http-authentication).
 
 ## Platform Support
 

--- a/doc/flutter-recipes.md
+++ b/doc/flutter-recipes.md
@@ -149,7 +149,7 @@ The Flutter example service at [`example/flutter_http_client/lib/services/stream
 
 For OAuth-protected remote servers, keep the OAuth flow outside widget code:
 
-1. Create an `OAuthClientProvider` implementation or reuse one of the patterns in [`example/authentication/`](../example/authentication/).
+1. Create an `OAuthClientProvider` implementation or reuse one of the patterns in [`example/authentication/`](../example/authentication/). For MCP OAuth discovery, also implement `OAuthAuthorizationCodeProvider` so the transport can build the authorization URL and token exchange from server metadata.
 2. Store tokens through a platform-appropriate secure storage layer.
 3. Pass the provider to `StreamableHttpClientTransportOptions(authProvider: ...)`.
 4. Extract the authorization `code` from the browser/deep-link callback, call `await transport.finishAuth(code);`, then retry the MCP connection. If you disposed the transport after the failed attempt, recreate it with the same `authProvider` first.

--- a/doc/interoperability.md
+++ b/doc/interoperability.md
@@ -48,7 +48,7 @@ cross-SDK fixture:
 ```bash
 cd packages/mcp_dart_cli
 dart pub get
-dart run bin/mcp_dart.dart conformance --suite spec --json
+dart run bin/mcp_dart.dart conformance --suite all --json
 ```
 
 ## Adding a new matrix row

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -600,7 +600,7 @@ try {
 )
 ```
 
-`JsonSchema.string(enumValues: ...)` and `JsonEnum` serialize as standard JSON Schema using `enum`; `JsonEnum` also emits `enumNames` when values include titles. Legacy `type: 'enum'` / `values` input is still accepted when parsing.
+`JsonSchema.string(enumValues: ...)` and untitled `JsonEnum` values serialize as standard JSON Schema using `enum`. Titled `JsonEnum` values serialize with `oneOf` or, for array items, `anyOf` const/title entries. Legacy `type: 'enum'` / `values` and `enumNames` input is still accepted when parsing.
 
 ### Array
 

--- a/doc/spec-coverage-2025-11-25.md
+++ b/doc/spec-coverage-2025-11-25.md
@@ -12,7 +12,7 @@ Run the matrix-critical local gate from the repository root:
 ```bash
 cd packages/mcp_dart_cli
 dart pub get
-dart run bin/mcp_dart.dart conformance --suite spec --json
+dart run bin/mcp_dart.dart conformance --suite all --json
 ```
 
 Run the cross-SDK interop gate from the repository root:
@@ -26,7 +26,7 @@ dart test -t interop
 ```
 
 CI runs both gates: the core workflow runs the TypeScript interop suite and the
-CLI spec conformance gate, while the CLI workflow runs the conformance gate with
+full CLI conformance gate, while the CLI workflow runs the conformance gate with
 the CLI test suite.
 
 ## Matrix
@@ -40,7 +40,7 @@ the CLI test suite.
 | Task metadata and related-task propagation | [Schema reference tasks](https://modelcontextprotocol.io/specification/2025-11-25/schema#tasks) | Task-augmented requests require negotiated task support, and related-task metadata is preserved only where task association is valid. | [`test/server/tasks_test.dart`](../test/server/tasks_test.dart), [`test/client/task_client_test.dart`](../test/client/task_client_test.dart), [`test/shared/protocol_task_handlers_test.dart`](../test/shared/protocol_task_handlers_test.dart), [`test/server/tasks_components_test.dart`](../test/server/tasks_components_test.dart), [`test/server/mcp_test.dart`](../test/server/mcp_test.dart) | [`test/interop/dart_client_with_ts_server_task_test.dart`](../test/interop/dart_client_with_ts_server_task_test.dart), [`test/interop/ts_client_with_dart_server_test.dart`](../test/interop/ts_client_with_dart_server_test.dart), [`test/interop/ts/src/client.ts`](../test/interop/ts/src/client.ts) | `tasks.strips-unnegotiated-related-task-metadata`; SDK-generated related responses and `tasks/result` overwrite reserved related-task metadata from the source task id while preserving unrelated handler metadata. | Verified |
 | Progress token preservation and progress stream validation | [Progress](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress) | Progress tokens preserve string-or-integer wire shape, malformed token shapes fail at decode boundaries, and progress values should advance monotonically for a request. | [`test/types_edge_cases_test.dart`](../test/types_edge_cases_test.dart), [`test/shared/progress_test.dart`](../test/shared/progress_test.dart), [`test/shared/protocol_test.dart`](../test/shared/protocol_test.dart) | [`test/interop/dart_client_with_ts_server_features_test.dart`](../test/interop/dart_client_with_ts_server_features_test.dart), [`test/interop/ts_client_with_dart_server_test.dart`](../test/interop/ts_client_with_dart_server_test.dart), [`test/interop/test_dart_server.dart`](../test/interop/test_dart_server.dart) | `jsonrpc.preserves-string-progress-token`, `progress.rejects-malformed-progress-token`; `RequestHandlerExtra.sendProgress` rejects repeated/decreasing progress before sending invalid notifications. | Verified |
 | Streamable HTTP sessions, stale recovery, SSE replay, and batch rejection | [Transports](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports) | Session IDs, stale-session retry, `Last-Event-ID` replay, protocol-version headers, and JSON-RPC batch rejection follow Streamable HTTP semantics. | [`test/client/streamable_https_test.dart`](../test/client/streamable_https_test.dart), [`test/server/streamable_https_test.dart`](../test/server/streamable_https_test.dart) | [`test/interop/dart_client_with_ts_server_test.dart`](../test/interop/dart_client_with_ts_server_test.dart), [`test/interop/ts_client_with_dart_server_test.dart`](../test/interop/ts_client_with_dart_server_test.dart), [`test/interop/ts/src/replay_client.ts`](../test/interop/ts/src/replay_client.ts) | Covered by `dart test -t interop` and unit tests; no separate CLI raw-wire case yet because this requires HTTP server fixtures. | Verified |
-| Auth/security deployment behavior | [Authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization), [Transports security notes](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning) | OAuth, DNS rebinding, Origin/Host restrictions, and production deployment toggles are covered by executable harnesses where practical. | [`test/server/streamable_security_harness_test.dart`](../test/server/streamable_security_harness_test.dart), [`test/server/streamable_mcp_server_test.dart`](../test/server/streamable_mcp_server_test.dart), [`test/example/oauth_client_example_test.dart`](../test/example/oauth_client_example_test.dart), [`example/authentication/`](../example/authentication/), [`doc/transports.md`](transports.md) | [`test/interop/ts_client_with_dart_server_test.dart`](../test/interop/ts_client_with_dart_server_test.dart), [`test/interop/ts/src/oauth_client.ts`](../test/interop/ts/src/oauth_client.ts) | Safe local-development and production Host/Origin scenarios, bearer-token gating, compatibility-toggle trade-offs, first-class OAuth protected-resource metadata/challenges, OAuth protected-resource discovery, PKCE S256 authorization redirect, resource-bound token exchange, and bearer reconnect are covered by tests. | Verified |
+| Auth/security deployment behavior | [Authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization), [Transports security notes](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning) | OAuth, DNS rebinding, Origin/Host restrictions, and production deployment toggles are covered by executable harnesses where practical. | [`test/client/streamable_https_test.dart`](../test/client/streamable_https_test.dart), [`test/server/streamable_security_harness_test.dart`](../test/server/streamable_security_harness_test.dart), [`test/server/streamable_mcp_server_test.dart`](../test/server/streamable_mcp_server_test.dart), [`test/example/oauth_client_example_test.dart`](../test/example/oauth_client_example_test.dart), [`example/authentication/`](../example/authentication/), [`doc/transports.md`](transports.md) | [`test/interop/ts_client_with_dart_server_test.dart`](../test/interop/ts_client_with_dart_server_test.dart), [`test/interop/ts/src/oauth_client.ts`](../test/interop/ts/src/oauth_client.ts) | Safe local-development and production Host/Origin scenarios, bearer-token gating, compatibility-toggle trade-offs, first-class OAuth protected-resource metadata/challenges, OAuth insufficient-scope 403 challenges, official TypeScript SDK upscoping, OAuth protected-resource discovery, PKCE S256 authorization redirect, resource-bound token exchange, and bearer reconnect are covered by tests. | Verified |
 
 ## Stable Conformance Case Names
 
@@ -62,7 +62,7 @@ Use exact-case filtering when diagnosing one row:
 
 ```bash
 cd packages/mcp_dart_cli
-dart run bin/mcp_dart.dart conformance --suite spec --case lifecycle.rejects-pre-initialize-request
+dart run bin/mcp_dart.dart conformance --suite all --case lifecycle.rejects-pre-initialize-request
 ```
 
 ## Known Gaps

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -124,7 +124,7 @@ String enum schemas serialize as standard JSON Schema:
 }
 ```
 
-`JsonEnum` uses the same standard output. When enum values include display titles, it emits `enumNames` for compatibility with clients that understand title metadata; mixed primitive enums without titles emit an `enum` array without a `type`. Legacy serialized input using `type: 'enum'` / `values` is still accepted by parsers.
+`JsonEnum` uses the same standard output. When enum values include display titles, it emits JSON Schema `oneOf` entries with `const` and `title`; when a titled enum is used as array items, it emits `anyOf` entries. Mixed primitive enums without titles emit an `enum` array without a `type`. Legacy serialized input using `type: 'enum'` / `values` or `enumNames` is still accepted by parsers.
 
 ### Const Values
 

--- a/doc/transports.md
+++ b/doc/transports.md
@@ -329,6 +329,44 @@ endpoint-specific well-known path, such as
 reverse proxy or TLS terminator rewrites the scheme, host, or port observed by
 the Dart server.
 
+Use `authenticationHandler` when authorization needs to distinguish invalid
+credentials from insufficient scope:
+
+```dart
+authenticationHandler: (request) {
+  final authorization = request.headers.value('Authorization');
+  if (authorization == 'Bearer token-with-tools-write') {
+    return const StreamableMcpAuthenticationResult.allow();
+  }
+  if (authorization == 'Bearer token-without-tools-write') {
+    return const StreamableMcpAuthenticationResult.insufficientScope(
+      scope: 'tools:write',
+      errorDescription: 'Need tools:write',
+    );
+  }
+  return const StreamableMcpAuthenticationResult.unauthorized();
+},
+```
+
+With `oauthProtectedResource` configured, `insufficientScope` returns
+`403 Forbidden` plus a bearer challenge containing
+`error="insufficient_scope"`, `scope="..."`, and `resource_metadata="..."`.
+The existing bool `authenticator` callback remains source-compatible for simple
+allow/deny checks.
+
+On the client side, `StreamableHttpClientTransport` keeps existing
+`OAuthClientProvider` implementations working. Providers that also implement
+`OAuthAuthorizationCodeProvider` let the transport perform MCP OAuth discovery:
+it parses bearer challenges, fetches OAuth Protected Resource Metadata, falls
+back to the endpoint/root well-known protected-resource paths when needed,
+discovers OAuth Authorization Server Metadata or OpenID Connect Discovery
+metadata, builds a PKCE S256 authorization URL with the MCP `resource`
+parameter, and exchanges the authorization code with `code_verifier` and
+`resource` when `finishAuth(code)` is called. The exchanged value passed to
+`saveTokens` is an `OAuthAuthorizationCodeTokens` instance, so providers that
+want `tokenType`, `expiresIn`, or granted `scope` can read them by type-checking
+that subtype while older `OAuthTokens` implementations stay source-compatible.
+
 Executable coverage for these recipes lives in
 [`test/server/streamable_security_harness_test.dart`](../test/server/streamable_security_harness_test.dart).
 It verifies that local-development and production allowlists reject untrusted
@@ -336,11 +374,13 @@ Host/Origin headers before authentication runs, and that authentication still
 gates requests after transport-level checks pass. The OAuth client PKCE flow is
 covered by
 [`test/example/oauth_client_example_test.dart`](../test/example/oauth_client_example_test.dart)
-with a local token endpoint. The first-class OAuth protected-resource helper is
-covered by
+with a local token endpoint, and the client transport discovery path is covered
+by [`test/client/streamable_https_test.dart`](../test/client/streamable_https_test.dart).
+The first-class OAuth protected-resource helper is covered by
 [`test/server/streamable_mcp_server_test.dart`](../test/server/streamable_mcp_server_test.dart)
 and the official TypeScript SDK OAuth interop path in
-[`test/interop/ts_client_with_dart_server_test.dart`](../test/interop/ts_client_with_dart_server_test.dart).
+[`test/interop/ts_client_with_dart_server_test.dart`](../test/interop/ts_client_with_dart_server_test.dart),
+including insufficient-scope upscoping from `tools:read` to `tools:write`.
 
 ### Streamable HTTP Strict Defaults
 

--- a/example/authentication/github_oauth_example.dart
+++ b/example/authentication/github_oauth_example.dart
@@ -53,20 +53,20 @@ class GitHubOAuthConfig {
 class GitHubOAuthTokens extends OAuthTokens {
   final DateTime issuedAt;
   final String tokenType;
-  final List<String> scope;
+  final List<String> grantedScopes;
 
   GitHubOAuthTokens({
     required super.accessToken,
     super.refreshToken,
     required this.tokenType,
-    required this.scope,
+    required this.grantedScopes,
   }) : issuedAt = DateTime.now();
 
   Map<String, dynamic> toJson() => {
         'access_token': accessToken,
         'refresh_token': refreshToken,
         'token_type': tokenType,
-        'scope': scope.join(' '),
+        'scope': grantedScopes.join(' '),
         'issued_at': issuedAt.toIso8601String(),
       };
 
@@ -75,8 +75,16 @@ class GitHubOAuthTokens extends OAuthTokens {
       accessToken: json['access_token'],
       refreshToken: json['refresh_token'],
       tokenType: json['token_type'] ?? 'bearer',
-      scope: (json['scope'] as String?)?.split(' ') ?? [],
+      grantedScopes: _parseScopes(json['scope'] as String?),
     );
+  }
+
+  static List<String> _parseScopes(String? rawScopes) {
+    return rawScopes
+            ?.split(RegExp(r'[\s,]+'))
+            .where((scope) => scope.isNotEmpty)
+            .toList() ??
+        [];
   }
 }
 
@@ -265,7 +273,10 @@ class GitHubOAuthProvider implements OAuthClientProvider {
         accessToken: data['access_token'],
         refreshToken: data['refresh_token'],
         tokenType: data['token_type'] ?? 'bearer',
-        scope: (data['scope'] as String?)?.split(',') ?? config.scopes,
+        grantedScopes:
+            GitHubOAuthTokens._parseScopes(data['scope'] as String?).isEmpty
+                ? config.scopes
+                : GitHubOAuthTokens._parseScopes(data['scope'] as String?),
       );
 
       await storage.saveTokens(tokens);
@@ -418,7 +429,7 @@ Future<void> main(List<String> args) async {
       final tokens = await authProvider.waitForAuthorization();
       print('\n✓ Authorization successful!');
       print('  Access token: ${tokens.accessToken.substring(0, 20)}...');
-      print('  Scopes: ${tokens.scope.join(', ')}\n');
+      print('  Scopes: ${tokens.grantedScopes.join(', ')}\n');
     } else {
       print('✓ Using existing tokens from storage\n');
     }

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;
 
+import 'package:crypto/crypto.dart' as crypto;
 import 'package:http/http.dart' as http;
 import 'package:mcp_dart/src/shared/transport.dart';
 import 'package:mcp_dart/src/types.dart';
@@ -137,6 +138,7 @@ class StreamableHttpClientTransport
   bool _staleSessionDetected = false;
   final StreamableHttpReconnectionOptions _reconnectionOptions;
   bool _isClosed = false;
+  _PendingOAuthAuthorization? _pendingOAuthAuthorization;
 
   @override
   void Function()? onclose;
@@ -160,29 +162,331 @@ class StreamableHttpClientTransport
             _defaultStreamableHttpReconnectionOptions,
         _httpClient = http.Client();
 
-  Future<void> _authThenStart() async {
-    if (_authProvider == null) {
-      throw UnauthorizedError("No auth provider");
+  bool _isAuthorizationRequiredResponse(
+    int statusCode,
+    Map<String, String> headers,
+  ) {
+    if (statusCode == 401) {
+      return true;
     }
-
-    AuthResult result;
-    try {
-      result = await auth(_authProvider!, serverUrl: _url);
-    } catch (error) {
-      if (error is Error) {
-        onerror?.call(error);
-      } else {
-        onerror?.call(McpError(0, error.toString()));
-      }
-      rethrow;
+    if (statusCode != 403) {
+      return false;
     }
-
-    if (result != "AUTHORIZED") {
-      throw UnauthorizedError();
-    }
-
-    return await _startOrAuthSse(const StartSseOptions());
+    final challenge =
+        OAuthBearerChallengeParameters.fromHeader(headers['www-authenticate']);
+    return challenge?.error == 'insufficient_scope';
   }
+
+  Future<void> _handleAuthorizationRequired(
+    http.StreamedResponse response,
+  ) async {
+    final authProvider = _authProvider;
+    if (authProvider == null) {
+      await response.stream.drain<void>();
+      throw UnauthorizedError('Authentication required');
+    }
+
+    final challenge = OAuthBearerChallengeParameters.fromHeader(
+      response.headers['www-authenticate'],
+    );
+    await response.stream.drain<void>();
+
+    if (authProvider is OAuthAuthorizationCodeProvider) {
+      final authorizationRequest = await _prepareAuthorizationRequest(
+        authProvider,
+        challenge,
+      );
+      await authProvider.redirectToAuthorizationUrl(
+        authorizationRequest.authorizationUri,
+      );
+      throw UnauthorizedError('Authentication required');
+    }
+
+    await authProvider.redirectToAuthorization();
+    throw UnauthorizedError('Authentication required');
+  }
+
+  Future<OAuthAuthorizationRequest> _prepareAuthorizationRequest(
+    OAuthAuthorizationCodeProvider provider,
+    OAuthBearerChallengeParameters? challenge,
+  ) async {
+    final protectedResourceMetadata =
+        await _discoverProtectedResourceMetadata(challenge);
+    final authorizationServerUri =
+        protectedResourceMetadata.authorizationServers.isEmpty
+            ? null
+            : protectedResourceMetadata.authorizationServers.first;
+    if (authorizationServerUri == null) {
+      throw UnauthorizedError(
+        'Protected resource metadata did not include authorization_servers',
+      );
+    }
+
+    final authorizationServerMetadata =
+        await _discoverAuthorizationServerMetadata(authorizationServerUri);
+    final authorizationEndpoint =
+        authorizationServerMetadata.authorizationEndpoint;
+    final tokenEndpoint = authorizationServerMetadata.tokenEndpoint;
+    if (authorizationEndpoint == null || tokenEndpoint == null) {
+      throw UnauthorizedError(
+        'Authorization server metadata is missing authorization_endpoint or token_endpoint',
+      );
+    }
+
+    final methods = authorizationServerMetadata.codeChallengeMethodsSupported;
+    if (methods != null && !methods.contains('S256')) {
+      throw UnauthorizedError(
+        'Authorization server does not advertise PKCE S256 support',
+      );
+    }
+
+    final scope = challenge?.scope ??
+        (provider.scopes.isEmpty ? null : provider.scopes.join(' ')) ??
+        protectedResourceMetadata.scopesSupported?.join(' ');
+    final codeVerifier = _generatePkceCodeVerifier();
+    final codeChallenge = _generatePkceS256Challenge(codeVerifier);
+    final state = _generateOAuthState();
+
+    final authorizationUri = authorizationEndpoint.replace(
+      queryParameters: {
+        ...authorizationEndpoint.queryParameters,
+        'response_type': 'code',
+        'client_id': provider.clientId,
+        'redirect_uri': provider.redirectUri.toString(),
+        'code_challenge': codeChallenge,
+        'code_challenge_method': 'S256',
+        'state': state,
+        'resource': protectedResourceMetadata.resource.toString(),
+        if (scope != null && scope.isNotEmpty) 'scope': scope,
+      },
+    );
+
+    final authorizationRequest = OAuthAuthorizationRequest(
+      authorizationUri: authorizationUri,
+      codeVerifier: codeVerifier,
+      codeChallenge: codeChallenge,
+      state: state,
+      resource: protectedResourceMetadata.resource,
+      scope: scope,
+    );
+
+    _pendingOAuthAuthorization = _PendingOAuthAuthorization(
+      tokenEndpoint: tokenEndpoint,
+      codeVerifier: codeVerifier,
+      clientId: provider.clientId,
+      clientSecret: provider.clientSecret,
+      redirectUri: provider.redirectUri,
+      resource: protectedResourceMetadata.resource,
+    );
+
+    return authorizationRequest;
+  }
+
+  Future<OAuthProtectedResourceMetadataDocument>
+      _discoverProtectedResourceMetadata(
+    OAuthBearerChallengeParameters? challenge,
+  ) async {
+    final resourceMetadata = challenge?.resourceMetadata;
+    if (resourceMetadata != null) {
+      return _fetchProtectedResourceMetadata(resourceMetadata);
+    }
+
+    final errors = <Object>[];
+    for (final uri in _protectedResourceMetadataCandidates()) {
+      try {
+        return await _fetchProtectedResourceMetadata(uri);
+      } catch (error) {
+        errors.add(error);
+      }
+    }
+
+    throw UnauthorizedError(
+      'Failed to discover OAuth protected-resource metadata: $errors',
+    );
+  }
+
+  List<Uri> _protectedResourceMetadataCandidates() {
+    final candidates = <Uri>[];
+    final endpointPath = _url.path.isEmpty ? '/' : _url.path;
+    if (endpointPath != '/') {
+      candidates.add(
+        _url.replace(
+          path: '/.well-known/oauth-protected-resource$endpointPath',
+          queryParameters: const {},
+          fragment: null,
+        ),
+      );
+    }
+    candidates.add(
+      _url.replace(
+        path: '/.well-known/oauth-protected-resource',
+        queryParameters: const {},
+        fragment: null,
+      ),
+    );
+
+    final seen = <String>{};
+    return [
+      for (final candidate in candidates)
+        if (seen.add(candidate.toString())) candidate,
+    ];
+  }
+
+  Future<OAuthProtectedResourceMetadataDocument>
+      _fetchProtectedResourceMetadata(Uri uri) async {
+    final response = await _httpClient.get(
+      uri,
+      headers: const {'Accept': 'application/json'},
+    );
+    if (response.statusCode != 200) {
+      throw UnauthorizedError(
+        'Protected-resource metadata request failed with HTTP ${response.statusCode}',
+      );
+    }
+    final json = jsonDecode(response.body);
+    if (json is! Map<String, dynamic>) {
+      throw UnauthorizedError(
+        'Protected-resource metadata must be a JSON object',
+      );
+    }
+    return OAuthProtectedResourceMetadataDocument.fromJson(json);
+  }
+
+  Future<OAuthAuthorizationServerMetadataDocument>
+      _discoverAuthorizationServerMetadata(Uri issuer) async {
+    final errors = <Object>[];
+    for (final uri in _authorizationServerMetadataCandidates(issuer)) {
+      try {
+        return await _fetchAuthorizationServerMetadata(uri);
+      } catch (error) {
+        errors.add(error);
+      }
+    }
+    throw UnauthorizedError(
+      'Failed to discover OAuth authorization-server metadata: $errors',
+    );
+  }
+
+  List<Uri> _authorizationServerMetadataCandidates(Uri issuer) {
+    final issuerPath = issuer.path.isEmpty ? '' : issuer.path;
+    final pathPrefix = issuerPath == '/' ? '' : issuerPath;
+    final candidates = [
+      issuer.replace(
+        path: '/.well-known/oauth-authorization-server$pathPrefix',
+        queryParameters: const {},
+        fragment: null,
+      ),
+      issuer.replace(
+        path: '/.well-known/openid-configuration$pathPrefix',
+        queryParameters: const {},
+        fragment: null,
+      ),
+      issuer.replace(
+        path:
+            '${pathPrefix.isEmpty ? '' : pathPrefix}/.well-known/oauth-authorization-server',
+        queryParameters: const {},
+        fragment: null,
+      ),
+      issuer.replace(
+        path:
+            '${pathPrefix.isEmpty ? '' : pathPrefix}/.well-known/openid-configuration',
+        queryParameters: const {},
+        fragment: null,
+      ),
+    ];
+
+    final seen = <String>{};
+    return [
+      for (final candidate in candidates)
+        if (seen.add(candidate.toString())) candidate,
+    ];
+  }
+
+  Future<OAuthAuthorizationServerMetadataDocument>
+      _fetchAuthorizationServerMetadata(Uri uri) async {
+    final response = await _httpClient.get(
+      uri,
+      headers: const {'Accept': 'application/json'},
+    );
+    if (response.statusCode != 200) {
+      throw UnauthorizedError(
+        'Authorization-server metadata request failed with HTTP ${response.statusCode}',
+      );
+    }
+    final json = jsonDecode(response.body);
+    if (json is! Map<String, dynamic>) {
+      throw UnauthorizedError(
+        'Authorization-server metadata must be a JSON object',
+      );
+    }
+    return OAuthAuthorizationServerMetadataDocument.fromJson(json);
+  }
+
+  Future<OAuthTokens> _exchangeAuthorizationCode(
+    OAuthAuthorizationCodeProvider provider,
+    String authorizationCode,
+    _PendingOAuthAuthorization pendingAuthorization,
+  ) async {
+    final response = await _httpClient.post(
+      pendingAuthorization.tokenEndpoint,
+      headers: const {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Accept': 'application/json',
+      },
+      body: {
+        'grant_type': 'authorization_code',
+        'code': authorizationCode,
+        'redirect_uri': pendingAuthorization.redirectUri.toString(),
+        'client_id': pendingAuthorization.clientId,
+        if (pendingAuthorization.clientSecret != null)
+          'client_secret': pendingAuthorization.clientSecret!,
+        'code_verifier': pendingAuthorization.codeVerifier,
+        'resource': pendingAuthorization.resource.toString(),
+      },
+    );
+    if (response.statusCode != 200) {
+      throw UnauthorizedError(
+        'Token exchange failed with HTTP ${response.statusCode}',
+      );
+    }
+
+    final json = jsonDecode(response.body);
+    if (json is! Map<String, dynamic>) {
+      throw UnauthorizedError('Token response must be a JSON object');
+    }
+    final accessToken = json['access_token'];
+    if (accessToken is! String || accessToken.isEmpty) {
+      throw UnauthorizedError('Token response did not include access_token');
+    }
+
+    final tokens = OAuthAuthorizationCodeTokens(
+      accessToken: accessToken,
+      refreshToken: json['refresh_token'] as String?,
+      tokenType: json['token_type'] as String? ?? 'Bearer',
+      expiresIn: json['expires_in'] as int?,
+      scope: json['scope'] as String?,
+    );
+    await provider.saveTokens(tokens);
+    return tokens;
+  }
+
+  String _generatePkceCodeVerifier() =>
+      _base64UrlNoPadding(_secureRandomBytes(32));
+
+  String _generatePkceS256Challenge(String verifier) {
+    final digest = crypto.sha256.convert(utf8.encode(verifier));
+    return _base64UrlNoPadding(digest.bytes);
+  }
+
+  String _generateOAuthState() => _base64UrlNoPadding(_secureRandomBytes(16));
+
+  List<int> _secureRandomBytes(int length) {
+    final random = math.Random.secure();
+    return List<int>.generate(length, (_) => random.nextInt(256));
+  }
+
+  String _base64UrlNoPadding(List<int> bytes) =>
+      base64UrlEncode(bytes).replaceAll('=', '');
 
   Future<Map<String, String>> _commonHeaders() async {
     final headers = <String, String>{};
@@ -243,9 +547,12 @@ class StreamableHttpClientTransport
       final response = await _httpClient.send(request);
 
       if (response.statusCode != 200) {
-        if (response.statusCode == 401 && _authProvider != null) {
-          // Need to authenticate
-          return await _authThenStart();
+        if (_authProvider != null &&
+            _isAuthorizationRequiredResponse(
+              response.statusCode,
+              response.headers,
+            )) {
+          return await _handleAuthorizationRequired(response);
         }
 
         // 405 indicates that the server does not offer an SSE stream at GET endpoint
@@ -558,8 +865,21 @@ class StreamableHttpClientTransport
       throw UnauthorizedError("No auth provider");
     }
 
+    final authProvider = _authProvider!;
+    final pendingAuthorization = _pendingOAuthAuthorization;
+    if (authProvider is OAuthAuthorizationCodeProvider &&
+        pendingAuthorization != null) {
+      await _exchangeAuthorizationCode(
+        authProvider,
+        authorizationCode,
+        pendingAuthorization,
+      );
+      _pendingOAuthAuthorization = null;
+      return;
+    }
+
     final result = await auth(
-      _authProvider!,
+      authProvider,
       serverUrl: _url,
       authorizationCode: authorizationCode,
     );
@@ -630,9 +950,14 @@ class StreamableHttpClientTransport
       if (_authProvider != null) {
         final tokens = await _authProvider!.tokens();
         if (tokens == null) {
-          // No tokens available - trigger authentication flow
-          await _authProvider!.redirectToAuthorization();
-          throw UnauthorizedError('Authentication required');
+          if (_authProvider is OAuthAuthorizationCodeProvider) {
+            // Let the server return a challenge so discovery can follow MCP
+            // protected-resource metadata before redirecting.
+          } else {
+            // No tokens available - trigger authentication flow
+            await _authProvider!.redirectToAuthorization();
+            throw UnauthorizedError('Authentication required');
+          }
         }
       }
 
@@ -648,10 +973,12 @@ class StreamableHttpClientTransport
       final response = await _httpClient.send(request);
 
       if (response.statusCode < 200 || response.statusCode >= 300) {
-        if (response.statusCode == 401 && _authProvider != null) {
-          // Authentication failed with the server - try to refresh or redirect
-          await _authProvider!.redirectToAuthorization();
-          throw UnauthorizedError('Authentication failed with the server');
+        if (_authProvider != null &&
+            _isAuthorizationRequiredResponse(
+              response.statusCode,
+              response.headers,
+            )) {
+          return await _handleAuthorizationRequired(response);
         }
 
         final text = await response.stream.transform(utf8.decoder).join();
@@ -866,12 +1193,309 @@ abstract class OAuthClientProvider {
   Future<void> redirectToAuthorization();
 }
 
+/// Optional OAuth provider interface for first-class MCP authorization-code flow.
+abstract class OAuthAuthorizationCodeProvider implements OAuthClientProvider {
+  /// OAuth client id.
+  String get clientId;
+
+  /// Redirect URI registered for the client.
+  Uri get redirectUri;
+
+  /// Optional client secret for confidential clients.
+  String? get clientSecret;
+
+  /// Requested scopes when a bearer challenge does not provide one.
+  List<String> get scopes;
+
+  /// Redirect the user agent to [authorizationUri].
+  Future<void> redirectToAuthorizationUrl(Uri authorizationUri);
+
+  /// Persist exchanged OAuth tokens.
+  Future<void> saveTokens(OAuthTokens tokens);
+}
+
+/// Parsed Bearer `WWW-Authenticate` challenge parameters.
+class OAuthBearerChallengeParameters {
+  final Uri? resourceMetadata;
+  final String? scope;
+  final String? error;
+  final String? errorDescription;
+  final Map<String, String> additionalParameters;
+
+  const OAuthBearerChallengeParameters({
+    this.resourceMetadata,
+    this.scope,
+    this.error,
+    this.errorDescription,
+    this.additionalParameters = const {},
+  });
+
+  factory OAuthBearerChallengeParameters.fromParameters(
+    Map<String, String> parameters,
+  ) {
+    final knownKeys = {
+      'resource_metadata',
+      'scope',
+      'error',
+      'error_description',
+    };
+    final resourceMetadata = parameters['resource_metadata'];
+    return OAuthBearerChallengeParameters(
+      resourceMetadata:
+          resourceMetadata == null ? null : Uri.parse(resourceMetadata),
+      scope: parameters['scope'],
+      error: parameters['error'],
+      errorDescription: parameters['error_description'],
+      additionalParameters: Map<String, String>.from(parameters)
+        ..removeWhere((key, value) => knownKeys.contains(key)),
+    );
+  }
+
+  static OAuthBearerChallengeParameters? fromHeader(String? header) {
+    if (header == null) {
+      return null;
+    }
+
+    final trimmed = header.trim();
+    if (!trimmed.toLowerCase().startsWith('bearer')) {
+      return null;
+    }
+
+    final parameters = _parseAuthenticateParameters(
+      trimmed.substring('bearer'.length).trim(),
+    );
+    return OAuthBearerChallengeParameters.fromParameters(parameters);
+  }
+}
+
+/// OAuth Protected Resource Metadata discovered by the client transport.
+class OAuthProtectedResourceMetadataDocument {
+  final Uri resource;
+  final List<Uri> authorizationServers;
+  final List<String>? bearerMethodsSupported;
+  final List<String>? scopesSupported;
+  final Map<String, dynamic> additionalFields;
+
+  const OAuthProtectedResourceMetadataDocument({
+    required this.resource,
+    required this.authorizationServers,
+    this.bearerMethodsSupported,
+    this.scopesSupported,
+    this.additionalFields = const {},
+  });
+
+  factory OAuthProtectedResourceMetadataDocument.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    final resource = json['resource'];
+    final authorizationServers = json['authorization_servers'];
+    if (resource is! String || authorizationServers is! List) {
+      throw const FormatException(
+        'Protected-resource metadata requires resource and authorization_servers.',
+      );
+    }
+
+    return OAuthProtectedResourceMetadataDocument(
+      resource: Uri.parse(resource),
+      authorizationServers: authorizationServers
+          .map((value) => Uri.parse(value as String))
+          .toList(),
+      bearerMethodsSupported:
+          (json['bearer_methods_supported'] as List?)?.cast<String>(),
+      scopesSupported: (json['scopes_supported'] as List?)?.cast<String>(),
+      additionalFields: Map<String, dynamic>.from(json)
+        ..removeWhere(
+          (key, value) => {
+            'resource',
+            'authorization_servers',
+            'bearer_methods_supported',
+            'scopes_supported',
+          }.contains(key),
+        ),
+    );
+  }
+}
+
+/// OAuth Authorization Server Metadata discovered by the client transport.
+class OAuthAuthorizationServerMetadataDocument {
+  final Uri issuer;
+  final Uri? authorizationEndpoint;
+  final Uri? tokenEndpoint;
+  final List<String>? codeChallengeMethodsSupported;
+  final Map<String, dynamic> additionalFields;
+
+  const OAuthAuthorizationServerMetadataDocument({
+    required this.issuer,
+    this.authorizationEndpoint,
+    this.tokenEndpoint,
+    this.codeChallengeMethodsSupported,
+    this.additionalFields = const {},
+  });
+
+  factory OAuthAuthorizationServerMetadataDocument.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    final issuer = json['issuer'];
+    if (issuer is! String) {
+      throw const FormatException(
+        'Authorization-server metadata requires issuer.',
+      );
+    }
+
+    final authorizationEndpoint = json['authorization_endpoint'];
+    final tokenEndpoint = json['token_endpoint'];
+    return OAuthAuthorizationServerMetadataDocument(
+      issuer: Uri.parse(issuer),
+      authorizationEndpoint: authorizationEndpoint is String
+          ? Uri.parse(authorizationEndpoint)
+          : null,
+      tokenEndpoint: tokenEndpoint is String ? Uri.parse(tokenEndpoint) : null,
+      codeChallengeMethodsSupported:
+          (json['code_challenge_methods_supported'] as List?)?.cast<String>(),
+      additionalFields: Map<String, dynamic>.from(json)
+        ..removeWhere(
+          (key, value) => {
+            'issuer',
+            'authorization_endpoint',
+            'token_endpoint',
+            'code_challenge_methods_supported',
+          }.contains(key),
+        ),
+    );
+  }
+}
+
+/// Authorization request built from MCP OAuth discovery metadata.
+class OAuthAuthorizationRequest {
+  final Uri authorizationUri;
+  final String codeVerifier;
+  final String codeChallenge;
+  final String state;
+  final Uri resource;
+  final String? scope;
+
+  const OAuthAuthorizationRequest({
+    required this.authorizationUri,
+    required this.codeVerifier,
+    required this.codeChallenge,
+    required this.state,
+    required this.resource,
+    this.scope,
+  });
+}
+
 /// Represents OAuth tokens
 class OAuthTokens {
   final String accessToken;
   final String? refreshToken;
 
-  OAuthTokens({required this.accessToken, this.refreshToken});
+  OAuthTokens({
+    required this.accessToken,
+    this.refreshToken,
+  });
+}
+
+/// OAuth authorization-code token response metadata.
+///
+/// The transport passes this subtype to [OAuthAuthorizationCodeProvider.saveTokens]
+/// after exchanging an authorization code. It keeps [OAuthTokens] source-compatible
+/// for existing subclasses while exposing standard token response fields.
+class OAuthAuthorizationCodeTokens extends OAuthTokens {
+  final String tokenType;
+  final int? expiresIn;
+  final String? scope;
+
+  OAuthAuthorizationCodeTokens({
+    required super.accessToken,
+    super.refreshToken,
+    this.tokenType = 'Bearer',
+    this.expiresIn,
+    this.scope,
+  });
+}
+
+class _PendingOAuthAuthorization {
+  final Uri tokenEndpoint;
+  final String codeVerifier;
+  final String clientId;
+  final String? clientSecret;
+  final Uri redirectUri;
+  final Uri resource;
+
+  const _PendingOAuthAuthorization({
+    required this.tokenEndpoint,
+    required this.codeVerifier,
+    required this.clientId,
+    required this.clientSecret,
+    required this.redirectUri,
+    required this.resource,
+  });
+}
+
+Map<String, String> _parseAuthenticateParameters(String input) {
+  final parameters = <String, String>{};
+  var index = 0;
+
+  void skipSeparators() {
+    while (index < input.length &&
+        (input.codeUnitAt(index) == 0x20 || input[index] == ',')) {
+      index += 1;
+    }
+  }
+
+  while (index < input.length) {
+    skipSeparators();
+    if (index >= input.length) {
+      break;
+    }
+
+    final keyStart = index;
+    while (index < input.length && input[index] != '=' && input[index] != ',') {
+      index += 1;
+    }
+    if (index >= input.length || input[index] != '=') {
+      break;
+    }
+
+    final key = input.substring(keyStart, index).trim();
+    index += 1;
+
+    String value;
+    if (index < input.length && input[index] == '"') {
+      index += 1;
+      final buffer = StringBuffer();
+      while (index < input.length) {
+        final char = input[index];
+        if (char == '\\') {
+          index += 1;
+          if (index < input.length) {
+            buffer.write(input[index]);
+            index += 1;
+          }
+          continue;
+        }
+        if (char == '"') {
+          index += 1;
+          break;
+        }
+        buffer.write(char);
+        index += 1;
+      }
+      value = buffer.toString();
+    } else {
+      final valueStart = index;
+      while (index < input.length && input[index] != ',') {
+        index += 1;
+      }
+      value = input.substring(valueStart, index).trim();
+    }
+
+    if (key.isNotEmpty) {
+      parameters[key] = value;
+    }
+  }
+
+  return parameters;
 }
 
 /// Result of an authentication attempt

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -463,11 +463,21 @@ class StreamableHttpClientTransport
       accessToken: accessToken,
       refreshToken: json['refresh_token'] as String?,
       tokenType: json['token_type'] as String? ?? 'Bearer',
-      expiresIn: json['expires_in'] as int?,
+      expiresIn: _parseExpiresIn(json['expires_in']),
       scope: json['scope'] as String?,
     );
     await provider.saveTokens(tokens);
     return tokens;
+  }
+
+  int? _parseExpiresIn(Object? value) {
+    if (value == null) {
+      return null;
+    }
+    if (value is num && value.isFinite) {
+      return value.toInt();
+    }
+    throw UnauthorizedError('Token response expires_in must be a number');
   }
 
   String _generatePkceCodeVerifier() =>
@@ -1240,9 +1250,15 @@ class OAuthBearerChallengeParameters {
       'error_description',
     };
     final resourceMetadata = parameters['resource_metadata'];
+    Uri? parsedResourceMetadata;
+    if (resourceMetadata != null) {
+      final uri = Uri.tryParse(resourceMetadata);
+      if (uri != null && uri.hasScheme) {
+        parsedResourceMetadata = uri;
+      }
+    }
     return OAuthBearerChallengeParameters(
-      resourceMetadata:
-          resourceMetadata == null ? null : Uri.parse(resourceMetadata),
+      resourceMetadata: parsedResourceMetadata,
       scope: parameters['scope'],
       error: parameters['error'],
       errorDescription: parameters['error_description'],

--- a/lib/src/client/task_client.dart
+++ b/lib/src/client/task_client.dart
@@ -12,7 +12,10 @@ class _RawResult implements BaseResultData {
   _RawResult(this.data, {this.meta});
 
   @override
-  Map<String, dynamic> toJson() => data;
+  Map<String, dynamic> toJson() => {
+        ...data,
+        if (meta != null) '_meta': meta,
+      };
 }
 
 /// Helper to handle task-augmented tool calls and interactions.

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -1298,7 +1298,7 @@ class McpServer {
     server.assertCanSetRequestHandler(Method.completionComplete);
     server.registerCapabilities(
       const ServerCapabilities(
-        completions: ServerCapabilitiesCompletions(listChanged: true),
+        completions: ServerCapabilitiesCompletions(),
       ),
     );
     server.setRequestHandler<JsonRpcCompleteRequest>(

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -403,9 +403,14 @@ class Server extends Protocol {
         break;
 
       case Method.notificationsCompletionsListChanged:
-        if (!(_capabilities.completions?.listChanged ?? false)) {
+        throw StateError(
+          "$method is not part of stable MCP 2025-11-25. Use ${Method.notificationsExperimentalCompletionsListChanged} for extension behavior.",
+        );
+
+      case Method.notificationsExperimentalCompletionsListChanged:
+        if (_capabilities.completions == null) {
           throw StateError(
-            "Server does not support completion list changed notifications capability (required for sending $method)",
+            "Server does not support completions capability (required for sending $method)",
           );
         }
         break;
@@ -755,7 +760,13 @@ class Server extends Protocol {
     return notification(notif);
   }
 
-  /// Sends a `notifications/completions/list_changed` notification to the client.
+  /// Sends an experimental completion list-changed notification to the client.
+  ///
+  /// Stable MCP 2025-11-25 does not define a completion list-changed
+  /// notification or capability flag.
+  @Deprecated(
+    'Stable MCP 2025-11-25 does not define completion list-changed notifications.',
+  )
   Future<void> sendCompletionListChanged() {
     const notif = JsonRpcCompletionListChangedNotification();
     return notification(notif);

--- a/lib/src/server/streamable_mcp_server.dart
+++ b/lib/src/server/streamable_mcp_server.dart
@@ -154,6 +154,61 @@ class OAuthProtectedResourceOptions {
   });
 }
 
+/// Result returned by [StreamableMcpServer.authenticationHandler].
+class StreamableMcpAuthenticationResult {
+  final _StreamableMcpAuthenticationStatus _status;
+
+  /// Scope required for an insufficient-scope response.
+  final String? scope;
+
+  /// Optional human-readable bearer error description.
+  final String? errorDescription;
+
+  /// Additional bearer challenge parameters.
+  final Map<String, String> additionalChallengeParameters;
+
+  const StreamableMcpAuthenticationResult._(
+    this._status, {
+    this.scope,
+    this.errorDescription,
+    this.additionalChallengeParameters = const {},
+  });
+
+  /// Allows the request to proceed.
+  const StreamableMcpAuthenticationResult.allow()
+      : this._(_StreamableMcpAuthenticationStatus.allow);
+
+  /// Rejects the request as unauthenticated or invalidly authenticated.
+  const StreamableMcpAuthenticationResult.unauthorized({
+    String? errorDescription,
+    Map<String, String> additionalChallengeParameters = const {},
+  }) : this._(
+          _StreamableMcpAuthenticationStatus.unauthorized,
+          errorDescription: errorDescription,
+          additionalChallengeParameters: additionalChallengeParameters,
+        );
+
+  /// Rejects the request because the presented token lacks required scope.
+  const StreamableMcpAuthenticationResult.insufficientScope({
+    required String scope,
+    String? errorDescription,
+    Map<String, String> additionalChallengeParameters = const {},
+  }) : this._(
+          _StreamableMcpAuthenticationStatus.insufficientScope,
+          scope: scope,
+          errorDescription: errorDescription,
+          additionalChallengeParameters: additionalChallengeParameters,
+        );
+
+  bool get _allowed => _status == _StreamableMcpAuthenticationStatus.allow;
+}
+
+enum _StreamableMcpAuthenticationStatus {
+  allow,
+  unauthorized,
+  insufficientScope,
+}
+
 /// A high-level server implementation that manages multiple MCP sessions over Streamable HTTP.
 ///
 /// This server handles:
@@ -199,6 +254,14 @@ class StreamableMcpServer {
   /// Returns true if the request is allowed, false otherwise.
   final FutureOr<bool> Function(HttpRequest request)? authenticator;
 
+  /// Optional callback that can return detailed authentication failures.
+  ///
+  /// Use this instead of [authenticator] when a server needs to distinguish
+  /// invalid/missing credentials from OAuth insufficient-scope failures.
+  final FutureOr<StreamableMcpAuthenticationResult> Function(
+    HttpRequest request,
+  )? authenticationHandler;
+
   /// Optional OAuth protected-resource metadata and challenge behavior.
   ///
   /// When configured, the server serves OAuth Protected Resource Metadata and
@@ -236,6 +299,7 @@ class StreamableMcpServer {
     this.path = '/mcp',
     this.eventStore,
     this.authenticator,
+    this.authenticationHandler,
     this.oauthProtectedResource,
     this.enableDnsRebindingProtection = true,
     this.allowedHosts,
@@ -315,7 +379,25 @@ class StreamableMcpServer {
       return;
     }
 
-    if (authenticator != null) {
+    final authenticationHandler = this.authenticationHandler;
+    if (authenticationHandler != null) {
+      StreamableMcpAuthenticationResult authResult;
+      try {
+        authResult = await authenticationHandler(request);
+      } catch (e) {
+        _logger.error('Authentication error: $e');
+        request.response
+          ..statusCode = HttpStatus.internalServerError
+          ..write('Authentication Error')
+          ..close();
+        return;
+      }
+
+      if (!authResult._allowed) {
+        await _respondAuthenticationFailure(request, authResult);
+        return;
+      }
+    } else if (authenticator != null) {
       bool allowed = false;
       try {
         allowed = await authenticator!(request);
@@ -599,6 +681,16 @@ class StreamableMcpServer {
   }
 
   Future<void> _respondUnauthorized(HttpRequest request) async {
+    await _respondAuthenticationFailure(
+      request,
+      const StreamableMcpAuthenticationResult.unauthorized(),
+    );
+  }
+
+  Future<void> _respondAuthenticationFailure(
+    HttpRequest request,
+    StreamableMcpAuthenticationResult result,
+  ) async {
     final options = oauthProtectedResource;
     if (options == null) {
       request.response
@@ -608,28 +700,44 @@ class StreamableMcpServer {
       return;
     }
 
+    final insufficientScope =
+        result._status == _StreamableMcpAuthenticationStatus.insufficientScope;
     request.response
-      ..statusCode = HttpStatus.unauthorized
+      ..statusCode =
+          insufficientScope ? HttpStatus.forbidden : HttpStatus.unauthorized
       ..headers.set(
         HttpHeaders.wwwAuthenticateHeader,
-        _wwwAuthenticateHeaderValue(request, options),
+        _wwwAuthenticateHeaderValue(request, options, result),
       )
-      ..write('Unauthorized');
+      ..write(insufficientScope ? 'Forbidden' : 'Unauthorized');
     await request.response.close();
   }
 
   String _wwwAuthenticateHeaderValue(
     HttpRequest request,
     OAuthProtectedResourceOptions options,
+    StreamableMcpAuthenticationResult result,
   ) {
     final metadataUri = options.metadataUri ??
         _absoluteUriForRequest(
           request,
           _protectedResourceMetadataPath(options),
         );
+    if (result._status ==
+        _StreamableMcpAuthenticationStatus.insufficientScope) {
+      return OAuthBearerChallenge.insufficientScope(
+        resourceMetadata: metadataUri,
+        scope: result.scope!,
+        errorDescription: result.errorDescription,
+        additionalParameters: result.additionalChallengeParameters,
+      ).toHeaderValue();
+    }
+
     return OAuthBearerChallenge(
       resourceMetadata: metadataUri,
       scope: options.scope,
+      errorDescription: result.errorDescription,
+      additionalParameters: result.additionalChallengeParameters,
     ).toHeaderValue();
   }
 

--- a/lib/src/shared/json_schema/json_schema.dart
+++ b/lib/src/shared/json_schema/json_schema.dart
@@ -747,12 +747,22 @@ class JsonArray extends JsonSchema {
 
   @override
   Map<String, dynamic> toJson() {
+    final itemSchema = items;
+    final serializedItems = itemSchema == null
+        ? null
+        : switch (itemSchema) {
+            final JsonEnum enumItems => enumItems._toJson(
+                titledStringConstListKeyword: 'anyOf',
+              ),
+            final JsonSchema schema => schema.toJson(),
+          };
+
     return {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
       if (_hasDefault) 'default': defaultValue,
       'type': 'array',
-      if (items != null) 'items': items!.toJson(),
+      if (serializedItems != null) 'items': serializedItems,
       if (minItems != null) 'minItems': minItems,
       if (maxItems != null) 'maxItems': maxItems,
       if (uniqueItems != null) 'uniqueItems': uniqueItems,
@@ -1351,7 +1361,11 @@ class JsonEnum extends JsonSchema {
   }
 
   @override
-  Map<String, dynamic> toJson() {
+  Map<String, dynamic> toJson() => _toJson();
+
+  Map<String, dynamic> _toJson({
+    String titledStringConstListKeyword = 'oneOf',
+  }) {
     final normalizedEntries =
         values.map((value) => _normalizeEntry(value)).toList(growable: false);
     final hasTitles = normalizedEntries.any((entry) => entry.title != null);
@@ -1383,29 +1397,11 @@ class JsonEnum extends JsonSchema {
       };
     }
 
-    final enumValuesKeyword = _enumValuesKeyword;
-    if (enumValuesKeyword != null) {
+    if (hasTitles) {
       return {
         ...annotations,
-        if (_enumTypeKeyword != null) 'type': _enumTypeKeyword,
-        enumValuesKeyword:
-            normalizedEntries.map((entry) => entry.value).toList(),
-        if (hasTitles)
-          'enumNames': normalizedEntries
-              .map((entry) => entry.title ?? '${entry.value}')
-              .toList(),
-      };
-    }
-
-    return {
-      ...annotations,
-      if (allStrings) 'type': 'string',
-      if (allStrings)
-        'enum': normalizedEntries.map((entry) => entry.value as String).toList()
-      else if (!hasTitles)
-        'enum': normalizedEntries.map((entry) => entry.value).toList()
-      else
-        'oneOf': normalizedEntries
+        if (allStrings) 'type': 'string',
+        titledStringConstListKeyword: normalizedEntries
             .map(
               (entry) => {
                 'const': entry.value,
@@ -1415,10 +1411,26 @@ class JsonEnum extends JsonSchema {
               },
             )
             .toList(),
-      if (allStrings && hasTitles)
-        'enumNames': normalizedEntries
-            .map((entry) => entry.title ?? entry.value as String)
-            .toList(),
+      };
+    }
+
+    final enumValuesKeyword = _enumValuesKeyword;
+    if (enumValuesKeyword != null) {
+      return {
+        ...annotations,
+        if (_enumTypeKeyword != null) 'type': _enumTypeKeyword,
+        enumValuesKeyword:
+            normalizedEntries.map((entry) => entry.value).toList(),
+      };
+    }
+
+    return {
+      ...annotations,
+      if (allStrings) 'type': 'string',
+      if (allStrings)
+        'enum': normalizedEntries.map((entry) => entry.value as String).toList()
+      else
+        'enum': normalizedEntries.map((entry) => entry.value).toList(),
     };
   }
 

--- a/lib/src/types/completion.dart
+++ b/lib/src/types/completion.dart
@@ -228,13 +228,22 @@ class CompleteResult implements BaseResultData {
   }
 
   @override
-  Map<String, dynamic> toJson() => {'completion': completion.toJson()};
+  Map<String, dynamic> toJson() => {
+        'completion': completion.toJson(),
+        if (meta != null) '_meta': meta,
+      };
 }
 
-/// Notification from server indicating the list of available completions has changed.
+/// Experimental notification indicating available completions have changed.
+///
+/// Stable MCP 2025-11-25 does not define a completion list changed
+/// notification. This class emits an explicit experimental method namespace.
+@Deprecated(
+  'Stable MCP 2025-11-25 does not define completion list-changed notifications.',
+)
 class JsonRpcCompletionListChangedNotification extends JsonRpcNotification {
   const JsonRpcCompletionListChangedNotification()
-      : super(method: Method.notificationsCompletionsListChanged);
+      : super(method: Method.notificationsExperimentalCompletionsListChanged);
 
   factory JsonRpcCompletionListChangedNotification.fromJson(
     Map<String, dynamic> json,

--- a/lib/src/types/elicitation.dart
+++ b/lib/src/types/elicitation.dart
@@ -226,10 +226,19 @@ class ElicitResult implements BaseResultData {
   /// The submitted form data (only present when action is 'accept')
   final Map<String, dynamic>? content;
 
-  /// The URL that the user should navigate to (only present when action is 'accept' in URL mode)
+  /// Legacy URL-mode response echo.
+  ///
+  /// MCP 2025-11-25 keeps URL and elicitation id on the request and completion
+  /// notification, not on successful URL-mode accept results.
+  @Deprecated(
+    'URL-mode elicitation results no longer emit url; use the original request or completion notification.',
+  )
   final String? url;
 
-  /// A unique identifier for the elicitation (only present when action is 'accept' in URL mode)
+  /// Legacy URL-mode response echo.
+  @Deprecated(
+    'URL-mode elicitation results no longer emit elicitationId; use the original request or completion notification.',
+  )
   final String? elicitationId;
 
   /// Optional metadata
@@ -242,16 +251,28 @@ class ElicitResult implements BaseResultData {
     this.url,
     this.elicitationId,
     this.meta,
-  });
+  }) : assert(
+          action == 'accept' || action == 'decline' || action == 'cancel',
+          'ElicitResult.action must be accept, decline, or cancel.',
+        );
 
   factory ElicitResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final action = json['action'];
+    if (action is! String || !_isValidElicitAction(action)) {
+      throw FormatException('Invalid elicitation action: $action');
+    }
+
+    final content = json['content'];
+    if (content != null && content is! Map) {
+      throw const FormatException('ElicitResult content must be an object.');
+    }
+
     return ElicitResult(
-      action: json['action'] as String,
-      content: json['content'] as Map<String, dynamic>?,
+      action: action,
+      content: content?.cast<String, dynamic>(),
       url: json['url'] as String?,
       elicitationId: json['elicitationId'] as String?,
-      meta: meta,
+      meta: (json['_meta'] as Map?)?.cast<String, dynamic>(),
     );
   }
 
@@ -259,8 +280,7 @@ class ElicitResult implements BaseResultData {
   Map<String, dynamic> toJson() => {
         'action': action,
         if (content != null) 'content': content,
-        if (url != null) 'url': url,
-        if (elicitationId != null) 'elicitationId': elicitationId,
+        if (meta != null) '_meta': meta,
       };
 
   /// Helper to check if the user accepted the input
@@ -272,6 +292,9 @@ class ElicitResult implements BaseResultData {
   /// Helper to check if the user cancelled the input
   bool get cancelled => action == 'cancel';
 }
+
+bool _isValidElicitAction(String action) =>
+    action == 'accept' || action == 'decline' || action == 'cancel';
 
 /// Parameters for the `notifications/elicitation/complete` notification.
 ///

--- a/lib/src/types/elicitation.dart
+++ b/lib/src/types/elicitation.dart
@@ -221,7 +221,13 @@ class JsonRpcElicitRequest extends JsonRpcRequest {
 /// Result data for a successful `elicitation/create` response
 class ElicitResult implements BaseResultData {
   /// The action taken by the user: 'accept', 'decline', or 'cancel'
-  final String action;
+  final String _action;
+
+  /// The action taken by the user: 'accept', 'decline', or 'cancel'
+  String get action {
+    _validateElicitAction(_action);
+    return _action;
+  }
 
   /// The submitted form data (only present when action is 'accept')
   final Map<String, dynamic>? content;
@@ -246,15 +252,12 @@ class ElicitResult implements BaseResultData {
   final Map<String, dynamic>? meta;
 
   const ElicitResult({
-    required this.action,
+    required String action,
     this.content,
     this.url,
     this.elicitationId,
     this.meta,
-  }) : assert(
-          action == 'accept' || action == 'decline' || action == 'cancel',
-          'ElicitResult.action must be accept, decline, or cancel.',
-        );
+  }) : _action = action;
 
   factory ElicitResult.fromJson(Map<String, dynamic> json) {
     final action = json['action'];
@@ -295,6 +298,16 @@ class ElicitResult implements BaseResultData {
 
 bool _isValidElicitAction(String action) =>
     action == 'accept' || action == 'decline' || action == 'cancel';
+
+void _validateElicitAction(String action) {
+  if (!_isValidElicitAction(action)) {
+    throw ArgumentError.value(
+      action,
+      'action',
+      'ElicitResult.action must be accept, decline, or cancel.',
+    );
+  }
+}
 
 /// Parameters for the `notifications/elicitation/complete` notification.
 ///

--- a/lib/src/types/initialization.dart
+++ b/lib/src/types/initialization.dart
@@ -625,7 +625,13 @@ class ServerCapabilitiesTools {
 
 /// Describes capabilities related to completions.
 class ServerCapabilitiesCompletions {
-  /// Whether the server supports `notifications/completions/list_changed`.
+  /// Legacy non-standard completion list changed flag.
+  ///
+  /// MCP 2025-11-25 defines `completions` as an empty capability object and
+  /// does not define a stable `notifications/completions/list_changed` method.
+  @Deprecated(
+    'MCP 2025-11-25 completions capability is an empty object; listChanged is ignored when serializing.',
+  )
   final bool? listChanged;
 
   const ServerCapabilitiesCompletions({
@@ -638,9 +644,7 @@ class ServerCapabilitiesCompletions {
     );
   }
 
-  Map<String, dynamic> toJson() => {
-        if (listChanged != null) 'listChanged': listChanged,
-      };
+  Map<String, dynamic> toJson() => {};
 }
 
 /// Describes capabilities related to tasks.
@@ -870,6 +874,7 @@ class InitializeResult implements BaseResultData {
         'capabilities': capabilities.toJson(),
         'serverInfo': serverInfo.toJson(),
         if (instructions != null) 'instructions': instructions,
+        if (meta != null) '_meta': meta,
       };
 }
 

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -59,8 +59,14 @@ class Method {
       "notifications/prompts/list_changed";
   static const notificationsToolsListChanged =
       "notifications/tools/list_changed";
+  @Deprecated(
+    'notifications/completions/list_changed is not part of stable MCP 2025-11-25. '
+    'Use notifications/experimental/completions/list_changed for extension behavior.',
+  )
   static const notificationsCompletionsListChanged =
       "notifications/completions/list_changed";
+  static const notificationsExperimentalCompletionsListChanged =
+      "notifications/experimental/completions/list_changed";
   static const notificationsMessage = "notifications/message";
   static const notificationsRootsListChanged =
       "notifications/roots/list_changed";
@@ -227,7 +233,7 @@ sealed class JsonRpcMessage {
             JsonRpcPromptListChangedNotification.fromJson(json),
           Method.notificationsToolsListChanged =>
             JsonRpcToolListChangedNotification.fromJson(json),
-          Method.notificationsCompletionsListChanged =>
+          Method.notificationsExperimentalCompletionsListChanged =>
             JsonRpcCompletionListChangedNotification.fromJson(json),
           Method.notificationsMessage =>
             JsonRpcLoggingMessageNotification.fromJson(
@@ -431,7 +437,10 @@ abstract class BaseResultData {
   /// Optional metadata associated with the result.
   Map<String, dynamic>? get meta;
 
-  /// Converts the result data (excluding meta) to its JSON representation.
+  /// Converts the result data to its JSON representation.
+  ///
+  /// Implementations must include `_meta` when [meta] is non-null so typed
+  /// results preserve the MCP `Result._meta` field during direct serialization.
   Map<String, dynamic> toJson();
 }
 

--- a/lib/src/types/misc.dart
+++ b/lib/src/types/misc.dart
@@ -8,7 +8,9 @@ class EmptyResult implements BaseResultData {
   const EmptyResult({this.meta});
 
   @override
-  Map<String, dynamic> toJson() => {};
+  Map<String, dynamic> toJson() => {
+        if (meta != null) '_meta': meta,
+      };
 }
 
 /// Parameters for the `notifications/cancelled` notification.

--- a/lib/src/types/prompts.dart
+++ b/lib/src/types/prompts.dart
@@ -169,6 +169,7 @@ class ListPromptsResult implements BaseResultData {
   Map<String, dynamic> toJson() => {
         'prompts': prompts.map((p) => p.toJson()).toList(),
         if (nextCursor != null) 'nextCursor': nextCursor,
+        if (meta != null) '_meta': meta,
       };
 }
 
@@ -280,6 +281,7 @@ class GetPromptResult implements BaseResultData {
   Map<String, dynamic> toJson() => {
         if (description != null) 'description': description,
         'messages': messages.map((m) => m.toJson()).toList(),
+        if (meta != null) '_meta': meta,
       };
 }
 

--- a/lib/src/types/resources.dart
+++ b/lib/src/types/resources.dart
@@ -277,6 +277,7 @@ class ListResourcesResult implements BaseResultData {
   Map<String, dynamic> toJson() => {
         'resources': resources.map((r) => r.toJson()).toList(),
         if (nextCursor != null) 'nextCursor': nextCursor,
+        if (meta != null) '_meta': meta,
       };
 }
 
@@ -355,6 +356,7 @@ class ListResourceTemplatesResult implements BaseResultData {
   Map<String, dynamic> toJson() => {
         'resourceTemplates': resourceTemplates.map((t) => t.toJson()).toList(),
         if (nextCursor != null) 'nextCursor': nextCursor,
+        if (meta != null) '_meta': meta,
       };
 }
 
@@ -420,6 +422,7 @@ class ReadResourceResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         'contents': contents.map((c) => c.toJson()).toList(),
+        if (meta != null) '_meta': meta,
       };
 }
 

--- a/lib/src/types/roots.dart
+++ b/lib/src/types/roots.dart
@@ -64,6 +64,7 @@ class ListRootsResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         'roots': roots.map((r) => r.toJson()).toList(),
+        if (meta != null) '_meta': meta,
       };
 }
 

--- a/lib/src/types/tasks.dart
+++ b/lib/src/types/tasks.dart
@@ -243,6 +243,7 @@ class ListTasksResult implements BaseResultData {
   Map<String, dynamic> toJson() => {
         'tasks': tasks.map((t) => t.toJson()).toList(),
         if (nextCursor != null) 'nextCursor': nextCursor,
+        if (meta != null) '_meta': meta,
       };
 }
 
@@ -397,6 +398,7 @@ class CreateTaskResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         'task': task.toJson(),
+        if (meta != null) '_meta': meta,
       };
 }
 

--- a/packages/mcp_dart_cli/CHANGELOG.md
+++ b/packages/mcp_dart_cli/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Add `mcp_dart conformance` with built-in JSON-RPC and protocol-version fixture checks, deterministic JSON-RPC fuzz cases, exact-case filtering, and JSON output for CI/scripts.
 - Add `mcp_dart conformance --suite spec` for MCP 2025-11-25 lifecycle,
   capability, elicitation, task-metadata, and progress-token raw-wire checks.
+- Document `mcp_dart conformance --suite all` as the stable non-fuzz coverage
+  gate used by CI.
 
 ## 0.1.7
 

--- a/packages/mcp_dart_cli/README.md
+++ b/packages/mcp_dart_cli/README.md
@@ -132,11 +132,11 @@ Run built-in fixture checks, MCP 2025-11-25 spec-critical checks, and determinis
 # Run all built-in fixture cases
 mcp_dart conformance
 
-# Run MCP 2025-11-25 spec-critical cases
-mcp_dart conformance --suite spec
-
-# Run all non-fuzz suites
+# Run all stable non-fuzz suites
 mcp_dart conformance --suite all
+
+# Run only MCP 2025-11-25 raw-wire spec cases
+mcp_dart conformance --suite spec
 
 # Run one case by exact name
 mcp_dart conformance --case jsonrpc.preserves-string-response-id

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,11 +16,11 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
+  crypto: ^3.0.7
   http: ^1.4.0
   meta: ^1.17.0
 
 dev_dependencies:
-  crypto: ^3.0.7
   lints: ^6.0.0
   path: ^1.9.1
   test: ^1.24.0

--- a/test/client/client_elicitation_defaults_test.dart
+++ b/test/client/client_elicitation_defaults_test.dart
@@ -208,11 +208,7 @@ void main() {
       Map<String, dynamic>? receivedContent;
       client.onElicitRequest = (params) async {
         receivedContent = {}; // No content for URL elicitation typically
-        return const ElicitResult(
-          action: 'accept',
-          url: 'http://example.com/form',
-          elicitationId: '123',
-        );
+        return const ElicitResult(action: 'accept');
       };
 
       final elicitRequest = JsonRpcElicitRequest(

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -38,6 +38,49 @@ class MockOAuthClientProvider implements OAuthClientProvider {
   }
 }
 
+class DiscoveryOAuthClientProvider implements OAuthAuthorizationCodeProvider {
+  @override
+  final String clientId;
+
+  @override
+  final Uri redirectUri;
+
+  @override
+  final String? clientSecret;
+
+  @override
+  final List<String> scopes;
+
+  OAuthTokens? storedTokens;
+  Uri? authorizationUri;
+  int legacyRedirects = 0;
+
+  DiscoveryOAuthClientProvider({
+    this.clientId = 'client-1',
+    required this.redirectUri,
+    this.clientSecret,
+    this.scopes = const ['tools:read'],
+  });
+
+  @override
+  Future<OAuthTokens?> tokens() async => storedTokens;
+
+  @override
+  Future<void> redirectToAuthorization() async {
+    legacyRedirects += 1;
+  }
+
+  @override
+  Future<void> redirectToAuthorizationUrl(Uri authorizationUri) async {
+    this.authorizationUri = authorizationUri;
+  }
+
+  @override
+  Future<void> saveTokens(OAuthTokens tokens) async {
+    storedTokens = tokens;
+  }
+}
+
 void main() {
   late HttpServer testServer;
   late int serverPort;
@@ -1451,6 +1494,178 @@ void main() {
       },
       timeout: const Timeout(Duration(seconds: 10)),
     );
+
+    group('OAuth Discovery', () {
+      test('parses bearer challenge parameters', () {
+        final challenge = OAuthBearerChallengeParameters.fromHeader(
+          r'Bearer resource_metadata="https://mcp.example/.well-known/oauth-protected-resource/mcp", scope="tools:\"read\"\\admin", error="insufficient_scope"',
+        );
+
+        expect(
+          challenge?.resourceMetadata.toString(),
+          'https://mcp.example/.well-known/oauth-protected-resource/mcp',
+        );
+        expect(challenge?.scope, r'tools:"read"\admin');
+        expect(challenge?.error, 'insufficient_scope');
+      });
+
+      test('discovers metadata, redirects with PKCE, and exchanges tokens',
+          () async {
+        final oauthServer = await HttpServer.bind(
+          InternetAddress.loopbackIPv4,
+          0,
+        );
+        addTearDown(() => oauthServer.close(force: true));
+        final oauthPort = oauthServer.port;
+        final oauthUrl = Uri.parse('http://localhost:$oauthPort/mcp');
+        var tokenExchangeSeen = false;
+
+        oauthServer.listen((request) async {
+          switch (request.uri.path) {
+            case '/mcp':
+              if (request.headers.value(HttpHeaders.authorizationHeader) ==
+                  'Bearer exchanged-token') {
+                request.response
+                  ..statusCode = HttpStatus.ok
+                  ..headers.contentType = ContentType.json
+                  ..write(
+                    jsonEncode(
+                      const JsonRpcResponse(
+                        id: 77,
+                        result: {'ok': true},
+                      ).toJson(),
+                    ),
+                  );
+              } else {
+                request.response
+                  ..statusCode = HttpStatus.unauthorized
+                  ..headers.set(
+                    HttpHeaders.wwwAuthenticateHeader,
+                    'Bearer resource_metadata="http://localhost:$oauthPort/.well-known/oauth-protected-resource/mcp", scope="tools:read"',
+                  )
+                  ..write('Unauthorized');
+              }
+              await request.response.close();
+              break;
+            case '/.well-known/oauth-protected-resource/mcp':
+              request.response
+                ..statusCode = HttpStatus.ok
+                ..headers.contentType = ContentType.json
+                ..write(
+                  jsonEncode({
+                    'resource': 'http://localhost:$oauthPort/mcp',
+                    'authorization_servers': [
+                      'http://localhost:$oauthPort/auth',
+                    ],
+                    'scopes_supported': ['tools:read'],
+                  }),
+                );
+              await request.response.close();
+              break;
+            case '/.well-known/oauth-authorization-server/auth':
+              request.response
+                ..statusCode = HttpStatus.ok
+                ..headers.contentType = ContentType.json
+                ..write(
+                  jsonEncode({
+                    'issuer': 'http://localhost:$oauthPort/auth',
+                    'authorization_endpoint':
+                        'http://localhost:$oauthPort/authorize',
+                    'token_endpoint': 'http://localhost:$oauthPort/token',
+                    'code_challenge_methods_supported': ['S256'],
+                  }),
+                );
+              await request.response.close();
+              break;
+            case '/token':
+              final body = await utf8.decoder.bind(request).join();
+              final form = Uri.splitQueryString(body);
+              expect(form['grant_type'], 'authorization_code');
+              expect(form['code'], 'auth-code');
+              expect(form['client_id'], 'client-1');
+              expect(form['redirect_uri'], 'http://localhost/callback');
+              expect(form['resource'], 'http://localhost:$oauthPort/mcp');
+              expect(form['code_verifier'], isNotEmpty);
+              tokenExchangeSeen = true;
+              request.response
+                ..statusCode = HttpStatus.ok
+                ..headers.contentType = ContentType.json
+                ..write(
+                  jsonEncode({
+                    'access_token': 'exchanged-token',
+                    'refresh_token': 'refresh-token',
+                    'token_type': 'Bearer',
+                    'expires_in': 3600,
+                    'scope': 'tools:read',
+                  }),
+                );
+              await request.response.close();
+              break;
+            default:
+              request.response.statusCode = HttpStatus.notFound;
+              await request.response.close();
+          }
+        });
+
+        final authProvider = DiscoveryOAuthClientProvider(
+          redirectUri: Uri.parse('http://localhost/callback'),
+        );
+        final oauthTransport = StreamableHttpClientTransport(
+          oauthUrl,
+          opts: StreamableHttpClientTransportOptions(
+            authProvider: authProvider,
+          ),
+        );
+        addTearDown(oauthTransport.close);
+        await oauthTransport.start();
+
+        final request = const JsonRpcRequest(id: 77, method: 'test/method');
+        await expectLater(
+          oauthTransport.send(request),
+          throwsA(isA<UnauthorizedError>()),
+        );
+
+        final authorizationUri = authProvider.authorizationUri;
+        expect(authorizationUri, isNotNull);
+        expect(authorizationUri!.path, '/authorize');
+        expect(authorizationUri.queryParameters['response_type'], 'code');
+        expect(authorizationUri.queryParameters['client_id'], 'client-1');
+        expect(
+          authorizationUri.queryParameters['redirect_uri'],
+          'http://localhost/callback',
+        );
+        expect(
+          authorizationUri.queryParameters['resource'],
+          oauthUrl.toString(),
+        );
+        expect(authorizationUri.queryParameters['scope'], 'tools:read');
+        expect(
+          authorizationUri.queryParameters['code_challenge_method'],
+          'S256',
+        );
+        expect(authorizationUri.queryParameters['code_challenge'], isNotEmpty);
+        expect(authProvider.legacyRedirects, 0);
+
+        await oauthTransport.finishAuth('auth-code');
+        expect(tokenExchangeSeen, isTrue);
+        expect(authProvider.storedTokens?.accessToken, 'exchanged-token');
+        expect(authProvider.storedTokens, isA<OAuthAuthorizationCodeTokens>());
+        final storedTokens =
+            authProvider.storedTokens as OAuthAuthorizationCodeTokens;
+        expect(storedTokens.tokenType, 'Bearer');
+        expect(storedTokens.expiresIn, 3600);
+        expect(storedTokens.scope, 'tools:read');
+
+        final completer = Completer<JsonRpcMessage>();
+        oauthTransport.onmessage = completer.complete;
+        await oauthTransport.send(request);
+        final response = await completer.future.timeout(
+          const Duration(seconds: 3),
+        );
+        expect(response, isA<JsonRpcResponse>());
+        expect((response as JsonRpcResponse).result['ok'], isTrue);
+      });
+    });
 
     group('Error Handling and Edge Cases', () {
       test('handles finishAuth without auth provider', () async {

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -1509,6 +1509,16 @@ void main() {
         expect(challenge?.error, 'insufficient_scope');
       });
 
+      test('ignores invalid bearer challenge resource metadata', () {
+        final challenge = OAuthBearerChallengeParameters.fromHeader(
+          r'Bearer resource_metadata="http://[", scope="tools:read"',
+        );
+
+        expect(challenge, isNotNull);
+        expect(challenge?.resourceMetadata, isNull);
+        expect(challenge?.scope, 'tools:read');
+      });
+
       test('discovers metadata, redirects with PKCE, and exchanges tokens',
           () async {
         final oauthServer = await HttpServer.bind(
@@ -1595,7 +1605,7 @@ void main() {
                     'access_token': 'exchanged-token',
                     'refresh_token': 'refresh-token',
                     'token_type': 'Bearer',
-                    'expires_in': 3600,
+                    'expires_in': 3600.0,
                     'scope': 'tools:read',
                   }),
                 );

--- a/test/elicitation_test.dart
+++ b/test/elicitation_test.dart
@@ -455,11 +455,7 @@ void main() {
       ElicitRequest? receivedParams;
       client.onElicitRequest = (params) async {
         receivedParams = params;
-        return const ElicitResult(
-          action: 'accept',
-          url: 'https://oauth.example.com/authorize',
-          elicitationId: 'oauth-123',
-        );
+        return const ElicitResult(action: 'accept');
       };
 
       await client.connect(transport);
@@ -480,7 +476,9 @@ void main() {
       expect(receivedParams, isNotNull);
       expect(receivedParams!.isUrlMode, isTrue);
       expect(transport.sentMessages.single, isA<JsonRpcResponse>());
-      expect((transport.sentMessages.single as JsonRpcResponse).id, 7);
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      expect(response.id, 7);
+      expect(response.result, equals({'action': 'accept'}));
 
       await client.close();
     });

--- a/test/integration/completions_capability_test.dart
+++ b/test/integration/completions_capability_test.dart
@@ -18,7 +18,7 @@ void main() {
       expect(caps.completions, isA<ServerCapabilitiesCompletions>());
     });
 
-    test('Server declares completions capability with listChanged', () {
+    test('legacy listChanged flag is retained in memory only', () {
       final mcpServer = McpServer(
         const Implementation(name: "test-server", version: "1.0.0"),
         options: const ServerOptions(
@@ -31,6 +31,7 @@ void main() {
       final caps = mcpServer.server.getCapabilities();
       expect(caps.completions, isNotNull);
       expect(caps.completions?.listChanged, equals(true));
+      expect(caps.toJson()['completions'], isEmpty);
     });
 
     test('Server without completions capability returns null', () {
@@ -82,7 +83,7 @@ void main() {
 
       final caps = mcpServer.server.getCapabilities();
       expect(caps.completions, isNotNull);
-      expect(caps.completions?.listChanged, equals(true));
+      expect(caps.toJson()['completions'], isEmpty);
       expect(caps.tools, isNotNull);
       expect(caps.resources, isNotNull);
       expect(caps.prompts, isNotNull);
@@ -98,8 +99,19 @@ void main() {
       final deserializedCaps = ServerCapabilities.fromJson(json);
 
       expect(deserializedCaps.completions, isNotNull);
-      expect(deserializedCaps.completions?.listChanged, equals(true));
+      expect(json['completions'], isEmpty);
       expect(deserializedCaps.experimental?['test'], equals(true));
+    });
+
+    test('legacy completions listChanged payload still parses', () {
+      final caps = ServerCapabilities.fromJson(
+        const {
+          'completions': {'listChanged': true},
+        },
+      );
+
+      expect(caps.completions?.listChanged, isTrue);
+      expect(caps.toJson()['completions'], isEmpty);
     });
   });
 }

--- a/test/interop/test_dart_server.dart
+++ b/test/interop/test_dart_server.dart
@@ -44,6 +44,32 @@ McpServer createServer() {
     },
   );
 
+  server.registerTool(
+    'choose_mode',
+    description: 'Exposes titled enum schemas for cross-SDK inspection',
+    inputSchema: JsonSchema.object(
+      properties: {
+        'mode': const JsonEnum([
+          'simple',
+          {'value': 'complex', 'title': 'Complex Option'},
+        ]),
+        'permissions': const JsonArray(
+          items: JsonEnum([
+            {'value': 'read', 'title': 'Read'},
+            {'value': 'write', 'title': 'Write'},
+          ]),
+          uniqueItems: true,
+        ),
+      },
+      required: ['mode'],
+    ),
+    callback: (args, extra) async {
+      return CallToolResult(
+        content: [TextContent(text: jsonEncode(args))],
+      );
+    },
+  );
+
   // Resources
   server.registerResource(
     'Test Resource',

--- a/test/interop/ts/src/client.ts
+++ b/test/interop/ts/src/client.ts
@@ -90,6 +90,73 @@ function assertRelatedTaskMeta(
   }
 }
 
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} was not an object: ${JSON.stringify(value)}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertTitledEnumSchema(tools: unknown): void {
+  const toolsResult = requireRecord(tools, 'tools/list result');
+  const toolList = toolsResult.tools;
+  if (!Array.isArray(toolList)) {
+    throw new Error(`tools/list result missing tools array: ${JSON.stringify(tools)}`);
+  }
+
+  const chooseModeTool = toolList
+    .map((tool) => requireRecord(tool, 'tool'))
+    .find((tool) => tool.name === 'choose_mode');
+  if (!chooseModeTool) {
+    throw new Error('choose_mode tool was not listed');
+  }
+
+  const inputSchema = requireRecord(
+    chooseModeTool.inputSchema,
+    'choose_mode inputSchema'
+  );
+  const properties = requireRecord(
+    inputSchema.properties,
+    'choose_mode properties'
+  );
+  const mode = requireRecord(properties.mode, 'choose_mode mode schema');
+  const modeChoices = mode.oneOf;
+  if (!Array.isArray(modeChoices)) {
+    throw new Error(`mode schema missing oneOf: ${JSON.stringify(mode)}`);
+  }
+  const complexChoice = modeChoices
+    .map((choice) => requireRecord(choice, 'mode choice'))
+    .find((choice) => choice.const === 'complex');
+  if (complexChoice?.title !== 'Complex Option') {
+    throw new Error(
+      `mode schema missing const/title choice: ${JSON.stringify(mode)}`
+    );
+  }
+
+  const permissions = requireRecord(
+    properties.permissions,
+    'choose_mode permissions schema'
+  );
+  const permissionItems = requireRecord(
+    permissions.items,
+    'choose_mode permissions items schema'
+  );
+  const permissionChoices = permissionItems.anyOf;
+  if (!Array.isArray(permissionChoices)) {
+    throw new Error(
+      `permissions item schema missing anyOf: ${JSON.stringify(permissionItems)}`
+    );
+  }
+  const writeChoice = permissionChoices
+    .map((choice) => requireRecord(choice, 'permission choice'))
+    .find((choice) => choice.const === 'write');
+  if (writeChoice?.title !== 'Write') {
+    throw new Error(
+      `permissions schema missing const/title choice: ${JSON.stringify(permissionItems)}`
+    );
+  }
+}
+
 async function main() {
   const args = process.argv.slice(2);
   let transportType = 'stdio';
@@ -244,9 +311,14 @@ async function main() {
     // 1. List Tools
     const tools = await client.listTools();
     const toolNames = tools.tools.map((t) => t.name);
-    if (!toolNames.includes('echo') || !toolNames.includes('add')) {
+    if (
+      !toolNames.includes('echo') ||
+      !toolNames.includes('add') ||
+      !toolNames.includes('choose_mode')
+    ) {
       throw new Error(`Missing tools. Found: ${toolNames}`);
     }
+    assertTitledEnumSchema(tools);
 
     // 2. Call Tool 'echo'
     const echoResult = await client.callTool({

--- a/test/interop/ts/src/oauth_client.ts
+++ b/test/interop/ts/src/oauth_client.ts
@@ -16,6 +16,10 @@ function getArg(name: string): string {
   throw new Error(`Missing required argument: ${name}`);
 }
 
+function hasFlag(name: string): boolean {
+  return process.argv.includes(name);
+}
+
 class TestOAuthProvider implements OAuthClientProvider {
   private _tokens?: OAuthTokens;
   private _codeVerifier?: string;
@@ -69,7 +73,10 @@ class TestOAuthProvider implements OAuthClientProvider {
     return this._codeVerifier;
   }
 
-  assertAuthorizationRedirect(expectedResource: string): void {
+  assertAuthorizationRedirect(
+    expectedResource: string,
+    expectedScope = 'tools:read'
+  ): void {
     if (!this._authorizationUrl) {
       throw new Error('Authorization redirect was not requested');
     }
@@ -96,6 +103,9 @@ class TestOAuthProvider implements OAuthClientProvider {
     if (params.get('resource') !== expectedResource) {
       throw new Error(`Unexpected resource: ${params.get('resource')}`);
     }
+    if (params.get('scope') !== expectedScope) {
+      throw new Error(`Unexpected scope: ${params.get('scope')}`);
+    }
     if (params.get('state') !== 'ts-oauth-state') {
       throw new Error(`Unexpected state: ${params.get('state')}`);
     }
@@ -119,38 +129,73 @@ async function connectAndListTools(
     }
   );
 
-  await client.connect(transport);
+  let connected = false;
   try {
+    await client.connect(transport);
+    connected = true;
     const result = await client.listTools();
     return result.tools.map((tool) => tool.name);
   } finally {
-    await client.close();
+    if (connected) {
+      await client.close();
+    } else {
+      await transport.close();
+    }
   }
 }
 
-async function main(): Promise<void> {
-  const url = getArg('--url');
-  const provider = new TestOAuthProvider();
-
+async function expectAuthorizationRequired(
+  operation: () => Promise<unknown>,
+  label: string
+): Promise<void> {
   try {
-    await connectAndListTools(url, provider);
-    throw new Error('Initial protected request unexpectedly succeeded');
+    await operation();
   } catch (error) {
-    if (!(error instanceof UnauthorizedError)) {
-      throw error;
+    if (error instanceof UnauthorizedError) {
+      return;
     }
+    throw error;
   }
+  throw new Error(`${label} unexpectedly succeeded`);
+}
 
-  provider.assertAuthorizationRedirect(url);
-
+async function finishAuthorization(
+  url: string,
+  provider: TestOAuthProvider,
+  code: string
+): Promise<void> {
   const authTransport = new StreamableHTTPClientTransport(new URL(url), {
     authProvider: provider,
   });
   await authTransport.start();
   try {
-    await authTransport.finishAuth('valid-code');
+    await authTransport.finishAuth(code);
   } finally {
     await authTransport.close();
+  }
+}
+
+async function main(): Promise<void> {
+  const url = getArg('--url');
+  const expectUpscope = hasFlag('--expect-upscope');
+  const provider = new TestOAuthProvider();
+
+  await expectAuthorizationRequired(
+    () => connectAndListTools(url, provider),
+    'Initial protected request'
+  );
+
+  provider.assertAuthorizationRedirect(url, 'tools:read');
+
+  await finishAuthorization(url, provider, 'valid-code');
+
+  if (expectUpscope) {
+    await expectAuthorizationRequired(
+      () => connectAndListTools(url, provider),
+      'Insufficient-scope protected request'
+    );
+    provider.assertAuthorizationRedirect(url, 'tools:write');
+    await finishAuthorization(url, provider, 'upscope-code');
   }
 
   const toolNames = await connectAndListTools(url, provider);

--- a/test/interop/ts_client_with_dart_server_test.dart
+++ b/test/interop/ts_client_with_dart_server_test.dart
@@ -548,6 +548,91 @@ void main() {
     );
 
     test(
+      'official TS Streamable HTTP client handles insufficient-scope challenge',
+      () async {
+        final port = await _findAvailablePort();
+        final mcpUrl = 'http://127.0.0.1:$port/mcp';
+        final authorizationServer =
+            await _OAuthAuthorizationServer.start(expectedResource: mcpUrl);
+        var unauthorizedRequests = 0;
+        var insufficientScopeRequests = 0;
+        var authenticatedRequests = 0;
+
+        final streamableServer = StreamableMcpServer(
+          serverFactory: (_) => createServer(),
+          host: '127.0.0.1',
+          port: port,
+          authenticationHandler: (request) {
+            final authorization = request.headers.value(
+              HttpHeaders.authorizationHeader,
+            );
+            if (authorization == 'Bearer ts-upscope-token') {
+              authenticatedRequests += 1;
+              return const StreamableMcpAuthenticationResult.allow();
+            }
+            if (authorization == 'Bearer ts-access-token') {
+              insufficientScopeRequests += 1;
+              return const StreamableMcpAuthenticationResult.insufficientScope(
+                scope: 'tools:write',
+                errorDescription: 'Need tools:write',
+              );
+            }
+            unauthorizedRequests += 1;
+            return const StreamableMcpAuthenticationResult.unauthorized();
+          },
+          oauthProtectedResource: OAuthProtectedResourceOptions(
+            metadata: OAuthProtectedResourceMetadata(
+              resource: Uri.parse(mcpUrl),
+              authorizationServers: [Uri.parse(authorizationServer.baseUrl)],
+              scopesSupported: const ['tools:read', 'tools:write'],
+            ),
+            scope: 'tools:read',
+          ),
+        );
+
+        await streamableServer.start();
+        try {
+          final result = await Process.run(
+            'node',
+            [
+              tsOAuthClientPath,
+              '--url',
+              mcpUrl,
+              '--expect-upscope',
+            ],
+            runInShell: true,
+          );
+
+          if (result.exitCode != 0) {
+            print('TS OAuth upscope stdout: ${result.stdout}');
+            print('TS OAuth upscope stderr: ${result.stderr}');
+          }
+
+          expect(
+            result.exitCode,
+            equals(0),
+            reason: 'Official TS OAuth interop failed for insufficient scope',
+          );
+          expect(unauthorizedRequests, greaterThanOrEqualTo(1));
+          expect(insufficientScopeRequests, greaterThanOrEqualTo(1));
+          expect(authenticatedRequests, greaterThanOrEqualTo(1));
+          expect(
+            authorizationServer.tokenForms.map((form) => form['code']),
+            containsAll(['valid-code', 'upscope-code']),
+          );
+          expect(
+            authorizationServer.tokenForms.last,
+            containsPair('resource', mcpUrl),
+          );
+        } finally {
+          await streamableServer.stop();
+          await authorizationServer.stop();
+        }
+      },
+      timeout: const Timeout(Duration(seconds: 30)),
+    );
+
+    test(
       'Dart Streamable HTTP server rejects operations before initialized',
       () async {
         final port = await _findAvailablePort();
@@ -982,6 +1067,7 @@ class _OAuthAuthorizationServer {
   final HttpServer _httpServer;
   final String expectedResource;
   Map<String, String>? lastTokenForm;
+  final List<Map<String, String>> tokenForms = [];
   int authorizationMetadataRequests = 0;
 
   _OAuthAuthorizationServer._(this._httpServer, this.expectedResource);
@@ -1031,7 +1117,7 @@ class _OAuthAuthorizationServer {
           'grant_types_supported': ['authorization_code', 'refresh_token'],
           'code_challenge_methods_supported': ['S256'],
           'token_endpoint_auth_methods_supported': ['none'],
-          'scopes_supported': ['tools:read'],
+          'scopes_supported': ['tools:read', 'tools:write'],
         }),
       );
     await request.response.close();
@@ -1046,7 +1132,9 @@ class _OAuthAuthorizationServer {
 
     final body = await utf8.decodeStream(request);
     lastTokenForm = Uri.splitQueryString(body);
-    if (lastTokenForm!['code'] != 'valid-code' ||
+    tokenForms.add(lastTokenForm!);
+    final code = lastTokenForm!['code'];
+    if ((code != 'valid-code' && code != 'upscope-code') ||
         lastTokenForm!['resource'] != expectedResource ||
         lastTokenForm!['code_verifier'] == null ||
         lastTokenForm!['code_verifier']!.isEmpty) {
@@ -1063,16 +1151,16 @@ class _OAuthAuthorizationServer {
       return;
     }
 
+    final upscope = code == 'upscope-code';
     request.response
       ..statusCode = HttpStatus.ok
       ..headers.contentType = ContentType.json
       ..write(
         jsonEncode({
-          'access_token': 'ts-access-token',
-          'refresh_token': 'ts-refresh-token',
+          'access_token': upscope ? 'ts-upscope-token' : 'ts-access-token',
           'token_type': 'Bearer',
           'expires_in': 3600,
-          'scope': 'tools:read',
+          'scope': upscope ? 'tools:write' : 'tools:read',
         }),
       );
     await request.response.close();

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -247,8 +247,10 @@ void main() {
 
       final json = schema.toJson();
       expect(json['type'], 'string');
-      expect(json['enum'], ['simple', 'complex']);
-      expect(json['enumNames'], ['simple', 'Complex Option']);
+      expect(json['oneOf'], [
+        {'const': 'simple'},
+        {'const': 'complex', 'title': 'Complex Option'},
+      ]);
       expect(json.containsKey('values'), isFalse);
 
       final deserialized = JsonEnum.fromJson(json);

--- a/test/server/streamable_mcp_server_test.dart
+++ b/test/server/streamable_mcp_server_test.dart
@@ -831,6 +831,76 @@ void main() {
       expect(allowed.statusCode, HttpStatus.ok);
     });
 
+    test('OAuth insufficient-scope auth returns forbidden bearer challenge',
+        () async {
+      await server.stop();
+
+      server = StreamableMcpServer(
+        serverFactory: (sid) => McpServer(
+          const Implementation(name: 'OAuthScopeServer', version: '1.0'),
+        ),
+        host: host,
+        port: port,
+        authenticationHandler: (req) {
+          final authorization =
+              req.headers.value(HttpHeaders.authorizationHeader);
+          if (authorization == 'Bearer good') {
+            return const StreamableMcpAuthenticationResult.allow();
+          }
+          if (authorization == 'Bearer missing-scope') {
+            return const StreamableMcpAuthenticationResult.insufficientScope(
+              scope: 'tools:write',
+              errorDescription: 'Need tools:write',
+            );
+          }
+          return const StreamableMcpAuthenticationResult.unauthorized();
+        },
+        oauthProtectedResource: OAuthProtectedResourceOptions(
+          metadata: OAuthProtectedResourceMetadata(
+            resource: Uri.parse(baseUrl),
+            authorizationServers: [Uri.parse('https://auth.example.com')],
+            scopesSupported: const ['tools:read', 'tools:write'],
+          ),
+          scope: 'tools:read',
+        ),
+      );
+      await server.start();
+
+      final missingScope = await postInitializeWithHeaders(
+        headers: {
+          HttpHeaders.authorizationHeader: 'Bearer missing-scope',
+        },
+      );
+
+      expect(missingScope.statusCode, HttpStatus.forbidden);
+      expect(missingScope.body, 'Forbidden');
+      final scopeChallenge =
+          missingScope.headers[HttpHeaders.wwwAuthenticateHeader];
+      expect(scopeChallenge, contains('error="insufficient_scope"'));
+      expect(scopeChallenge, contains('scope="tools:write"'));
+      expect(scopeChallenge, contains('error_description="Need tools:write"'));
+      expect(
+        scopeChallenge,
+        contains(
+          'resource_metadata="http://localhost:$port/.well-known/oauth-protected-resource/mcp"',
+        ),
+      );
+
+      final unauthorized = await postInitialize();
+      expect(unauthorized.statusCode, HttpStatus.unauthorized);
+      expect(
+        unauthorized.headers[HttpHeaders.wwwAuthenticateHeader],
+        isNot(contains('insufficient_scope')),
+      );
+
+      final allowed = await postInitializeWithHeaders(
+        headers: {
+          HttpHeaders.authorizationHeader: 'Bearer good',
+        },
+      );
+      expect(allowed.statusCode, HttpStatus.ok);
+    });
+
     test('OAuth challenge can use configured public metadata URL', () async {
       await server.stop();
 

--- a/test/shared/json_schema_test.dart
+++ b/test/shared/json_schema_test.dart
@@ -179,7 +179,7 @@ void main() {
       });
     });
 
-    test('JsonEnum serializes titled string values compatibly', () {
+    test('JsonEnum serializes titled string values as const choices', () {
       const schema = JsonEnum([
         'simple',
         {'value': 'complex', 'title': 'Complex Option'},
@@ -187,8 +187,32 @@ void main() {
 
       expect(schema.toJson(), {
         'type': 'string',
-        'enum': ['simple', 'complex'],
-        'enumNames': ['simple', 'Complex Option'],
+        'oneOf': [
+          {'const': 'simple'},
+          {'const': 'complex', 'title': 'Complex Option'},
+        ],
+      });
+    });
+
+    test('JsonArray serializes titled enum items with anyOf choices', () {
+      const schema = JsonArray(
+        items: JsonEnum([
+          {'value': 'read', 'title': 'Read'},
+          {'value': 'write', 'title': 'Write'},
+        ]),
+        uniqueItems: true,
+      );
+
+      expect(schema.toJson(), {
+        'type': 'array',
+        'items': {
+          'type': 'string',
+          'anyOf': [
+            {'const': 'read', 'title': 'Read'},
+            {'const': 'write', 'title': 'Write'},
+          ],
+        },
+        'uniqueItems': true,
       });
     });
 

--- a/test/tool_schema_test.dart
+++ b/test/tool_schema_test.dart
@@ -161,15 +161,20 @@ void main() {
           json['inputSchema']['properties']['mode'] as Map<String, dynamic>;
 
       expect(modeSchema['type'], equals('string'));
-      expect(modeSchema['enum'], equals(['simple', 'complex']));
-      expect(modeSchema['enumNames'], equals(['simple', 'Complex Option']));
+      expect(
+        modeSchema['oneOf'],
+        equals([
+          {'const': 'simple'},
+          {'const': 'complex', 'title': 'Complex Option'},
+        ]),
+      );
       expect(modeSchema.containsKey('values'), isFalse);
 
       final restored = Tool.fromJson(json);
-      final restoredMode = (restored.inputSchema as JsonObject)
-          .properties!['mode'] as JsonString;
-      expect(restoredMode.enumValues, equals(['simple', 'complex']));
-      expect(restoredMode.enumNames, equals(['simple', 'Complex Option']));
+      final restoredMode =
+          (restored.inputSchema as JsonObject).properties!['mode'] as JsonEnum;
+      expect(restoredMode.normalizedValues, equals(['simple', 'complex']));
+      expect((restoredMode.values[1] as Map)['title'], 'Complex Option');
     });
 
     test('ListToolsResult preserves tool required fields', () {

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -600,6 +600,12 @@ void main() {
     test('includes meta when present', () {
       final result = const EmptyResult(meta: {'key': 'value'});
       expect(result.meta, equals({'key': 'value'}));
+      expect(
+        result.toJson(),
+        equals({
+          '_meta': {'key': 'value'},
+        }),
+      );
     });
   });
 

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -843,6 +843,10 @@ void main() {
         () => ElicitResult.fromJson(const {'action': 'later'}),
         throwsA(isA<FormatException>()),
       );
+      expect(
+        () => const ElicitResult(action: 'later').toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
     });
 
     test('ElicitResult parses legacy URL fields but does not emit them', () {

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -73,6 +73,66 @@ void main() {
     });
   });
 
+  group('Result Meta Tests', () {
+    const Map<String, dynamic> meta = {'traceId': 'abc'};
+
+    void expectMeta(BaseResultData result) {
+      expect(result.toJson()['_meta'], equals(meta));
+      final response = JsonRpcResponse(
+        id: 1,
+        result: result.toJson(),
+        meta: result.meta,
+      );
+      expect(response.toJson()['result']['_meta'], equals(meta));
+    }
+
+    test('typed result serializers preserve _meta', () {
+      const task = Task(
+        taskId: 'task-1',
+        status: TaskStatus.completed,
+        ttl: null,
+        createdAt: '2026-05-25T00:00:00.000Z',
+        lastUpdatedAt: '2026-05-25T00:00:01.000Z',
+        meta: meta,
+      );
+
+      for (final result in <BaseResultData>[
+        const EmptyResult(meta: meta),
+        const InitializeResult(
+          protocolVersion: latestProtocolVersion,
+          capabilities: ServerCapabilities(),
+          serverInfo: Implementation(name: 'server', version: '1.0'),
+          meta: meta,
+        ),
+        const ListRootsResult(roots: [], meta: meta),
+        const ListResourcesResult(resources: [], meta: meta),
+        const ListResourceTemplatesResult(resourceTemplates: [], meta: meta),
+        const ReadResourceResult(contents: [], meta: meta),
+        const ListPromptsResult(prompts: [], meta: meta),
+        const GetPromptResult(messages: [], meta: meta),
+        CompleteResult(
+          completion: CompletionResultData(values: const []),
+          meta: meta,
+        ),
+        const ElicitResult(action: 'accept', meta: meta),
+        const ListToolsResult(tools: [], meta: meta),
+        const CallToolResult(content: [], meta: meta),
+        task,
+        const ListTasksResult(tasks: [], meta: meta),
+        const CreateTaskResult(task: task, meta: meta),
+        const CreateMessageResult(
+          model: 'model',
+          stopReason: StopReason.endTurn,
+          role: SamplingMessageRole.assistant,
+          content: SamplingTextContent(text: 'done'),
+          meta: meta,
+        ),
+      ]) {
+        expectMeta(result);
+      }
+    });
+  });
+
   group('ToolExecution Tests', () {
     test('rejects invalid taskSupport while parsing wire JSON', () {
       expect(
@@ -95,9 +155,11 @@ void main() {
           const ServerCapabilitiesCompletions(listChanged: true);
 
       final json = completions.toJson();
-      expect(json['listChanged'], equals(true));
+      expect(json, isEmpty);
 
-      final deserialized = ServerCapabilitiesCompletions.fromJson(json);
+      final deserialized = ServerCapabilitiesCompletions.fromJson(
+        const {'listChanged': true},
+      );
       expect(deserialized.listChanged, equals(true));
     });
 
@@ -118,12 +180,12 @@ void main() {
       expect(json['prompts']['listChanged'], equals(true));
       expect(json['resources']['subscribe'], equals(true));
       expect(json['tools']['listChanged'], equals(true));
-      expect(json['completions']['listChanged'], equals(true));
+      expect(json['completions'], isEmpty);
 
       final deserialized = ServerCapabilities.fromJson(json);
       expect(deserialized.prompts?.listChanged, equals(true));
       expect(deserialized.resources?.subscribe, equals(true));
-      expect(deserialized.completions?.listChanged, equals(true));
+      expect(deserialized.completions, isNotNull);
     });
 
     test('ServerCapabilities serialization and deserialization', () {
@@ -774,6 +836,25 @@ void main() {
       expect(restored.declined, equals(true));
       expect(restored.accepted, equals(false));
       expect(restored.content, isNull);
+    });
+
+    test('ElicitResult rejects invalid actions', () {
+      expect(
+        () => ElicitResult.fromJson(const {'action': 'later'}),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('ElicitResult parses legacy URL fields but does not emit them', () {
+      final result = ElicitResult.fromJson(const {
+        'action': 'accept',
+        'url': 'https://example.com/auth',
+        'elicitationId': 'elicitation-1',
+      });
+
+      expect(result.url, equals('https://example.com/auth'));
+      expect(result.elicitationId, equals('elicitation-1'));
+      expect(result.toJson(), equals({'action': 'accept'}));
     });
   });
 


### PR DESCRIPTION
## Summary

Addresses the MCP 2025-11-25 spec-gap work across protocol types, Streamable HTTP auth, completion notifications, elicitation URL-mode handling, JSON Schema enum output, result metadata preservation, docs, and CLI conformance coverage.

Key changes:
- Preserve typed result `_meta` fields and broaden protocol fixture coverage for JSON-RPC IDs/progress tokens.
- Align completion `listChanged` behavior with stable vs experimental capability semantics.
- Tighten elicitation result/action validation and URL-mode serialization.
- Add Streamable HTTP OAuth discovery helpers and server-side authentication results, including insufficient-scope challenges.
- Emit JSON Schema 2020-12-compatible titled enum shapes and keep legacy enum-name parsing compatibility.
- Update docs, changelogs, and interop fixtures for the new protocol coverage.

## Compatibility

No existing public API was intentionally removed or renamed. The avoidable `OAuthTokens` source-compat risk was removed by keeping the base token shape stable and adding `OAuthAuthorizationCodeTokens` for authorization-code metadata.

There are intended wire/behavior changes for spec compliance, especially schema output for titled enums, elicitation URL-mode serialization, and stable completion `listChanged` capability serialization.

## Validation

- `dart format .`
- `dart analyze`
- `packages/mcp_dart_cli`: `dart analyze`
- `test/interop/ts`: `npm run build`
- focused OAuth/interop tests
- `dart test -t interop`
- full `dart test` (`1048` passing)
- `packages/mcp_dart_cli`: `dart run bin/mcp_dart.dart conformance --suite all --json` (`10/10` passing)
- `git diff --check`
