### PR TITLE
Polish example docs and smoke tests

### DIFF
--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -46,17 +46,25 @@ jobs:
       - name: Run pana (package analysis)
         run: |
           dart pub global activate pana
+          set +e
           dart pub global run pana --json --no-warning --exit-code-threshold 0 > pana_output.json
+          PANA_EXIT=$?
+          set -e
           # Filter out log lines and extract scores from the summary
-          RESULT=$(cat pana_output.json | grep -v '^{"logName"')
-          SCORE=$(echo "$RESULT" | grep -o '"grantedPoints": *[0-9]*' | tail -1 | grep -o '[0-9]*$')
-          MAX_POINTS=$(echo "$RESULT" | grep -o '"maxPoints": *[0-9]*' | tail -1 | grep -o '[0-9]*$')
+          RESULT=$(grep -v '^{"logName"' pana_output.json || true)
+          SCORE=$(echo "$RESULT" | grep -o '"grantedPoints": *[0-9]*' | tail -1 | grep -o '[0-9]*$' || true)
+          MAX_POINTS=$(echo "$RESULT" | grep -o '"maxPoints": *[0-9]*' | tail -1 | grep -o '[0-9]*$' || true)
           echo "Pana score: $SCORE/$MAX_POINTS"
           # We might want to enforce a threshold, e.g. 130 or 140 initially.
           # For now, let's strict check if it matches expectation or just warn.
           # Given the previous task aimed for 160/160, let's keep it strict but maybe allow slight dev.
           # For this initial workflow file, I will fail if not max points to maintain quality.
-          if [ "$SCORE" != "$MAX_POINTS" ]; then
+          if [ "$PANA_EXIT" -ne 0 ] || [ "$SCORE" != "$MAX_POINTS" ]; then
+            if grep -q 'depends on mcp_dart .*which doesn.*t match any versions' pana_output.json; then
+              echo "::warning::Skipping strict CLI pana score because this PR prepares the CLI against an unpublished mcp_dart release. Publish mcp_dart first, then rerun pana before publishing mcp_dart_cli."
+              exit 0
+            fi
+            echo "pana exited with code $PANA_EXIT."
             echo "Error: Package score is $SCORE/$MAX_POINTS."
             echo ""
             echo "Detailed report:"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@
   example flow, including TypeScript SDK OAuth interop coverage.
 - Documented first-class OAuth protected-resource metadata and bearer challenge
   support for `StreamableMcpServer`.
+- Refreshed example documentation for current stdio, weather, Streamable HTTP,
+  Flutter, Jaspr, and MCP Apps flows, including non-credentialed smoke commands.
+- Refreshed additional guide snippets for request timeouts, task capability
+  pre-advertisement, progress reporting, local documentation links, and
+  documented `dart run` targets.
+- Improved pub.dev discoverability metadata with a clearer package
+  description, documentation link, topics, platform declarations, and package
+  page summary copy.
 
 ### Spec Alignment
 
@@ -208,6 +216,9 @@
 - Improved JSON Schema parsing and validation for `const`, enum-only schemas,
   titled enum `const` entries, and simple `type` array unions such as nullable
   schemas.
+- Fixed browser example interoperability by allowing the MCP protocol-version
+  header in CORS preflight responses, mapping Flutter prompt input to advertised
+  prompt arguments, and using typed DOM inputs in the Jaspr client.
 
 ### Tooling
 
@@ -217,6 +228,11 @@
   raw-wire checks.
 - CI now runs `mcp_dart conformance --suite all --json` so JSON-RPC and
   protocol-version fixtures are checked with the spec suite.
