### PR TITLE
Add MCP 2026 RC discovery foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Unreleased
+
+### MCP 2026-07-28 RC
+
+- Started the MCP 2026-07-28 RC development line with opt-in protocol
+  constants, stateless request metadata helpers, and `server/discover` request
+  and result types.
+- Added server-side `server/discover` handling before legacy initialization and
+  initial stateless request validation for per-request protocol version,
+  client identity, and client capability metadata.
+- Added opt-in client discovery via `McpClientOptions(useServerDiscover: true)`
+  while keeping the stable `initialize` flow as the default until the 2026
+  stateless transport and MRTR implementation is complete.
+
 ## 2.2.0
 
 ### Documentation

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -12,9 +12,25 @@ class McpClientOptions extends ProtocolOptions {
   /// Capabilities to advertise as being supported by this client.
   final ClientCapabilities? capabilities;
 
+  /// Preferred protocol version for opt-in `server/discover` negotiation.
+  ///
+  /// The current default keeps existing clients on the stable initialization
+  /// flow unless [useServerDiscover] is enabled.
+  final String protocolVersion;
+
+  /// Whether [McpClient.connect] should probe with `server/discover` first.
+  final bool useServerDiscover;
+
+  /// Whether a `server/discover` method-not-found response should fall back to
+  /// the legacy `initialize` handshake.
+  final bool allowLegacyInitializationFallback;
+
   const McpClientOptions({
     super.enforceStrictCapabilities,
     this.capabilities,
+    this.protocolVersion = latestDraftProtocolVersion,
+    this.useServerDiscover = false,
+    this.allowLegacyInitializationFallback = true,
   });
 }
 