+- Added local non-credentialed example smoke tests for stdio, iostream,
+  required-field schema preservation, CLI inspect, completions, and MCP Apps
+  metadata examples.
+- Added Markdown documentation guards for broken local links and documented
+  `dart run` targets.
 
 ## 2.1.1
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 [![Pub Version](https://img.shields.io/pub/v/mcp_dart?color=blueviolet)](https://pub.dev/packages/mcp_dart)
 [![likes](https://img.shields.io/pub/likes/mcp_dart?logo=dart)](https://pub.dev/packages/mcp_dart/score)
 
+`mcp_dart` is a Dart and Flutter SDK for building Model Context Protocol
+(MCP) servers, clients, and AI host integrations. Use it to expose Dart tools
+over stdio or Streamable HTTP, connect Flutter apps to MCP servers, and validate
+real deployments with the companion CLI.
+
 The Model Context Protocol (MCP) is a standardized protocol for communication between AI applications and external services. It enables:
 
 - **Tools**: Allow AI to execute actions (API calls, computations, etc.)

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -22,37 +22,37 @@ For task-focused guidance, also see:
 Complete stdio-based server with tools, resources, and prompts:
 
 ```bash
-# Run server
-dart run example/server_stdio.dart
-
-# Run client (in another terminal)
+# The client starts example/server_stdio.dart over stdio.
 dart run example/client_stdio.dart
 ```
 
 **Features**:
 
-- Multiple tools (echo, add, longRunningOperation)
-- Static and template-based resources
-- Prompt templates with arguments
-- Progress notifications
-- Comprehensive error handling
+- Tool invocation with the `calculate` arithmetic tool
+- Static resource reading from `file:///logs`
+- Prompt retrieval with the `analyze-code` prompt
+- Ping, capability discovery, and clean stdio shutdown
 
 ### Weather API Integration
 
 **Location**: [`example/weather.dart`](../example/weather.dart)
 
-Real-world API integration example:
+Real-world API integration example using the US National Weather Service API:
 
 ```bash
-dart run example/weather.dart
+dart run packages/mcp_dart_cli/bin/mcp_dart.dart inspect \
+  --tool get-alerts \
+  --json-args '{"state":"CA"}' \
+  dart run example/weather.dart
 ```
 
 **Features**:
 
-- External API calls (OpenWeatherMap)
-- Environment variable configuration
+- External API calls to `api.weather.gov`
+- No API key required
+- US alert lookup by two-letter state code
+- US forecast lookup by latitude and longitude
 - Error handling for API failures
-- JSON response formatting
 - Type-safe parameter validation
 
 ## Transport Examples
@@ -74,7 +74,7 @@ dart run example/server_sse.dart
 - Session management
 - Multiple concurrent connections
 
-### Streamable HTTPS
+### Streamable HTTP
 
 **Location**: [`example/streamable_https/`](../example/streamable_https/)
 
@@ -93,7 +93,7 @@ dart run example/streamable_https/client_streamable_https.dart
 - Session persistence
 - Connection resumption
 - Stateful and stateless modes
-- CORS support
+- CORS support for browser examples
 
 ### High-Level Streamable Server
 
@@ -237,6 +237,13 @@ Low-level MCP Apps metadata wiring without helper wrappers:
 dart run example/mcp_apps_metadata_server.dart
 ```
 
+**Features**:
+
+- Manual `_meta` payloads for MCP Apps resources and tools
+- `ui://weather/dashboard` HTML resource registration
+- `ResourceLink` output from a tool result
+- Host-facing `io.modelcontextprotocol/ui` metadata
+
 ### Argument Completions
 
 **Location**: [`example/completions_capability_demo.dart`](../example/completions_capability_demo.dart)
@@ -337,8 +344,10 @@ dart run
 Flutter mobile app with MCP integration:
 
 ```bash
+dart run example/streamable_https/server_streamable_https.dart
+
 cd example/flutter_http_client
-flutter run
+flutter run -d chrome
 ```
 
 **Features**:
@@ -351,6 +360,28 @@ flutter run
 
 See [Flutter Host and Client Recipes](flutter-recipes.md) for platform-specific transport, lifecycle, authentication, and testing guidance.
 
+### Jaspr MCP Client
+
+**Location**: [`example/jaspr-client/`](../example/jaspr-client/)
+
+Browser client focused on elicitation, sampling, and task-aware tool flows:
+
+```bash
+dart run example/simple_task_interactive_server.dart
+
+cd example/jaspr-client
+dart pub get
+jaspr serve
+```
+
+**Features**:
+
+- Browser-compatible Streamable HTTP transport
+- Tool discovery and form-based argument input
+- Elicitation dialog handling for `confirm_delete`
+- Sampling dialog handling for `write_haiku`
+- Console-style event log for connection and task events
+
 ## Common Patterns
 
 ### Error Handling Pattern
@@ -358,33 +389,43 @@ See [Flutter Host and Client Recipes](flutter-recipes.md) for platform-specific 
 ```dart
 // From weather.dart
 server.registerTool(
-  'get-weather',
+  'get-alerts',
+  description: 'Get weather alerts for a state',
   inputSchema: JsonSchema.object(
     properties: {
-      'city': JsonSchema.string(),
+      'state': JsonSchema.string(
+        description: 'Two-letter state code (e.g. CA, NY)',
+      ),
     },
-    required: ['city'],
+    required: ['state'],
   ),
   callback: (args, extra) async {
-    try {
-      final weather = await weatherApi.getCurrent(
-        city: args['city'] as String,
-      );
-
-      return CallToolResult(
-        content: [TextContent(text: jsonEncode(weather))],
-      );
-    } on HttpException catch (e) {
-      return CallToolResult(
+    final state = (args['state'] as String?)?.toUpperCase();
+    if (state == null || state.length != 2) {
+      return const CallToolResult(
         isError: true,
-        content: [TextContent(text: 'API error: ${e.message}')],
-      );
-    } catch (e) {
-      return CallToolResult(
-        isError: true,
-        content: [TextContent(text: 'Unexpected error: $e')],
+        content: [TextContent(text: 'Invalid state code provided.')],
       );
     }
+
+    final alertsData = await makeNWSRequest('$nwsApiBase/alerts?area=$state');
+    if (alertsData == null) {
+      return const CallToolResult(
+        isError: true,
+        content: [TextContent(text: 'Failed to retrieve alerts data.')],
+      );
+    }
+
+    final features = alertsData['features'] as List<dynamic>? ?? [];
+    if (features.isEmpty) {
+      return CallToolResult.fromContent(
+        [TextContent(text: 'No active alerts for $state.')],
+      );
+    }
+
+    return CallToolResult.fromContent(
+      [TextContent(text: 'Active alerts for $state: ...')],
+    );
   },
 );
 ```
@@ -392,27 +433,21 @@ server.registerTool(
 ### Progress Tracking Pattern
 
 ```dart
-// From server_stdio.dart
 server.registerTool(
-  'longRunningOperation',
+  'long-running-operation',
   inputSchema: JsonSchema.object(properties: {}),
   callback: (args, extra) async {
-    final progressToken = extra.progressToken;
-
     for (var i = 0; i <= 100; i += 10) {
       await Future.delayed(Duration(milliseconds: 100));
-
-      if (progressToken != null) {
-        await server.sendProgress(
-          progressToken: progressToken,
-          progress: i,
-          total: 100,
-        );
-      }
+      await extra.sendProgress(
+        i.toDouble(),
+        total: 100,
+        message: 'Processing $i%',
+      );
     }
 
-    return CallToolResult(
-      content: [TextContent(text: 'Operation complete')],
+    return CallToolResult.fromContent(
+      [const TextContent(text: 'Operation complete')],
     );
   },
 );
@@ -421,7 +456,6 @@ server.registerTool(
 ### Resource Template Pattern
 
 ```dart
-// URI template for dynamic resources
 // URI template for dynamic resources
 server.registerResourceTemplate(
   'User Profile',
@@ -576,12 +610,9 @@ flutter pub get
 
 ### Environment Variables
 
-Many examples require environment variables:
+Credentialed examples require environment variables:
 
 ```bash
-# Weather example
-export OPENWEATHER_API_KEY=your_key
-
 # GitHub examples
 export GITHUB_CLIENT_ID=your_id
 export GITHUB_CLIENT_SECRET=your_secret
@@ -612,8 +643,12 @@ dart run example/completions_capability_demo.dart
 dart run example/elicitation_http_server.dart
 
 # Flutter example
+dart run example/streamable_https/server_streamable_https.dart
 cd example/flutter_http_client
-flutter run
+flutter run -d chrome
+
+# Non-credentialed smoke checks used by CI/local release validation
+dart test test/example/non_credentialed_examples_smoke_test.dart
 ```
 
 ## Next Steps

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -500,14 +500,20 @@ await client.callTool(
 );
 ```
 
-### Connection Timeout
+### Request Timeout
 
-Increase timeout for slow operations:
+Increase timeout for a slow request with `RequestOptions`:
 
 ```dart
 final client = McpClient(
   Implementation(name: 'client', version: '1.0.0'),
-  requestTimeout: Duration(seconds: 30),  // Default is 10 seconds
+);
+
+final result = await client.callTool(
+  CallToolRequest(name: 'slow-tool', arguments: {}),
+  options: RequestOptions(
+    timeout: Duration(seconds: 30),
+  ),
 );
 ```
 

--- a/doc/migration_2025_11_25_compat.md
+++ b/doc/migration_2025_11_25_compat.md
@@ -269,7 +269,7 @@ server options before connecting:
 ```dart
 final server = McpServer(
   const Implementation(name: 'server', version: '1.0.0'),
-  options: const ServerOptions(
+  options: const McpServerOptions(
     capabilities: ServerCapabilities(
       tasks: ServerCapabilitiesTasks(
         requests: ServerCapabilitiesTasksRequests(

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -494,12 +494,12 @@ await server.connect(transport);
 ```
 
 If a task-based tool must be registered after `connect()`, pre-advertise the
-capability in `ServerOptions` before connecting:
+capability in `McpServerOptions` before connecting:
 
 ```dart
 final server = McpServer(
   const Implementation(name: 'task-server', version: '1.0.0'),
-  options: const ServerOptions(
+  options: const McpServerOptions(
     capabilities: ServerCapabilities(
       tasks: ServerCapabilitiesTasks(
         requests: ServerCapabilitiesTasksRequests(
@@ -536,40 +536,50 @@ await for (final message in taskClient.callToolStream(
 ### API Integration
 
 ```dart
+const nwsApiBase = 'https://api.weather.gov';
+
 server.registerTool(
-  'get-weather',
-  description: 'Get current weather for a city',
+  'get-alerts',
+  description: 'Get weather alerts for a US state',
   inputSchema: JsonSchema.object(
     properties: {
-      'city': JsonSchema.string(description: 'City name'),
-      'units': JsonSchema.string(
-        enumValues: ['metric', 'imperial'],
-        defaultValue: 'metric',
+      'state': JsonSchema.string(
+        description: 'Two-letter state code, for example CA or NY',
       ),
     },
-    required: ['city'],
+    required: ['state'],
   ),
   callback: (args, extra) async {
-    final city = args['city'] as String;
-    final units = args['units'] as String? ?? 'metric';
+    final state = (args['state'] as String?)?.toUpperCase();
+    if (state == null || state.length != 2) {
+      return const CallToolResult(
+        content: [TextContent(text: 'Invalid state code provided.')],
+        isError: true,
+      );
+    }
 
-    final weather = await weatherApi.getCurrent(
-      city: city,
-      units: units,
-    );
+    final alertsData = await makeNWSRequest('$nwsApiBase/alerts?area=$state');
+    if (alertsData == null) {
+      return CallToolResult.fromContent(
+        [const TextContent(text: 'Failed to retrieve alerts data.')],
+      );
+    }
 
-    return CallToolResult(
-      content: [
-        TextContent(
-          text: 'Weather in $city:\n'
-                'Temperature: ${weather.temp}°\n'
-                'Conditions: ${weather.description}',
-        ),
-      ],
+    final features = alertsData['features'] as List<dynamic>? ?? [];
+    if (features.isEmpty) {
+      return CallToolResult.fromContent(
+        [TextContent(text: 'No active alerts for $state.')],
+      );
+    }
+
+    return CallToolResult.fromContent(
+      [TextContent(text: 'Active alerts for $state: ${features.length}')],
     );
   },
 );
 ```
+
+See [`example/weather.dart`](../example/weather.dart) for the complete National Weather Service example, including request headers, forecast lookup, and alert formatting.
 
 ### Database Query
 

--- a/example/authentication/GITHUB_SETUP.md
+++ b/example/authentication/GITHUB_SETUP.md
@@ -246,5 +246,5 @@ You can extend the example to:
 
 If you encounter issues:
 1. Check the [GitHub MCP Server Issues](https://github.com/github/github-mcp-server/issues)
-2. Review [MCP Dart SDK Examples](../README.md)
+2. Review [MCP Dart SDK Examples](../../doc/examples.md)
 3. Open an issue with detailed error messages and steps to reproduce

--- a/example/flutter_http_client/README.md
+++ b/example/flutter_http_client/README.md
@@ -43,10 +43,18 @@ This will launch the application in Chrome. You can also use other browsers by s
 
 4. Once connected, you can use various buttons to interact with the server:
    - List Tools: See available tools on the server
-   - Call Tool: Execute a tool with arguments
+   - Call Tool: Execute the selected tool with the text input mapped to its primary required argument
    - List Prompts: View available prompts
+   - Get Prompt: Retrieve the selected prompt using its advertised prompt argument schema
    - List Resources: See available resources
    - Start Notifications: Begin receiving server notifications
+
+### Local Smoke Flow
+
+The default server exposes a `greet` tool and a `greeting-template` prompt.
+After connecting to `http://localhost:3000/mcp`, enter a name in the text field,
+then run `List Tools`, `Call Tool`, `List Prompts`, `Get Prompt`, and
+`List Resources`.
 
 ## Project Structure
 

--- a/example/flutter_http_client/lib/screens/mcp_client_screen.dart
+++ b/example/flutter_http_client/lib/screens/mcp_client_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_http_client/services/streamable_mcp_service.dart';
+import 'package:mcp_dart/mcp_dart.dart';
 
 class McpClientScreen extends StatefulWidget {
   final StreamableMcpService mcpService;
@@ -271,7 +272,24 @@ class McpClientScreenState extends State<McpClientScreen> {
     _showLoading(true);
     try {
       final inputText = _inputController.text.trim();
-      final args = {'text': inputText};
+      Prompt? prompt;
+      for (final candidate
+          in widget.mcpService.availablePrompts ?? <Prompt>[]) {
+        if (candidate.name == _selectedPrompt) {
+          prompt = candidate;
+          break;
+        }
+      }
+      final promptArgs = prompt?.arguments ?? [];
+      final args = <String, String>{};
+
+      if (promptArgs.isNotEmpty) {
+        final primaryArg = promptArgs.firstWhere(
+          (arg) => arg.required == true,
+          orElse: () => promptArgs.first,
+        );
+        args[primaryArg.name] = inputText.isEmpty ? 'MCP User' : inputText;
+      }
 
       final result = await widget.mcpService.getPrompt(_selectedPrompt, args);
 

--- a/example/jaspr-client/README.md
+++ b/example/jaspr-client/README.md
@@ -57,6 +57,7 @@ The server provides two demo tools:
 
 #### `confirm_delete` (Elicitation Demo)
 
+- Enter a filename, for example `test.txt`
 - Click **Call** on the `confirm_delete` tool
 - A modal dialog will appear asking for confirmation
 - Click **Yes** or **No** to respond
@@ -64,6 +65,7 @@ The server provides two demo tools:
 
 #### `write_haiku` (Sampling Demo)
 
+- Enter a topic, for example `autumn leaves`
 - Click **Call** on the `write_haiku` tool
 - A modal dialog will appear requesting an LLM response
 - Choose to use the mock haiku response or enter your own

--- a/example/jaspr-client/lib/components/connection_panel.dart
+++ b/example/jaspr-client/lib/components/connection_panel.dart
@@ -5,6 +5,7 @@ library;
 
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
+import 'package:web/web.dart' as web;
 
 import '../services/mcp_service.dart';
 
@@ -73,7 +74,7 @@ class _ConnectionPanelState extends State<ConnectionPanel> {
           },
           events: {
             'input': (event) {
-              _serverUrl = (event.target as dynamic).value as String;
+              _serverUrl = (event.target as web.HTMLInputElement).value;
             },
           },
         ),

--- a/example/jaspr-client/lib/components/prompts_panel.dart
+++ b/example/jaspr-client/lib/components/prompts_panel.dart
@@ -4,6 +4,7 @@ library;
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:mcp_dart/mcp_dart.dart';
+import 'package:web/web.dart' as web;
 
 class PromptsPanel extends StatefulComponent {
   final List<Prompt> prompts;
@@ -130,7 +131,7 @@ class _PromptsPanelState extends State<PromptsPanel> {
                 type: InputType.text,
                 events: {
                   'input': (e) {
-                    _argValues[arg.name] = (e.target as dynamic).value;
+                    _argValues[arg.name] = (e.target as web.HTMLInputElement).value;
                   },
                 },
               ),

--- a/example/jaspr-client/lib/components/sampling_dialog.dart
+++ b/example/jaspr-client/lib/components/sampling_dialog.dart
@@ -5,6 +5,7 @@ library;
 
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
+import 'package:web/web.dart' as web;
 
 /// A modal dialog for sampling requests.
 class SamplingDialog extends StatefulComponent {
@@ -87,7 +88,7 @@ Spring whispers goodbye''';
                 },
                 events: {
                   'input': (event) {
-                    _response = (event.target as dynamic).value as String;
+                    _response = (event.target as web.HTMLTextAreaElement).value;
                   },
                 },
                 [],

--- a/example/jaspr-client/lib/components/tools_panel.dart
+++ b/example/jaspr-client/lib/components/tools_panel.dart
@@ -6,6 +6,7 @@ library;
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:mcp_dart/mcp_dart.dart';
+import 'package:web/web.dart' as web;
 
 /// A panel displaying available tools with call buttons.
 class ToolsPanel extends StatefulComponent {
@@ -144,21 +145,21 @@ class _ToolsPanelState extends State<ToolsPanel> {
           inputType == InputType.checkbox ? 'change' : 'input': (e) {
             setState(() {
               if (inputType == InputType.number) {
-                final val = (e.target as dynamic).value;
-                if (val == null || val.toString().isEmpty) {
+                final val = (e.target as web.HTMLInputElement).value;
+                if (val.isEmpty) {
                   currentArgs.remove(argName);
                 } else {
                   if (argSchema is JsonInteger) {
-                    currentArgs[argName] = int.tryParse(val.toString());
+                    currentArgs[argName] = int.tryParse(val);
                   } else {
-                    currentArgs[argName] = num.tryParse(val.toString());
+                    currentArgs[argName] = num.tryParse(val);
                   }
                 }
               } else if (inputType == InputType.checkbox) {
-                final checked = (e.target as dynamic).checked;
+                final checked = (e.target as web.HTMLInputElement).checked;
                 currentArgs[argName] = checked;
               } else {
-                currentArgs[argName] = (e.target as dynamic).value;
+                currentArgs[argName] = (e.target as web.HTMLInputElement).value;
               }
             });
           },

--- a/example/simple_task_interactive_server.dart
+++ b/example/simple_task_interactive_server.dart
@@ -154,8 +154,10 @@ class InteractiveServer {
       httpRequest.response.headers.add('Access-Control-Allow-Origin', '*');
       httpRequest.response.headers
           .add('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-      httpRequest.response.headers
-          .add('Access-Control-Allow-Headers', 'Content-Type, mcp-session-id');
+      httpRequest.response.headers.add(
+        'Access-Control-Allow-Headers',
+        'Content-Type, mcp-session-id, mcp-protocol-version, Last-Event-ID, Authorization',
+      );
       httpRequest.response.headers
           .add('Access-Control-Expose-Headers', 'mcp-session-id');
 

--- a/example/streamable_https/server_streamable_https.dart
+++ b/example/streamable_https/server_streamable_https.dart
@@ -261,7 +261,7 @@ void setCorsHeaders(HttpRequest request) {
       .set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
   request.response.headers.set(
     'Access-Control-Allow-Headers',
-    'Origin, X-Requested-With, Content-Type, Accept, mcp-session-id, Last-Event-ID, Authorization',
+    'Origin, X-Requested-With, Content-Type, Accept, mcp-session-id, mcp-protocol-version, Last-Event-ID, Authorization',
   );
   request.response.headers.set('Access-Control-Allow-Credentials', 'true');
   request.response.headers.set('Access-Control-Max-Age', '86400'); // 24 hours

--- a/example/weather.dart
+++ b/example/weather.dart
@@ -75,8 +75,9 @@ void main() async {
       final alertsData = await makeNWSRequest(alertsUrl);
 
       if (alertsData == null) {
-        return CallToolResult.fromContent(
-          [const TextContent(text: "Failed to retrieve alerts data.")],
+        return const CallToolResult(
+          isError: true,
+          content: [TextContent(text: "Failed to retrieve alerts data.")],
         );
       }
 
@@ -128,8 +129,9 @@ void main() async {
       final pointsData = await makeNWSRequest(pointsUrl);
 
       if (pointsData == null) {
-        return CallToolResult.fromContent(
-          [
+        return CallToolResult(
+          isError: true,
+          content: [
             TextContent(
               text:
                   "Failed to retrieve grid point data for coordinates: $latitude, $longitude. This location may not be supported by the NWS API (only US locations are supported).",
@@ -140,9 +142,10 @@ void main() async {
 
       final forecastUrl = pointsData['properties']?['forecast'] as String?;
       if (forecastUrl == null) {
-        return CallToolResult.fromContent(
-          [
-            const TextContent(
+        return const CallToolResult(
+          isError: true,
+          content: [
+            TextContent(
               text: "Failed to get forecast URL from grid point data.",
             ),
           ],
@@ -151,9 +154,10 @@ void main() async {
 
       final forecastData = await makeNWSRequest(forecastUrl);
       if (forecastData == null) {
-        return CallToolResult.fromContent(
-          [
-            const TextContent(text: "Failed to retrieve forecast data."),
+        return const CallToolResult(
+          isError: true,
+          content: [
+            TextContent(text: "Failed to retrieve forecast data."),
           ],
         );
       }

--- a/packages/mcp_dart_cli/CHANGELOG.md
+++ b/packages/mcp_dart_cli/CHANGELOG.md
@@ -1,5 +1,10 @@
-## Unreleased
+## 0.1.8
 
+- Make `mcp_dart inspect` capability listing respect the server's advertised
+  capabilities instead of probing unsupported list methods.
+- Improve pub.dev metadata with a clearer description, documentation and issue
+  links, topics, platform declarations, and package page summary copy.
+- Update the CLI dependency constraint to `mcp_dart ^2.2.0`.
 - Add `mcp_dart conformance` with built-in JSON-RPC and protocol-version fixture checks, deterministic JSON-RPC fuzz cases, exact-case filtering, and JSON output for CI/scripts.
 - Add `mcp_dart conformance --suite spec` for MCP 2025-11-25 lifecycle,
   capability, elicitation, task-metadata, and progress-token raw-wire checks.

--- a/packages/mcp_dart_cli/README.md
+++ b/packages/mcp_dart_cli/README.md
@@ -1,6 +1,7 @@
 # mcp_dart_cli
 
-CLI for creating Model Context Protocol (MCP) servers in Dart.
+Command-line tools for creating, serving, inspecting, and testing Model Context
+Protocol (MCP) servers written in Dart.
 
 ## Installation
 

--- a/packages/mcp_dart_cli/lib/src/inspect_command.dart
+++ b/packages/mcp_dart_cli/lib/src/inspect_command.dart
@@ -266,9 +266,16 @@ class InspectCommand extends Command<int> {
 
   Future<void> _listCapabilities(McpClient client) async {
     try {
-      final tools = await client.listTools();
-      final resources = await client.listResources();
-      final prompts = await client.listPrompts();
+      final capabilities = client.getServerCapabilities();
+      final tools = capabilities?.tools != null
+          ? await client.listTools()
+          : const ListToolsResult(tools: []);
+      final resources = capabilities?.resources != null
+          ? await client.listResources()
+          : const ListResourcesResult(resources: []);
+      final prompts = capabilities?.prompts != null
+          ? await client.listPrompts()
+          : const ListPromptsResult(prompts: []);
       _printer.printCapabilities(tools, resources, prompts);
     } catch (e) {
       _logger.err('Failed to list capabilities: $e');

--- a/packages/mcp_dart_cli/lib/src/version.dart
+++ b/packages/mcp_dart_cli/lib/src/version.dart
@@ -1,1 +1,1 @@
-const packageVersion = '0.1.7';
+const packageVersion = '0.1.8';

--- a/packages/mcp_dart_cli/pubspec.yaml
+++ b/packages/mcp_dart_cli/pubspec.yaml
@@ -1,7 +1,20 @@
 name: mcp_dart_cli
-description: CLI for Model Context Protocol (MCP) servers in Dart.
-version: 0.1.7
+description: Command-line tools for creating, serving, inspecting, and testing Dart Model Context Protocol (MCP) servers.
+version: 0.1.8
 repository: https://github.com/leehack/mcp_dart
+homepage: https://github.com/leehack/mcp_dart/tree/main/packages/mcp_dart_cli
+issue_tracker: https://github.com/leehack/mcp_dart/issues
+documentation: https://github.com/leehack/mcp_dart/tree/main/packages/mcp_dart_cli
+topics:
+  - mcp
+  - ai
+  - cli
+  - dart
+  - testing
+platforms:
+  linux:
+  macos:
+  windows:
 
 environment:
   sdk: ^3.0.0
@@ -14,7 +27,7 @@ dependencies:
   stream_transform: ^2.1.1
   watcher: ^1.2.0
   yaml: ^3.1.3
-  mcp_dart: ^2.1.1
+  mcp_dart: ^2.2.0
   mason_logger: ^0.3.3
   meta: ^1.17.0
   pub_updater: ^0.5.0

--- a/packages/mcp_dart_cli/test/fixtures/tools_resources_server.dart
+++ b/packages/mcp_dart_cli/test/fixtures/tools_resources_server.dart
@@ -1,0 +1,50 @@
+import 'package:mcp_dart/mcp_dart.dart';
+
+Future<void> main() async {
+  final server = McpServer(
+    const Implementation(name: 'tools-resources-server', version: '1.0.0'),
+    options: const McpServerOptions(
+      capabilities: ServerCapabilities(
+        tools: ServerCapabilitiesTools(),
+        resources: ServerCapabilitiesResources(),
+      ),
+    ),
+  );
+
+  server.registerTool(
+    'echo',
+    description: 'Echoes text.',
+    inputSchema: JsonSchema.object(
+      properties: {
+        'message': JsonSchema.string(),
+      },
+      required: ['message'],
+    ),
+    callback: (args, extra) async {
+      return CallToolResult.fromContent(
+        [
+          TextContent(text: 'Echo: ${args['message']}'),
+        ],
+      );
+    },
+  );
+
+  server.registerResource(
+    'Demo Resource',
+    'demo://resource',
+    null,
+    (uri, extra) async {
+      return ReadResourceResult(
+        contents: [
+          TextResourceContents(
+            uri: uri.toString(),
+            mimeType: 'text/plain',
+            text: 'demo',
+          ),
+        ],
+      );
+    },
+  );
+
+  await server.connect(StdioServerTransport());
+}

--- a/packages/mcp_dart_cli/test/src/inspect_command_test.dart
+++ b/packages/mcp_dart_cli/test/src/inspect_command_test.dart
@@ -1,3 +1,4 @@
+import 'package:args/command_runner.dart';
 import 'package:mason/mason.dart';
 import 'package:mcp_dart_cli/src/inspect_command.dart';
 import 'package:mocktail/mocktail.dart';
@@ -33,6 +34,25 @@ void main() {
 
     test('arg parser supports json-args option', () {
       expect(command.argParser.options.containsKey('json-args'), isTrue);
+    });
+
+    test('lists only advertised capabilities', () async {
+      final runner = CommandRunner<int>('mcp_dart', 'CLI')..addCommand(command);
+
+      final result = await runner.run([
+        'inspect',
+        'dart',
+        'run',
+        'test/fixtures/tools_resources_server.dart',
+      ]);
+
+      expect(result, equals(ExitCode.success.code));
+      verify(() => logger.info('Tools:')).called(1);
+      verify(() => logger.info('Resources:')).called(1);
+      verify(() => logger.info('Prompts: (None)')).called(1);
+      verifyNever(
+        () => logger.err(any(that: startsWith('Failed to list capabilities'))),
+      );
     });
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,23 @@
 name: mcp_dart
-description: Dart Implementation of Model Context Protocol (MCP) SDK.
+description: Dart and Flutter SDK for building Model Context Protocol (MCP) servers, clients, hosts, and AI tools.
 version: 2.2.0
 repository: https://github.com/leehack/mcp_dart
 homepage: https://github.com/leehack/mcp_dart
 issue_tracker: https://github.com/leehack/mcp_dart/issues
-documentation: https://pub.dev/documentation/mcp_dart/latest/
+documentation: https://github.com/leehack/mcp_dart/tree/main/doc
 topics:
   - mcp
   - ai
   - llm
-  - server
-  - client
+  - api
+  - dart
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:
 
 environment:
   sdk: ^3.0.0

--- a/test/docs/markdown_docs_test.dart
+++ b/test/docs/markdown_docs_test.dart
@@ -1,0 +1,182 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  final repoRoot = Directory.current.path;
+  final repoFiles = _repoFiles(repoRoot).toSet();
+  final repoRelativeFiles = repoFiles
+      .map((file) => p.split(p.relative(file, from: repoRoot)).join('/'))
+      .toSet();
+  final repoRelativeFileSuffixes = _pathSuffixes(repoRelativeFiles).toSet();
+  final markdownFiles = _markdownFiles(repoRoot).toList()..sort();
+
+  group('Markdown docs', () {
+    test('local links resolve to checked-in files or directories', () {
+      final brokenLinks = <String>[];
+
+      for (final file in markdownFiles) {
+        final content = File(file).readAsStringSync();
+        for (final match in _markdownLinkPattern.allMatches(content)) {
+          final rawTarget = match.namedGroup('target')!;
+          final target = _stripFragment(rawTarget);
+          if (!_isLocalLink(target)) {
+            continue;
+          }
+
+          final resolved = p.normalize(p.join(p.dirname(file), target));
+          if (!File(resolved).existsSync() &&
+              !Directory(resolved).existsSync()) {
+            brokenLinks.add(
+              '${p.relative(file, from: repoRoot)} -> $rawTarget',
+            );
+          }
+        }
+      }
+
+      expect(brokenLinks, isEmpty);
+    });
+
+    test('documented dart run file targets exist', () {
+      final missingTargets = <String>[];
+
+      for (final file in markdownFiles) {
+        final content = File(file).readAsStringSync();
+        for (final match in _dartRunFilePattern.allMatches(content)) {
+          final target = match.namedGroup('target')!;
+          if (!_dartRunTargetExists(
+            repoRoot,
+            file,
+            target,
+            repoFiles,
+            repoRelativeFiles,
+            repoRelativeFileSuffixes,
+          )) {
+            missingTargets.add(
+              '${p.relative(file, from: repoRoot)} -> dart run $target',
+            );
+          }
+        }
+      }
+
+      expect(missingTargets, isEmpty);
+    });
+  });
+}
+
+Iterable<String> _pathSuffixes(Set<String> paths) sync* {
+  for (final path in paths) {
+    final parts = path.split('/');
+    for (var index = 0; index < parts.length; index++) {
+      yield parts.sublist(index).join('/');
+    }
+  }
+}
+
+final _markdownLinkPattern = RegExp(
+  r'(?<!!)\[[^\]]+\]\((?<target>[^)\s]+)(?:\s+"[^"]*")?\)',
+);
+
+final _dartRunFilePattern = RegExp(
+  r'dart run (?<target>(?:example|packages|test|bin)/[^\s`]+\.dart)',
+);
+
+Iterable<String> _markdownFiles(String repoRoot) sync* {
+  final roots = [
+    'README.md',
+    'CHANGELOG.md',
+    'doc',
+    'example',
+    p.join('packages', 'templates'),
+    p.join('packages', 'mcp_dart_cli', 'README.md'),
+    p.join('packages', 'mcp_dart_cli', 'CHANGELOG.md'),
+    p.join('packages', 'mcp_dart_cli', 'CONTRIBUTING.md'),
+    p.join('packages', 'mcp_dart_cli', 'example'),
+  ];
+
+  for (final root in roots) {
+    final path = p.join(repoRoot, root);
+    final file = File(path);
+    if (file.existsSync() && path.endsWith('.md')) {
+      yield path;
+      continue;
+    }
+
+    final directory = Directory(path);
+    if (!directory.existsSync()) {
+      continue;
+    }
+
+    yield* _filesUnder(directory)
+        .where((file) => file.path.endsWith('.md'))
+        .map((file) => file.path);
+  }
+}
+
+Iterable<String> _repoFiles(String repoRoot) sync* {
+  yield* _filesUnder(Directory(repoRoot)).map((file) => p.normalize(file.path));
+}
+
+Iterable<File> _filesUnder(Directory directory) sync* {
+  for (final entity in directory.listSync()) {
+    if (entity is Directory) {
+      if (_shouldSkipDirectory(entity)) {
+        continue;
+      }
+      yield* _filesUnder(entity);
+    } else if (entity is File) {
+      yield entity;
+    }
+  }
+}
+
+bool _shouldSkipDirectory(Directory directory) {
+  final name = p.basename(directory.path);
+  return name.startsWith('.') ||
+      const {
+        'build',
+        'coverage',
+      }.contains(name);
+}
+
+String _stripFragment(String target) {
+  final hashIndex = target.indexOf('#');
+  if (hashIndex == -1) {
+    return target;
+  }
+  return target.substring(0, hashIndex);
+}
+
+bool _isLocalLink(String target) {
+  if (target.isEmpty || target.startsWith('#')) {
+    return false;
+  }
+  final lower = target.toLowerCase();
+  return !lower.startsWith('http://') &&
+      !lower.startsWith('https://') &&
+      !lower.startsWith('mailto:');
+}
+
+bool _dartRunTargetExists(
+  String repoRoot,
+  String markdownFile,
+  String target,
+  Set<String> repoFiles,
+  Set<String> repoRelativeFiles,
+  Set<String> repoRelativeFileSuffixes,
+) {
+  final relativeToMarkdown =
+      p.normalize(p.join(p.dirname(markdownFile), target));
+  if (repoFiles.contains(relativeToMarkdown)) {
+    return true;
+  }
+
+  final relativeToRepoRoot = p.normalize(p.join(repoRoot, target));
+  if (repoFiles.contains(relativeToRepoRoot)) {
+    return true;
+  }
+
+  return repoRelativeFiles.contains(target) ||
+      repoRelativeFileSuffixes.contains(target);
+}

--- a/test/example/non_credentialed_examples_smoke_test.dart
+++ b/test/example/non_credentialed_examples_smoke_test.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  group('non-credentialed examples smoke tests', () {
+    test('stdio client drives stdio server tools resources and prompts',
+        () async {
+      final result = await _runDart(['run', 'example/client_stdio.dart']);
+
+      expect(result.exitCode, 0, reason: result.output);
+      expect(result.output, contains('Connected to server.'));
+      expect(result.output, contains('Result: 15'));
+      expect(result.output, contains('Sample log content'));
+      expect(result.output, contains('Prompt result:'));
+    });
+
+    test('iostream example connects in process', () async {
+      final result = await _runDart([
+        'run',
+        'example/iostream-client-server/simple.dart',
+      ]);
+
+      expect(result.exitCode, 0, reason: result.output);
+      expect(result.output, contains('Client setup complete.'));
+      expect(result.output, contains('Available tools: (calculate)'));
+    });
+
+    test('required fields demo preserves schemas', () async {
+      final result = await _runDart([
+        'run',
+        'example/required_fields_demo.dart',
+      ]);
+
+      expect(result.exitCode, 0, reason: result.output);
+      expect(result.output, contains('Required parameters: [operation, a, b]'));
+      expect(result.output, contains('MCP server integration works!'));
+    });
+
+    test('CLI inspect invokes completions demo over stdio', () async {
+      final result = await _runDart([
+        'run',
+        'packages/mcp_dart_cli/bin/mcp_dart.dart',
+        'inspect',
+        '--tool',
+        'echo',
+        '--json-args',
+        '{"message":"smoke"}',
+        Platform.resolvedExecutable,
+        'run',
+        'example/completions_capability_demo.dart',
+      ]);
+
+      expect(result.exitCode, 0, reason: result.output);
+      expect(result.output, contains('Connected to server!'));
+      expect(result.output, contains('Echo: smoke'));
+    });
+
+    test('CLI inspect lists MCP Apps metadata server capabilities', () async {
+      final result = await _runDart([
+        'run',
+        'packages/mcp_dart_cli/bin/mcp_dart.dart',
+        'inspect',
+        Platform.resolvedExecutable,
+        'run',
+        'example/mcp_apps_metadata_server.dart',
+      ]);
+
+      expect(result.exitCode, 0, reason: result.output);
+      expect(result.output, contains('weather_get_current'));
+      expect(result.output, contains('ui://weather/dashboard'));
+      expect(result.output, contains('Prompts: (None)'));
+      expect(result.output, isNot(contains('Failed to list capabilities')));
+    });
+
+    test('CLI inspect invokes MCP Apps helper server tool and resource',
+        () async {
+      final toolResult = await _runDart([
+        'run',
+        'packages/mcp_dart_cli/bin/mcp_dart.dart',
+        'inspect',
+        '--tool',
+        'weather_get_current',
+        '--json-args',
+        '{"location":"Seoul"}',
+        Platform.resolvedExecutable,
+        'run',
+        'example/mcp_apps_helpers_server.dart',
+      ]);
+
+      expect(toolResult.exitCode, 0, reason: toolResult.output);
+      expect(toolResult.output, contains('Current weather for Seoul'));
+      expect(toolResult.output, contains('ui://weather/dashboard.html'));
+
+      final resourceResult = await _runDart([
+        'run',
+        'packages/mcp_dart_cli/bin/mcp_dart.dart',
+        'inspect',
+        '--resource',
+        'ui://weather/dashboard.html',
+        Platform.resolvedExecutable,
+        'run',
+        'example/mcp_apps_helpers_server.dart',
+      ]);
+
+      expect(resourceResult.exitCode, 0, reason: resourceResult.output);
+      expect(resourceResult.output, contains('MCP APP RESOURCE'));
+      expect(resourceResult.output, contains('ui://weather/dashboard.html'));
+    });
+  });
+}
+
+Future<_CommandResult> _runDart(List<String> args) {
+  return _runCommand(
+    Platform.resolvedExecutable,
+    args,
+    timeout: const Duration(seconds: 30),
+  );
+}
+
+Future<_CommandResult> _runCommand(
+  String executable,
+  List<String> args, {
+  required Duration timeout,
+}) async {
+  final process = await Process.start(executable, args);
+  final stdoutFuture = process.stdout.transform(utf8.decoder).join();
+  final stderrFuture = process.stderr.transform(utf8.decoder).join();
+
+  int exitCode;
+  try {
+    exitCode = await process.exitCode.timeout(timeout);
+  } on TimeoutException {
+    process.kill();
+    exitCode = await process.exitCode.timeout(
+      const Duration(seconds: 5),
+      onTimeout: () {
+        if (Platform.isWindows) {
+          process.kill();
+        } else {
+          process.kill(ProcessSignal.sigkill);
+        }
+        return -1;
+      },
+    );
+    return _CommandResult(
+      exitCode: exitCode,
+      stdout: await stdoutFuture,
+      stderr: '${await stderrFuture}Timed out after $timeout',
+    );
+  }
+
+  return _CommandResult(
+    exitCode: exitCode,
+    stdout: await stdoutFuture,
+    stderr: await stderrFuture,
+  );
+}
+
+class _CommandResult {
+  final int exitCode;
+  final String stdout;
+  final String stderr;
+
+  const _CommandResult({
+    required this.exitCode,
+    required this.stdout,
+    required this.stderr,
+  });
+
+  String get output => [
+        if (stdout.isNotEmpty) stdout,
+        if (stderr.isNotEmpty) stderr,
+      ].join('\n');
+}


### PR DESCRIPTION
## Summary

- Refresh stale example and guide snippets for weather, stdio/Streamable HTTP, progress, timeout, and `McpServerOptions` usage.
- Fix browser example issues found during E2E testing, including CORS protocol headers, Flutter prompt argument selection, and typed Jaspr DOM casts.
- Make `mcp_dart inspect` list only advertised server capabilities and add a regression fixture for servers without prompts.
- Add docs/example guard tests for local Markdown links, documented `dart run` targets, and non-credentialed example smoke flows.
- Clarify the documented tool error handling pattern and mark weather API failures as `CallToolResult(isError: true)`.
- Improve pub.dev discoverability for both packages with clearer descriptions, documentation/issue links, topics, platform declarations, and package-page lead copy.
- Prepare the CLI `0.1.8` release by versioning the package, syncing `packageVersion`, closing the CLI changelog entry, and requiring `mcp_dart ^2.2.0`.
- Keep the CLI `pana` CI gate strict, with an explicit release-order exception only while `mcp_dart ^2.2.0` is not yet hosted on pub.dev.

## Review follow-up

- Use `Platform.resolvedExecutable` and portable timeout cleanup in the example smoke tests.
- Scope Markdown doc traversal away from generated/hidden directories and broad nested package scans.
- Precompute repository file path and suffix sets for documented `dart run` target validation.

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `git diff --check`
- `dart analyze`
- `dart test` (1071 passed)
- `dart analyze` in `packages/mcp_dart_cli`
- `dart test` in `packages/mcp_dart_cli` (55 passed)
- `dart run bin/mcp_dart.dart conformance --suite all --json` in `packages/mcp_dart_cli`
- Clean-copy root `dart pub publish --dry-run` (0 warnings)
- Clean-copy CLI `dart pub publish --dry-run` (0 warnings, expected dependency override hint)
- Clean-copy `pana` for root package: 160/160
- Clean-copy `pana` for CLI package before the `mcp_dart ^2.2.0` release-order bump: 160/160
- Current clean-copy `pana` for CLI is release-order blocked until `mcp_dart 2.2.0` is published; hosted pub.dev still resolves latest `mcp_dart` as `2.1.1`.
- Simulated CLI CI `pana` release-order skip condition against the current `50/160` report caused only by unresolved `mcp_dart ^2.2.0`.

## Release order

Publish/tag `mcp_dart 2.2.0` first, then publish/tag `mcp_dart_cli 0.1.8`. The CLI now intentionally depends on `mcp_dart ^2.2.0`, so hosted dependency resolution will fail if the CLI is published first.

## Notes

Credentialed Anthropic/Gemini/GitHub examples still require API keys or OAuth setup for live E2E runs; this PR covers them through docs/link/run-target validation plus the existing OAuth client example test.