@@ -69,8 +85,13 @@ class McpClient extends Protocol {
   Implementation? _serverVersion;
   ClientCapabilities _capabilities;
   final Implementation _clientInfo;
+  final String _preferredProtocolVersion;
+  final bool _useServerDiscover;
+  final bool _allowLegacyInitializationFallback;
   String? _instructions;
   Future<void>? _sessionRefresh;
+  String? _negotiatedProtocolVersion;
+  bool _usesStatelessProtocol = false;
   bool _sentInitialized = false;
 
   final Map<String, JsonSchema> _cachedToolOutputSchemas = {};
@@ -99,6 +120,11 @@ class McpClient extends Protocol {
   /// - [options]: Optional configuration settings including client capabilities.
   McpClient(this._clientInfo, {McpClientOptions? options})
       : _capabilities = options?.capabilities ?? const ClientCapabilities(),
+        _preferredProtocolVersion =
+            options?.protocolVersion ?? latestDraftProtocolVersion,
+        _useServerDiscover = options?.useServerDiscover ?? false,
+        _allowLegacyInitializationFallback =
+            options?.allowLegacyInitializationFallback ?? true,
         super(options) {
     // Register elicit handler if any elicitation mode is advertised.
     if (_capabilities.elicitation != null) {
@@ -209,6 +235,7 @@ class McpClient extends Protocol {
 
   Future<void> _initializeSession(Transport transport) async {
     _sentInitialized = false;
+    _usesStatelessProtocol = false;
 
     final initParams = InitializeRequest(
       protocolVersion: latestProtocolVersion,
@@ -236,6 +263,7 @@ class McpClient extends Protocol {
     _serverCapabilities = result.capabilities;
     _serverVersion = result.serverInfo;
     _instructions = result.instructions;
+    _negotiatedProtocolVersion = result.protocolVersion;
 
     if (transport is ProtocolVersionAwareTransport) {
       (transport as ProtocolVersionAwareTransport).protocolVersion =
@@ -256,6 +284,63 @@ class McpClient extends Protocol {
     );
   }
 
+  Map<String, dynamic> _statelessRequestMeta(Map<String, dynamic>? meta) {
+    return buildProtocolRequestMeta(
+      protocolVersion: _negotiatedProtocolVersion ?? _preferredProtocolVersion,
+      clientInfo: _clientInfo,
+      clientCapabilities: _capabilities,
+      meta: meta,
+    );
+  }
+
+  Future<DiscoverResult> discoverServer() async {
+    final result = await super.request<DiscoverResult>(
+      JsonRpcServerDiscoverRequest(
+        id: -1,
+        meta: buildProtocolRequestMeta(
+          protocolVersion: _preferredProtocolVersion,
+          clientInfo: _clientInfo,
+          clientCapabilities: _capabilities,
+        ),
+      ),
+      (json) => DiscoverResult.fromJson(json),
+    );
+
+    final protocolVersion = negotiateProtocolVersion(
+      result.supportedVersions,
+      localSupportedVersions: supportedProtocolVersionsWithDraft,
+    );
+    if (protocolVersion == null) {
+      throw McpError(
+        ErrorCode.unsupportedProtocolVersion.value,
+        "Server does not support a compatible MCP protocol version.",
+        {
+          'supported': result.supportedVersions,
+          'requested': _preferredProtocolVersion,
+        },
+      );
+    }
+
+    _serverCapabilities = result.capabilities;
+    _serverVersion = result.serverInfo;
+    _instructions = result.instructions;
+    _negotiatedProtocolVersion = protocolVersion;
+    _usesStatelessProtocol = isStatelessProtocolVersion(protocolVersion);
+    _sentInitialized = true;
+
+    final activeTransport = transport;
+    if (activeTransport is ProtocolVersionAwareTransport) {
+      (activeTransport as ProtocolVersionAwareTransport).protocolVersion =
+          protocolVersion;
+    }
+
+    _logger.debug(
+      "MCP Server Discovered. Server: ${result.serverInfo.name} ${result.serverInfo.version}, Protocol: $protocolVersion",
+    );
+
+    return result;
+  }
+
   /// Connects to the server using the given [transport].
   ///
   /// Initiates the MCP initialization handshake and processes the result.
@@ -264,6 +349,23 @@ class McpClient extends Protocol {
     await super.connect(transport);
 
     try {
+      if (_useServerDiscover) {
+        try {
+          await discoverServer();
+          return;
+        } catch (error) {
+          final canFallback = _allowLegacyInitializationFallback &&
+              error is McpError &&
+              error.code == ErrorCode.methodNotFound.value;
+          if (!canFallback) {
+            rethrow;
+          }
+          _logger.debug(
+            "server/discover not available; falling back to initialize.",
+          );
+        }
+      }
+
       await _initializeSession(transport);
     } catch (error) {
       _logger.error("MCP Client Initialization Failed: $error");
@@ -279,15 +381,26 @@ class McpClient extends Protocol {
     RequestOptions? options,
     int? relatedRequestId,
   ]) async {
+    final outboundRequest =
+        _usesStatelessProtocol && requestData.method != Method.serverDiscover
+            ? JsonRpcRequest(
+                id: requestData.id,
+                method: requestData.method,
+                params: requestData.params,
+                meta: _statelessRequestMeta(requestData.meta),
+              )
+            : requestData;
+
     try {
       return await super.request<T>(
-        requestData,
+        outboundRequest,
         resultFactory,
         options,
         relatedRequestId,
       );
     } catch (error) {
-      if (error is! StaleSessionError || requestData.method == 'initialize') {
+      if (error is! StaleSessionError ||
+          outboundRequest.method == 'initialize') {
         rethrow;
       }
 
@@ -316,7 +429,7 @@ class McpClient extends Protocol {
       }
 
       return await super.request<T>(
-        requestData,
+        outboundRequest,
         resultFactory,
         options,
         relatedRequestId,
@@ -332,6 +445,9 @@ class McpClient extends Protocol {
 
   /// Gets the server's instructions provided during initialization, if any.
   String? getInstructions() => _instructions;
+
+  /// Gets the negotiated protocol version after connection.
+  String? getProtocolVersion() => _negotiatedProtocolVersion;
 
   @override
   McpError? validateIncomingRequest(JsonRpcRequest request) {

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -73,6 +73,12 @@ class Server extends Protocol {
       : _capabilities = options?.capabilities ?? const ServerCapabilities(),
         _instructions = options?.instructions,
         super(options) {
+    setRequestHandler<JsonRpcServerDiscoverRequest>(
+      Method.serverDiscover,
+      (request, extra) async => _onDiscover(),
+      (id, params, meta) => JsonRpcServerDiscoverRequest(id: id, meta: meta),
+    );
+
     setRequestHandler<JsonRpcInitializeRequest>(
       Method.initialize,
       (request, extra) async => _oninitialize(request.initParams),
@@ -118,8 +124,83 @@ class Server extends Protocol {
     _loggingLevels.clear();
   }
 
+  McpError _unsupportedProtocolVersionError(String requestedVersion) {
+    return McpError(
+      ErrorCode.unsupportedProtocolVersion.value,
+      'Unsupported protocol version',
+      {
+        'supported': supportedProtocolVersionsWithDraft,
+        'requested': requestedVersion,
+      },
+    );
+  }
+
+  McpError? _validateStatelessRequestMetadata(JsonRpcRequest request) {
+    final meta = request.meta;
+    final requestedVersion = meta?[McpMetaKey.protocolVersion];
+    if (requestedVersion is! String || requestedVersion.isEmpty) {
+      return McpError(
+        ErrorCode.invalidRequest.value,
+        'Missing required request metadata: ${McpMetaKey.protocolVersion}',
+      );
+    }
+    if (!supportedProtocolVersionsWithDraft.contains(requestedVersion)) {
+      return _unsupportedProtocolVersionError(requestedVersion);
+    }
+    if (!isStatelessProtocolVersion(requestedVersion)) {
+      return McpError(
+        ErrorCode.invalidRequest.value,
+        'server/discover and stateless requests require a stateless protocol version.',
+      );
+    }
+
+    final clientInfo = meta?[McpMetaKey.clientInfo];
+    if (clientInfo is! Map) {
+      return McpError(
+        ErrorCode.invalidRequest.value,
+        'Missing required request metadata: ${McpMetaKey.clientInfo}',
+      );
+    }
+
+    final clientCapabilities = meta?[McpMetaKey.clientCapabilities];
+    if (clientCapabilities is! Map) {
+      return McpError(
+        ErrorCode.invalidRequest.value,
+        'Missing required request metadata: ${McpMetaKey.clientCapabilities}',
+      );
+    }
+
+    try {
+      Implementation.fromJson(clientInfo.cast<String, dynamic>());
+      ClientCapabilities.fromJson(clientCapabilities.cast<String, dynamic>());
+    } catch (error) {
+      return McpError(
+        ErrorCode.invalidRequest.value,
+        'Invalid stateless request metadata.',
+        error.toString(),
+      );
+    }
+
+    return null;
+  }
+
   @override
   McpError? validateIncomingRequest(JsonRpcRequest request) {
+    if (request.method == Method.serverDiscover) {
+      return _validateStatelessRequestMetadata(request);
+    }
+
+    final requestedProtocolVersion = request.meta?[McpMetaKey.protocolVersion];
+    if (requestedProtocolVersion is String &&
+        !supportedProtocolVersionsWithDraft
+            .contains(requestedProtocolVersion)) {
+      return _unsupportedProtocolVersionError(requestedProtocolVersion);
+    }
+    if (requestedProtocolVersion is String &&
+        isStatelessProtocolVersion(requestedProtocolVersion)) {
+      return _validateStatelessRequestMetadata(request);
+    }
+
     if (request.method == Method.initialize) {
       if (_lifecycleState != _ServerLifecycleState.uninitialized) {
         return McpError(
@@ -310,6 +391,16 @@ class Server extends Protocol {
     );
   }
 
+  /// Handles the client's `server/discover` request.
+  Future<DiscoverResult> _onDiscover() async {
+    return DiscoverResult(
+      supportedVersions: supportedProtocolVersionsWithDraft,
+      capabilities: getCapabilities(),
+      serverInfo: _serverInfo,
+      instructions: _instructions,
+    );
+  }
+
   /// Gets the client's reported capabilities, available after initialization.
   ClientCapabilities? getClientCapabilities() => _clientCapabilities;
 
@@ -445,6 +536,7 @@ class Server extends Protocol {
   @override
   void assertRequestHandlerCapability(String method) {
     switch (method) {
+      case Method.serverDiscover:
       case Method.initialize:
       case Method.ping:
       case Method.completionComplete:

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -238,6 +238,9 @@ class StreamableHTTPServerTransport
 
     if (req.method == "POST") {
       await _handlePostRequest(req, parsedBody);
+    } else if (_isStatelessProtocolVersionRequest(req) &&
+        (req.method == "GET" || req.method == "DELETE")) {
+      await _handleStatelessUnsupportedRequest(req.response);
     } else if (req.method == "GET") {
       await _handleGetRequest(req);
     } else if (req.method == "DELETE") {
@@ -261,21 +264,27 @@ class StreamableHTTPServerTransport
     }
 
     final requestedVersion = versionHeader.trim();
-    if (supportedProtocolVersions.contains(requestedVersion)) {
+    if (supportedProtocolVersionsWithDraft.contains(requestedVersion)) {
       return true;
     }
 
     await _writeJsonRpcErrorResponse(
       res,
       httpStatus: HttpStatus.badRequest,
-      errorCode: ErrorCode.invalidRequest,
-      message: 'Invalid MCP-Protocol-Version header',
+      errorCode: ErrorCode.unsupportedProtocolVersion,
+      message: 'Unsupported protocol version',
       data: {
         'requested': requestedVersion,
-        'supported': supportedProtocolVersions,
+        'supported': supportedProtocolVersionsWithDraft,
       },
     );
     return false;
+  }
+
+  bool _isStatelessProtocolVersionRequest(HttpRequest req) {
+    final versionHeader = req.headers.value('mcp-protocol-version');
+    return versionHeader != null &&
+        isStatelessProtocolVersion(versionHeader.trim());
   }
 
   bool _isValidVisibleAsciiToken(String value) {
@@ -655,6 +664,23 @@ class StreamableHTTPServerTransport
     await _safeClose(res);
   }
 
+  Future<void> _handleStatelessUnsupportedRequest(HttpResponse res) async {
+    res.statusCode = HttpStatus.methodNotAllowed;
+    res.headers.set(HttpHeaders.allowHeader, "POST");
+    res.write(
+      jsonEncode(
+        JsonRpcError(
+          id: null,
+          error: JsonRpcErrorData(
+            code: ErrorCode.connectionClosed.value,
+            message: 'Method not allowed for stateless MCP requests.',
+          ),
+        ).toJson(),
+      ),
+    );
+    await _safeClose(res);
+  }
+
   /// Handles POST requests containing JSON-RPC messages
   Future<void> _handlePostRequest(HttpRequest req, [dynamic parsedBody]) async {
     try {
@@ -779,6 +805,7 @@ class StreamableHTTPServerTransport
       // Check if this is an initialization request
       // https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle/
       final isInitializationRequest = messages.any(_isInitializeRequest);
+      final isStatelessRequest = messages.any(_isStatelessJsonRpcRequest);
       if (isInitializationRequest) {
         final requestSessionId = req.headers.value('mcp-session-id');
 
@@ -868,6 +895,7 @@ class StreamableHTTPServerTransport
       // clients using the Streamable HTTP transport MUST include it
       // in the Mcp-Session-Id header on all of their subsequent HTTP requests.
       if (!isInitializationRequest &&
+          !isStatelessRequest &&
           !await _validateSession(req, req.response)) {
         return;
       }
@@ -1225,7 +1253,16 @@ class StreamableHTTPServerTransport
   /// Checks if a message is an initialize request
   bool _isInitializeRequest(JsonRpcMessage message) {
     if (message is JsonRpcRequest) {
-      return message.method == "initialize";
+      return message.method == Method.initialize;
+    }
+    return false;
+  }
+
+  /// Checks if a message uses the stateless 2026 protocol metadata.
+  bool _isStatelessJsonRpcRequest(JsonRpcMessage message) {
+    if (message is JsonRpcRequest) {
+      final version = message.meta?[McpMetaKey.protocolVersion];
+      return version is String && isStatelessProtocolVersion(version);
     }
     return false;
   }

--- a/lib/src/types/initialization.dart
+++ b/lib/src/types/initialization.dart
@@ -491,6 +491,21 @@ class JsonRpcInitializeRequest extends JsonRpcRequest {
   }
 }
 
+/// Request sent by a 2026 client to discover server protocol support.
+class JsonRpcServerDiscoverRequest extends JsonRpcRequest {
+  JsonRpcServerDiscoverRequest({
+    required super.id,
+    super.meta,
+  }) : super(method: Method.serverDiscover);
+
+  factory JsonRpcServerDiscoverRequest.fromJson(Map<String, dynamic> json) {
+    return JsonRpcServerDiscoverRequest(
+      id: parseRequestId(json['id']),
+      meta: extractRequestMeta(json),
+    );
+  }
+}
+
 /// Describes capabilities related to elicitation > form mode for the server.
 class ServerElicitationForm {
   const ServerElicitationForm();
@@ -875,6 +890,69 @@ class InitializeResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         'protocolVersion': protocolVersion,
+        'capabilities': capabilities.toJson(),
+        'serverInfo': serverInfo.toJson(),
+        if (instructions != null) 'instructions': instructions,
+        if (meta != null) '_meta': meta,
+      };
+}
+
+/// Result data for a successful `server/discover` request.
+class DiscoverResult implements BaseResultData {
+  /// Result discriminator used by the 2026 result model.
+  final String resultType;
+
+  /// Protocol versions supported by the server.
+  final List<String> supportedVersions;
+
+  /// Capabilities the server supports.
+  final ServerCapabilities capabilities;
+
+  /// Information about the server implementation.
+  final Implementation serverInfo;
+
+  /// Instructions describing how to use the server and its features.
+  final String? instructions;
+
+  /// Optional metadata.
+  @override
+  final Map<String, dynamic>? meta;
+
+  const DiscoverResult({
+    this.resultType = 'complete',
+    required this.supportedVersions,
+    required this.capabilities,
+    required this.serverInfo,
+    this.instructions,
+    this.meta,
+  });
+
+  factory DiscoverResult.fromJson(Map<String, dynamic> json) {
+    final supportedVersions = json['supportedVersions'];
+    if (supportedVersions is! List) {
+      throw const FormatException(
+        'Missing or invalid supportedVersions for discover result',
+      );
+    }
+
+    return DiscoverResult(
+      resultType: json['resultType'] as String? ?? 'complete',
+      supportedVersions: supportedVersions.cast<String>(),
+      capabilities: ServerCapabilities.fromJson(
+        json['capabilities'] as Map<String, dynamic>,
+      ),
+      serverInfo: Implementation.fromJson(
+        json['serverInfo'] as Map<String, dynamic>,
+      ),
+      instructions: json['instructions'] as String?,
+      meta: json['_meta'] as Map<String, dynamic>?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'resultType': resultType,
+        'supportedVersions': supportedVersions,
         'capabilities': capabilities.toJson(),
         'serverInfo': serverInfo.toJson(),
         if (instructions != null) 'instructions': instructions,

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -10,8 +10,17 @@ import 'completion.dart';
 import 'roots.dart';
 import 'tasks.dart';
 
-/// The latest version of the Model Context Protocol supported.
-const latestProtocolVersion = "2025-11-25";
+/// The draft/RC MCP protocol version being prepared for the next major release.
+const draftProtocolVersion2026_07_28 = "2026-07-28";
+
+/// The latest stable version of the Model Context Protocol supported.
+const stableProtocolVersion2025_11_25 = "2025-11-25";
+
+/// The latest stable version of the Model Context Protocol supported.
+const latestProtocolVersion = stableProtocolVersion2025_11_25;
+
+/// The latest draft/RC protocol version implemented behind opt-in paths.
+const latestDraftProtocolVersion = draftProtocolVersion2026_07_28;
 
 /// List of supported Model Context Protocol versions.
 const supportedProtocolVersions = [
@@ -22,11 +31,69 @@ const supportedProtocolVersions = [
   "2024-10-07",
 ];
 
+/// Protocol versions supported by the 2026 RC development branch.
+const supportedProtocolVersionsWithDraft = [
+  latestDraftProtocolVersion,
+  ...supportedProtocolVersions,
+];
+
+/// Protocol versions that use per-request metadata instead of initialization.
+const statelessProtocolVersions = [
+  draftProtocolVersion2026_07_28,
+];
+
+/// Returns true when [version] uses the 2026 stateless request model.
+bool isStatelessProtocolVersion(String version) =>
+    statelessProtocolVersions.contains(version);
+
+/// Selects the first locally preferred version supported by a peer.
+String? negotiateProtocolVersion(
+  Iterable<String> peerSupportedVersions, {
+  Iterable<String> localSupportedVersions = supportedProtocolVersionsWithDraft,
+}) {
+  final peerVersions = peerSupportedVersions.toSet();
+  for (final version in localSupportedVersions) {
+    if (peerVersions.contains(version)) {
+      return version;
+    }
+  }
+  return null;
+}
+
+/// MCP-reserved `_meta` keys used by the 2026 stateless request model.
+class McpMetaKey {
+  static const protocolVersion = 'io.modelcontextprotocol/protocolVersion';
+  static const clientInfo = 'io.modelcontextprotocol/clientInfo';
+  static const clientCapabilities =
+      'io.modelcontextprotocol/clientCapabilities';
+  static const logLevel = 'io.modelcontextprotocol/logLevel';
+
+  const McpMetaKey._();
+}
+
+/// Builds request metadata required by the 2026 stateless request model.
+Map<String, dynamic> buildProtocolRequestMeta({
+  required String protocolVersion,
+  required Implementation clientInfo,
+  required ClientCapabilities clientCapabilities,
+  Map<String, dynamic>? meta,
+  Object? logLevel,
+}) {
+  return <String, dynamic>{
+    ...?meta,
+    McpMetaKey.protocolVersion: protocolVersion,
+    McpMetaKey.clientInfo: clientInfo.toJson(),
+    McpMetaKey.clientCapabilities: clientCapabilities.toJson(),
+    if (logLevel != null) McpMetaKey.logLevel: logLevel,
+  };
+}
+
 /// JSON-RPC protocol version string.
 const jsonRpcVersion = "2.0";
 
 /// Standard MCP JSON-RPC methods.
 class Method {
+  static const serverDiscover = "server/discover";
   static const initialize = "initialize";
   static const ping = "ping";
   static const resourcesList = "resources/list";
@@ -185,6 +252,7 @@ sealed class JsonRpcMessage {
 
       if (hasId) {
         return switch (method) {
+          Method.serverDiscover => JsonRpcServerDiscoverRequest.fromJson(json),
           Method.initialize => JsonRpcInitializeRequest.fromJson(json),
           Method.ping => JsonRpcPingRequest.fromJson(json),
           Method.resourcesList => JsonRpcListResourcesRequest.fromJson(json),
@@ -368,6 +436,12 @@ class JsonRpcResponse extends JsonRpcMessage {
 enum ErrorCode {
   connectionClosed(-32000),
   requestTimeout(-32001),
+
+  /// Required per-request client capabilities were not declared.
+  missingRequiredClientCapability(-32003),
+
+  /// The requested protocol version is unsupported by the receiver.
+  unsupportedProtocolVersion(-32004),
 
   /// URL mode elicitation is required before the request can be processed.
   /// The error data contains elicitations that must be completed.

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -1,0 +1,472 @@
+import 'dart:async';
+
+import 'package:mcp_dart/src/client/client.dart';
+import 'package:mcp_dart/src/server/server.dart';
+import 'package:mcp_dart/src/shared/transport.dart';
+import 'package:mcp_dart/src/types.dart';
+import 'package:test/test.dart';
+
+class RecordingTransport extends Transport {
+  final List<JsonRpcMessage> sentMessages = [];
+  bool started = false;
+  bool closed = false;
+
+  @override
+  String? get sessionId => null;
+
+  @override
+  Future<void> close() async {
+    closed = true;
+    onclose?.call();
+  }
+
+  @override
+  Future<void> send(JsonRpcMessage message, {int? relatedRequestId}) async {
+    sentMessages.add(message);
+  }
+
+  @override
+  Future<void> start() async {
+    started = true;
+  }
+
+  void receive(JsonRpcMessage message) {
+    onmessage?.call(message);
+  }
+}
+
+class DiscoveringClientTransport extends Transport
+    implements ProtocolVersionAwareTransport {
+  DiscoveringClientTransport({
+    this.discoverVersions = const [draftProtocolVersion2026_07_28],
+  });
+
+  final List<String> discoverVersions;
+  final List<JsonRpcMessage> sentMessages = [];
+
+  @override
+  String? protocolVersion;
+
+  @override
+  String? get sessionId => null;
+
+  @override
+  Future<void> close() async {
+    onclose?.call();
+  }
+
+  @override
+  Future<void> send(JsonRpcMessage message, {int? relatedRequestId}) async {
+    sentMessages.add(message);
+
+    if (message is JsonRpcRequest && message.method == Method.serverDiscover) {
+      onmessage?.call(
+        JsonRpcResponse(
+          id: message.id,
+          result: DiscoverResult(
+            supportedVersions: discoverVersions,
+            capabilities: const ServerCapabilities(
+              tools: ServerCapabilitiesTools(),
+            ),
+            serverInfo: const Implementation(name: 'server', version: '1.0.0'),
+          ).toJson(),
+        ),
+      );
+      return;
+    }
+
+    if (message is JsonRpcRequest && message.method == Method.toolsList) {
+      onmessage?.call(
+        JsonRpcResponse(
+          id: message.id,
+          result: const ListToolsResult(tools: []).toJson(),
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> start() async {}
+}
+
+class LegacyFallbackTransport extends Transport
+    implements ProtocolVersionAwareTransport {
+  final List<JsonRpcMessage> sentMessages = [];
+
+  @override
+  String? protocolVersion;
+
+  @override
+  String? get sessionId => null;
+
+  @override
+  Future<void> close() async {
+    onclose?.call();
+  }
+
+  @override
+  Future<void> send(JsonRpcMessage message, {int? relatedRequestId}) async {
+    sentMessages.add(message);
+
+    if (message is JsonRpcRequest && message.method == Method.serverDiscover) {
+      onmessage?.call(
+        JsonRpcError(
+          id: message.id,
+          error: JsonRpcErrorData(
+            code: ErrorCode.methodNotFound.value,
+            message: 'Method not found',
+          ),
+        ),
+      );
+      return;
+    }
+
+    if (message is JsonRpcRequest && message.method == Method.initialize) {
+      onmessage?.call(
+        JsonRpcResponse(
+          id: message.id,
+          result: const InitializeResult(
+            protocolVersion: stableProtocolVersion2025_11_25,
+            capabilities: ServerCapabilities(
+              tools: ServerCapabilitiesTools(),
+            ),
+            serverInfo: Implementation(name: 'server', version: '1.0.0'),
+          ).toJson(),
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> start() async {}
+}
+
+Map<String, dynamic> _clientMeta({String? protocolVersion}) {
+  return buildProtocolRequestMeta(
+    protocolVersion: protocolVersion ?? draftProtocolVersion2026_07_28,
+    clientInfo: const Implementation(name: 'client', version: '1.0.0'),
+    clientCapabilities: const ClientCapabilities(),
+  );
+}
+
+Future<void> _pump() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  group('MCP 2026-07-28 RC protocol foundation', () {
+    test('defines draft protocol version separately from stable default', () {
+      expect(latestProtocolVersion, stableProtocolVersion2025_11_25);
+      expect(latestDraftProtocolVersion, draftProtocolVersion2026_07_28);
+      expect(
+        supportedProtocolVersionsWithDraft,
+        contains(draftProtocolVersion2026_07_28),
+      );
+      expect(isStatelessProtocolVersion(draftProtocolVersion2026_07_28), true);
+      expect(isStatelessProtocolVersion(latestProtocolVersion), false);
+    });
+
+    test('builds stateless request metadata without dropping caller metadata',
+        () {
+      final meta = buildProtocolRequestMeta(
+        protocolVersion: draftProtocolVersion2026_07_28,
+        clientInfo: const Implementation(name: 'client', version: '1.0.0'),
+        clientCapabilities: const ClientCapabilities(),
+        meta: const {'caller': 'value'},
+        logLevel: 'debug',
+      );
+
+      expect(meta['caller'], 'value');
+      expect(
+        meta[McpMetaKey.protocolVersion],
+        draftProtocolVersion2026_07_28,
+      );
+      expect(meta[McpMetaKey.clientInfo], {
+        'name': 'client',
+        'version': '1.0.0',
+      });
+      expect(meta[McpMetaKey.clientCapabilities], <String, dynamic>{});
+      expect(meta[McpMetaKey.logLevel], 'debug');
+    });
+
+    test('serializes server/discover request and result', () {
+      final request = JsonRpcServerDiscoverRequest(
+        id: 'discover-1',
+        meta: _clientMeta(),
+      );
+
+      final requestJson = request.toJson();
+      expect(requestJson['method'], Method.serverDiscover);
+      expect(
+        requestJson['params']['_meta'][McpMetaKey.protocolVersion],
+        draftProtocolVersion2026_07_28,
+      );
+      expect(
+        requestJson['params']['_meta'][McpMetaKey.clientCapabilities],
+        <String, dynamic>{},
+      );
+
+      final result = const DiscoverResult(
+        supportedVersions: [draftProtocolVersion2026_07_28],
+        capabilities: ServerCapabilities(tools: ServerCapabilitiesTools()),
+        serverInfo: Implementation(name: 'server', version: '1.0.0'),
+        instructions: 'Use the tools.',
+      );
+      final resultJson = result.toJson();
+      expect(resultJson['resultType'], 'complete');
+      expect(resultJson['supportedVersions'], [draftProtocolVersion2026_07_28]);
+      expect(resultJson['capabilities'], {'tools': <String, dynamic>{}});
+      expect(
+        DiscoverResult.fromJson(resultJson).instructions,
+        'Use the tools.',
+      );
+    });
+
+    test('server handles server/discover before legacy initialization',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            tools: ServerCapabilitiesTools(),
+          ),
+          instructions: 'Discovery instructions.',
+        ),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcServerDiscoverRequest(id: 'discover-1', meta: _clientMeta()),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      expect(response.id, 'discover-1');
+      expect(
+        response.result['supportedVersions'],
+        contains(draftProtocolVersion2026_07_28),
+      );
+      expect(response.result['serverInfo']['name'], 'server');
+      expect(response.result['instructions'], 'Discovery instructions.');
+    });
+
+    test('server accepts stateless requests without initialize', () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            tools: ServerCapabilitiesTools(),
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcListToolsRequest>(
+        Method.toolsList,
+        (request, extra) async {
+          expect(
+            extra.meta?[McpMetaKey.protocolVersion],
+            draftProtocolVersion2026_07_28,
+          );
+          return const ListToolsResult(
+            tools: [
+              Tool(name: 'echo', inputSchema: JsonObject()),
+            ],
+          );
+        },
+        (id, params, meta) => JsonRpcListToolsRequest(
+          id: id,
+          params: params,
+          meta: meta,
+        ),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(JsonRpcListToolsRequest(id: 1, meta: _clientMeta()));
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      final tools = response.result['tools'] as List<dynamic>;
+      expect(tools.single['name'], 'echo');
+    });
+
+    test('server returns unsupported protocol version for stateless metadata',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcListToolsRequest(
+          id: 1,
+          meta: _clientMeta(protocolVersion: '1900-01-01'),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcError;
+      expect(response.error.code, ErrorCode.unsupportedProtocolVersion.value);
+      expect(response.error.data['requested'], '1900-01-01');
+      expect(
+        response.error.data['supported'],
+        contains(draftProtocolVersion2026_07_28),
+      );
+    });
+
+    test('server rejects malformed stateless request metadata', () {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+
+      McpError? validateToolRequest(Map<String, dynamic>? meta) {
+        return server.validateIncomingRequest(
+          JsonRpcListToolsRequest(id: 1, meta: meta),
+        );
+      }
+
+      McpError? validateDiscoverRequest(Map<String, dynamic>? meta) {
+        return server.validateIncomingRequest(
+          JsonRpcServerDiscoverRequest(id: 1, meta: meta),
+        );
+      }
+
+      expect(
+        validateDiscoverRequest(const {}),
+        isA<McpError>().having(
+          (error) => error.message,
+          'message',
+          contains(McpMetaKey.protocolVersion),
+        ),
+      );
+      expect(
+        validateDiscoverRequest(
+          _clientMeta(protocolVersion: stableProtocolVersion2025_11_25),
+        ),
+        isA<McpError>().having(
+          (error) => error.message,
+          'message',
+          contains('stateless protocol version'),
+        ),
+      );
+      expect(
+        validateToolRequest({
+          McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
+          McpMetaKey.clientCapabilities: <String, dynamic>{},
+        }),
+        isA<McpError>().having(
+          (error) => error.message,
+          'message',
+          contains(McpMetaKey.clientInfo),
+        ),
+      );
+      expect(
+        validateToolRequest({
+          McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
+          McpMetaKey.clientInfo: {
+            'name': 'client',
+            'version': '1.0.0',
+          },
+        }),
+        isA<McpError>().having(
+          (error) => error.message,
+          'message',
+          contains(McpMetaKey.clientCapabilities),
+        ),
+      );
+      expect(
+        validateToolRequest({
+          McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
+          McpMetaKey.clientInfo: {'name': 1},
+          McpMetaKey.clientCapabilities: <String, dynamic>{},
+        }),
+        isA<McpError>().having(
+          (error) => error.message,
+          'message',
+          contains('Invalid stateless request metadata.'),
+        ),
+      );
+    });
+
+    test('client can opt in to server/discover and sends stateless metadata',
+        () async {
+      final transport = DiscoveringClientTransport();
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+
+      await client.connect(transport);
+
+      expect(client.getProtocolVersion(), draftProtocolVersion2026_07_28);
+      expect(transport.protocolVersion, draftProtocolVersion2026_07_28);
+      expect(
+        (transport.sentMessages.single as JsonRpcRequest).method,
+        Method.serverDiscover,
+      );
+
+      await client.listTools();
+
+      final listRequest = transport.sentMessages.last as JsonRpcRequest;
+      expect(listRequest.method, Method.toolsList);
+      expect(
+        listRequest.meta?[McpMetaKey.protocolVersion],
+        draftProtocolVersion2026_07_28,
+      );
+      expect(listRequest.meta?[McpMetaKey.clientInfo], {
+        'name': 'client',
+        'version': '1.0.0',
+      });
+      expect(listRequest.meta?[McpMetaKey.clientCapabilities], {});
+    });
+
+    test('client rejects discovery when no compatible version is offered',
+        () async {
+      final transport = DiscoveringClientTransport(
+        discoverVersions: const ['1900-01-01'],
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+
+      await expectLater(
+        client.connect(transport),
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.code,
+            'code',
+            ErrorCode.unsupportedProtocolVersion.value,
+          ),
+        ),
+      );
+    });
+
+    test('client falls back to initialize when discovery is unavailable',
+        () async {
+      final transport = LegacyFallbackTransport();
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+
+      await client.connect(transport);
+
+      expect(client.getProtocolVersion(), stableProtocolVersion2025_11_25);
+      expect(transport.protocolVersion, stableProtocolVersion2025_11_25);
+      expect(
+        transport.sentMessages
+            .whereType<JsonRpcRequest>()
+            .map((message) => message.method),
+        containsAllInOrder([Method.serverDiscover, Method.initialize]),
+      );
+      expect(
+        transport.sentMessages.whereType<JsonRpcInitializedNotification>(),
+        isEmpty,
+      );
+      expect(
+        transport.sentMessages.whereType<JsonRpcNotification>().last.method,
+        Method.notificationsInitialized,
+      );
+    });
+  });
+}

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -1845,6 +1845,37 @@ void main() {
       expect(transport.sessionId, isNull);
     });
 
+    test('2026 stateless GET requests return method not allowed', () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => null,
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+      final request = await client.getUrl(Uri.parse('$serverUrlBase/mcp'));
+      request.headers.set(
+        'MCP-Protocol-Version',
+        draftProtocolVersion2026_07_28,
+      );
+
+      final response = await request.close();
+      final body =
+          jsonDecode(await utf8.decodeStream(response)) as Map<String, dynamic>;
+
+      expect(response.statusCode, HttpStatus.methodNotAllowed);
+      expect(response.headers.value(HttpHeaders.allowHeader), 'POST');
+      expect(body['error']['code'], ErrorCode.connectionClosed.value);
+      expect(
+        body['error']['message'],
+        'Method not allowed for stateless MCP requests.',
+      );
+    });
+
     test('close cleans up all resources', () async {
       final transport = StreamableHTTPServerTransport(
         options: StreamableHTTPServerTransportOptions(

--- a/test/server/streamable_mcp_server_test.dart
+++ b/test/server/streamable_mcp_server_test.dart
@@ -305,7 +305,7 @@ void main() {
 
       expect(res.statusCode, HttpStatus.badRequest);
       final body = jsonDecode(res.body) as Map<String, dynamic>;
-      expect(body['error']['code'], ErrorCode.invalidRequest.value);
+      expect(body['error']['code'], ErrorCode.unsupportedProtocolVersion.value);
     });
 
     test(


### PR DESCRIPTION
## Summary

- add MCP 2026-07-28 RC version constants, stateless metadata helpers, and `server/discover` wire types
- add server-side `server/discover` handling and stateless request metadata validation
- add opt-in client discovery and stateless metadata propagation while keeping stable initialize behavior available
- add regression coverage for discovery, stateless request metadata, and unsupported protocol errors

## Stacked PR Plan

This is the parent PR for issue #177. Follow-up PRs should target this branch until it lands.

Planned stack:
1. Discovery foundation (this PR)
2. Streamable HTTP 2026 stateless/header behavior
3. `subscriptions/listen`
4. MRTR / `InputRequiredResult`
5. task extension compatibility and dev release prep

## Release Note

Do not merge or publish as stable until the official MCP `2026-07-28` spec is released. This PR is intended for RC/dev review only.

## Validation

- `dart analyze`
- `dart test test/mcp_2026_07_28_test.dart`
- `dart test test/server/streamable_mcp_server_test.dart`
- `dart test -j 1`

Fixes part of #177.
