### PR TITLE
Add MCP 2026 stateless HTTP headers

### DIFF
--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -294,6 +294,13 @@ class McpClient extends Protocol {
   }
 
   Future<DiscoverResult> discoverServer() async {
+    final activeTransport = transport;
+    final ProtocolVersionAwareTransport? versionedTransport =
+        activeTransport is ProtocolVersionAwareTransport
+            ? activeTransport as ProtocolVersionAwareTransport
+            : null;
+    versionedTransport?.protocolVersion = _preferredProtocolVersion;
+
     final result = await super.request<DiscoverResult>(
       JsonRpcServerDiscoverRequest(
         id: -1,
@@ -328,11 +335,7 @@ class McpClient extends Protocol {
     _usesStatelessProtocol = isStatelessProtocolVersion(protocolVersion);
     _sentInitialized = true;
 
-    final activeTransport = transport;
-    if (activeTransport is ProtocolVersionAwareTransport) {
-      (activeTransport as ProtocolVersionAwareTransport).protocolVersion =
-          protocolVersion;
-    }
+    versionedTransport?.protocolVersion = protocolVersion;
 
     _logger.debug(
       "MCP Server Discovered. Server: ${result.serverInfo.name} ${result.serverInfo.version}, Protocol: $protocolVersion",

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -526,6 +526,86 @@ class StreamableHttpClientTransport
     return headers;
   }
 
+  Map<String, String> _headersForMessage(JsonRpcMessage message) {
+    final headers = <String, String>{};
+    final protocolVersion = _protocolVersion ?? _protocolVersionFrom(message);
+    if (protocolVersion != null) {
+      headers['MCP-Protocol-Version'] = protocolVersion;
+    }
+
+    if (protocolVersion == null ||
+        !isStatelessProtocolVersion(protocolVersion)) {
+      return headers;
+    }
+
+    final method = _methodFrom(message);
+    if (method == null) {
+      return headers;
+    }
+
+    headers['Mcp-Method'] = method;
+
+    final params = _paramsFrom(message);
+    final name = _standardNameHeaderValue(method, params);
+    if (name != null) {
+      headers['Mcp-Name'] = name;
+    }
+
+    return headers;
+  }
+
+  String? _methodFrom(JsonRpcMessage message) {
+    if (message is JsonRpcRequest) {
+      return message.method;
+    }
+    if (message is JsonRpcNotification) {
+      return message.method;
+    }
+    return null;
+  }
+
+  Map<String, dynamic>? _paramsFrom(JsonRpcMessage message) {
+    if (message is JsonRpcRequest) {
+      return message.params;
+    }
+    if (message is JsonRpcNotification) {
+      return message.params;
+    }
+    return null;
+  }
+
+  Map<String, dynamic>? _metaFrom(JsonRpcMessage message) {
+    if (message is JsonRpcRequest) {
+      return message.meta;
+    }
+    if (message is JsonRpcNotification) {
+      return message.meta;
+    }
+    return null;
+  }
+
+  String? _protocolVersionFrom(JsonRpcMessage message) {
+    final version = _metaFrom(message)?[McpMetaKey.protocolVersion];
+    return version is String ? version : null;
+  }
+
+  String? _standardNameHeaderValue(
+    String method,
+    Map<String, dynamic>? params,
+  ) {
+    if (params == null) {
+      return null;
+    }
+
+    final nameField = switch (method) {
+      Method.toolsCall => params['name'],
+      Method.resourcesRead => params['uri'],
+      Method.promptsGet => params['name'],
+      _ => null,
+    };
+    return nameField is String ? nameField : null;
+  }
+
   String? _clearStaleSession() {
     final staleSessionId = _sessionId;
     _sessionId = null;
@@ -972,6 +1052,7 @@ class StreamableHttpClientTransport
       }
 
       final headers = await _commonHeaders();
+      headers.addAll(_headersForMessage(message));
       final requestSessionId = headers['mcp-session-id'];
       headers['content-type'] = 'application/json';
       headers['accept'] = 'application/json, text/event-stream';

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -287,6 +287,16 @@ class StreamableHTTPServerTransport
         isStatelessProtocolVersion(versionHeader.trim());
   }
 
+  bool _isValidHeaderValue(String value) {
+    if (value.trim() != value) {
+      return false;
+    }
+
+    return value.codeUnits.every(
+      (unit) => unit == 0x09 || unit == 0x20 || unit >= 0x21 && unit <= 0x7E,
+    );
+  }
+
   bool _isValidVisibleAsciiToken(String value) {
     if (value.isEmpty) {
       return false;
@@ -313,13 +323,14 @@ class StreamableHTTPServerTransport
     required int httpStatus,
     required ErrorCode errorCode,
     required String message,
+    RequestId? id,
     Object? data,
   }) async {
     response.statusCode = httpStatus;
     response.write(
       jsonEncode(
         JsonRpcError(
-          id: null,
+          id: id,
           error: JsonRpcErrorData(
             code: errorCode.value,
             message: message,
@@ -329,6 +340,266 @@ class StreamableHTTPServerTransport
       ),
     );
     await _safeClose(response);
+  }
+
+  Future<void> _writeHeaderMismatchResponse(
+    HttpResponse response,
+    JsonRpcMessage message,
+    String detail,
+  ) {
+    return _writeJsonRpcErrorResponse(
+      response,
+      httpStatus: HttpStatus.badRequest,
+      errorCode: ErrorCode.headerMismatch,
+      id: message is JsonRpcRequest ? message.id : null,
+      message: 'Header mismatch: $detail',
+    );
+  }
+
+  String? _metadataProtocolVersion(JsonRpcMessage message) {
+    if (message is JsonRpcRequest) {
+      final version = message.meta?[McpMetaKey.protocolVersion];
+      return version is String ? version : null;
+    }
+    if (message is JsonRpcNotification) {
+      final version = message.meta?[McpMetaKey.protocolVersion];
+      return version is String ? version : null;
+    }
+    return null;
+  }
+
+  bool _usesStatelessHttpValidation(
+    HttpRequest req,
+    List<JsonRpcMessage> messages,
+  ) {
+    final headerVersion = req.headers.value('mcp-protocol-version')?.trim();
+    if (headerVersion != null && isStatelessProtocolVersion(headerVersion)) {
+      return true;
+    }
+
+    return messages.any((message) {
+      final version = _metadataProtocolVersion(message);
+      return version != null && isStatelessProtocolVersion(version);
+    });
+  }
+
+  String? _messageMethod(JsonRpcMessage message) {
+    if (message is JsonRpcRequest) {
+      return message.method;
+    }
+    if (message is JsonRpcNotification) {
+      return message.method;
+    }
+    return null;
+  }
+
+  Map<String, dynamic>? _messageParams(JsonRpcMessage message) {
+    if (message is JsonRpcRequest) {
+      return message.params;
+    }
+    if (message is JsonRpcNotification) {
+      return message.params;
+    }
+    return null;
+  }
+
+  String? _requiredNameHeaderValue(JsonRpcMessage message) {
+    final method = _messageMethod(message);
+    final params = _messageParams(message);
+    if (params == null) {
+      return null;
+    }
+
+    final value = switch (method) {
+      Method.toolsCall => params['name'],
+      Method.resourcesRead => params['uri'],
+      Method.promptsGet => params['name'],
+      _ => null,
+    };
+    return value is String ? value : null;
+  }
+
+  String? _decodeMcpParamHeaderValue(String value) {
+    if (value.startsWith('=?base64?') && value.endsWith('?=')) {
+      final encoded = value.substring('=?base64?'.length, value.length - 2);
+      try {
+        return utf8.decode(base64Decode(encoded));
+      } catch (_) {
+        return null;
+      }
+    }
+
+    return _isValidHeaderValue(value) ? value : null;
+  }
+
+  String? _primitiveHeaderString(Object? value) {
+    return switch (value) {
+      null => null,
+      String() => value,
+      num() => value.toString(),
+      bool() => value.toString(),
+      _ => null,
+    };
+  }
+
+  Future<bool> _validateMcpParamHeaders(
+    HttpRequest req,
+    HttpResponse res,
+    JsonRpcMessage message,
+  ) async {
+    final params = _messageParams(message);
+    final arguments = params?['arguments'];
+    if (arguments is! Map) {
+      return true;
+    }
+    final argumentMap = arguments.cast<String, dynamic>();
+
+    final headerNames = <String>[];
+    req.headers.forEach((name, values) {
+      headerNames.add(name);
+    });
+
+    for (final headerName in headerNames) {
+      const prefix = 'mcp-param-';
+      if (!headerName.toLowerCase().startsWith(prefix)) {
+        continue;
+      }
+
+      final headerSuffix = headerName.substring(prefix.length);
+      if (headerSuffix.isEmpty ||
+          !headerSuffix.codeUnits.every(
+            (unit) => unit >= 0x21 && unit <= 0x7E && unit != 0x3A,
+          )) {
+        await _writeHeaderMismatchResponse(
+          res,
+          message,
+          "$headerName header name is malformed",
+        );
+        return false;
+      }
+
+      if (!argumentMap.containsKey(headerSuffix)) {
+        continue;
+      }
+
+      final headerValue = req.headers.value(headerName);
+      final decodedValue =
+          headerValue == null ? null : _decodeMcpParamHeaderValue(headerValue);
+      final bodyValue = _primitiveHeaderString(argumentMap[headerSuffix]);
+      if (decodedValue == null || decodedValue != bodyValue) {
+        await _writeHeaderMismatchResponse(
+          res,
+          message,
+          "$headerName header value does not match body argument '$headerSuffix'",
+        );
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  Future<bool> _validateStatelessHttpHeaders(
+    HttpRequest req,
+    List<JsonRpcMessage> messages,
+  ) async {
+    if (!_usesStatelessHttpValidation(req, messages)) {
+      return true;
+    }
+
+    if (messages.length != 1) {
+      await _writeJsonRpcErrorResponse(
+        req.response,
+        httpStatus: HttpStatus.badRequest,
+        errorCode: ErrorCode.invalidRequest,
+        message:
+            'Invalid Request: stateless MCP POST body must contain one JSON-RPC message',
+      );
+      return false;
+    }
+
+    final message = messages.single;
+    final protocolHeader = req.headers.value('mcp-protocol-version')?.trim();
+    if (protocolHeader == null || protocolHeader.isEmpty) {
+      await _writeHeaderMismatchResponse(
+        req.response,
+        message,
+        'MCP-Protocol-Version header is required',
+      );
+      return false;
+    }
+    if (!_isValidHeaderValue(protocolHeader)) {
+      await _writeHeaderMismatchResponse(
+        req.response,
+        message,
+        'MCP-Protocol-Version header value is malformed',
+      );
+      return false;
+    }
+
+    final metadataVersion = _metadataProtocolVersion(message);
+    if (metadataVersion == null) {
+      await _writeHeaderMismatchResponse(
+        req.response,
+        message,
+        'MCP-Protocol-Version header has no matching request _meta protocol version',
+      );
+      return false;
+    }
+    if (protocolHeader != metadataVersion) {
+      await _writeHeaderMismatchResponse(
+        req.response,
+        message,
+        "MCP-Protocol-Version header value '$protocolHeader' does not match body value '$metadataVersion'",
+      );
+      return false;
+    }
+
+    final method = _messageMethod(message);
+    if (method == null) {
+      return true;
+    }
+
+    final methodHeader = req.headers.value('mcp-method');
+    if (methodHeader == null || methodHeader.isEmpty) {
+      await _writeHeaderMismatchResponse(
+        req.response,
+        message,
+        'Mcp-Method header is required',
+      );
+      return false;
+    }
+    if (methodHeader != method) {
+      await _writeHeaderMismatchResponse(
+        req.response,
+        message,
+        "Mcp-Method header value '$methodHeader' does not match body value '$method'",
+      );
+      return false;
+    }
+
+    final requiredName = _requiredNameHeaderValue(message);
+    if (requiredName != null) {
+      final nameHeader = req.headers.value('mcp-name');
+      if (nameHeader == null || nameHeader.isEmpty) {
+        await _writeHeaderMismatchResponse(
+          req.response,
+          message,
+          'Mcp-Name header is required',
+        );
+        return false;
+      }
+      if (nameHeader != requiredName) {
+        await _writeHeaderMismatchResponse(
+          req.response,
+          message,
+          "Mcp-Name header value '$nameHeader' does not match body value '$requiredName'",
+        );
+        return false;
+      }
+    }
+
+    return _validateMcpParamHeaders(req, req.response, message);
   }
 
   bool _isStandaloneSseStreamId(StreamId streamId) {
@@ -800,6 +1071,10 @@ class StreamableHTTPServerTransport
           onerror?.call(e is Error ? e : StateError(e.toString()));
           return;
         }
+      }
+
+      if (!await _validateStatelessHttpHeaders(req, messages)) {
+        return;
       }
 
       // Check if this is an initialization request

--- a/lib/src/server/streamable_mcp_server.dart
+++ b/lib/src/server/streamable_mcp_server.dart
@@ -455,15 +455,6 @@ class StreamableMcpServer {
     // To support the routing logic (new vs existing session), we must read it here.
 
     final sessionId = request.headers.value('mcp-session-id');
-    if (sessionId != null && !_transports.containsKey(sessionId)) {
-      await _respondWithJsonRpcError(
-        request.response,
-        httpStatus: HttpStatus.notFound,
-        errorCode: ErrorCode.connectionClosed,
-        message: 'Session not found',
-      );
-      return;
-    }
 
     final bodyBytes = await _collectBytes(request);
     final bodyString = utf8.decode(bodyBytes);
@@ -471,6 +462,17 @@ class StreamableMcpServer {
     try {
       body = jsonDecode(bodyString);
     } catch (e) {
+      if (sessionId != null &&
+          !_transports.containsKey(sessionId) &&
+          !_isStatelessProtocolVersionRequest(request)) {
+        await _respondWithJsonRpcError(
+          request.response,
+          httpStatus: HttpStatus.notFound,
+          errorCode: ErrorCode.connectionClosed,
+          message: 'Session not found',
+        );
+        return;
+      }
       await _respondWithJsonRpcError(
         request.response,
         httpStatus: HttpStatus.badRequest,
@@ -501,9 +503,28 @@ class StreamableMcpServer {
       return;
     }
 
+    final isStatelessRequest = _isStatelessRequest(request, body);
+    if (sessionId != null &&
+        !_transports.containsKey(sessionId) &&
+        !isStatelessRequest) {
+      await _respondWithJsonRpcError(
+        request.response,
+        httpStatus: HttpStatus.notFound,
+        errorCode: ErrorCode.connectionClosed,
+        message: 'Session not found',
+      );
+      return;
+    }
+
     StreamableHTTPServerTransport? transport;
 
-    if (sessionId != null) {
+    if (isStatelessRequest) {
+      transport = _createStatelessTransport();
+      final server = _serverFactory('');
+      await server.connect(transport);
+      await transport.handleRequest(request, body);
+      return;
+    } else if (sessionId != null) {
       transport = _transports[sessionId]!;
     } else if (_isInitializeRequest(body)) {
       // New initialization request
@@ -528,6 +549,11 @@ class StreamableMcpServer {
   }
 
   Future<void> _handleGetRequest(HttpRequest request) async {
+    if (_isStatelessProtocolVersionRequest(request)) {
+      await _createStatelessTransport().handleRequest(request);
+      return;
+    }
+
     final sessionId = request.headers.value('mcp-session-id');
     if (sessionId == null) {
       request.response
@@ -549,6 +575,11 @@ class StreamableMcpServer {
   }
 
   Future<void> _handleDeleteRequest(HttpRequest request) async {
+    if (_isStatelessProtocolVersionRequest(request)) {
+      await _createStatelessTransport().handleRequest(request);
+      return;
+    }
+
     final sessionId = request.headers.value('mcp-session-id');
     if (sessionId == null) {
       request.response
@@ -619,6 +650,67 @@ class StreamableMcpServer {
     };
 
     return transport;
+  }
+
+  StreamableHTTPServerTransport _createStatelessTransport() {
+    return StreamableHTTPServerTransport(
+      options: StreamableHTTPServerTransportOptions(
+        sessionIdGenerator: () => null,
+        eventStore: eventStore,
+        enableDnsRebindingProtection: enableDnsRebindingProtection,
+        allowedHosts: allowedHosts ?? {host},
+        allowedOrigins: allowedOrigins,
+        strictProtocolVersionHeaderValidation:
+            strictProtocolVersionHeaderValidation,
+        rejectBatchJsonRpcPayloads: rejectBatchJsonRpcPayloads,
+      ),
+    );
+  }
+
+  bool _isStatelessProtocolVersionRequest(HttpRequest request) {
+    final versionHeader = request.headers.value('mcp-protocol-version');
+    return versionHeader != null &&
+        isStatelessProtocolVersion(versionHeader.trim());
+  }
+
+  bool _isStatelessRequest(HttpRequest request, dynamic body) {
+    if (_isStatelessProtocolVersionRequest(request)) {
+      return true;
+    }
+    if (body is Map<String, dynamic>) {
+      final version = _bodyProtocolVersion(body);
+      return version != null && isStatelessProtocolVersion(version);
+    }
+    if (body is List) {
+      return body.whereType<Map<String, dynamic>>().any((item) {
+        final version = _bodyProtocolVersion(item);
+        return version != null && isStatelessProtocolVersion(version);
+      });
+    }
+    return false;
+  }
+
+  String? _bodyProtocolVersion(Map<String, dynamic> body) {
+    final topLevelMeta = body['_meta'];
+    if (topLevelMeta is Map) {
+      final version = topLevelMeta[McpMetaKey.protocolVersion];
+      if (version is String) {
+        return version;
+      }
+    }
+
+    final params = body['params'];
+    if (params is Map) {
+      final meta = params['_meta'];
+      if (meta is Map) {
+        final version = meta[McpMetaKey.protocolVersion];
+        if (version is String) {
+          return version;
+        }
+      }
+    }
+
+    return null;
   }
 
   bool _isInitializeRequest(dynamic body) {

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -437,6 +437,12 @@ enum ErrorCode {
   connectionClosed(-32000),
   requestTimeout(-32001),
 
+  /// HTTP request metadata headers do not match the JSON-RPC body.
+  ///
+  /// This is the MCP 2026-07-28 meaning of the shared -32001 server-error
+  /// code. [requestTimeout] is retained for older SDK behavior.
+  headerMismatch(-32001),
+
   /// Required per-request client capabilities were not declared.
   missingRequiredClientCapability(-32003),
 

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -81,6 +81,12 @@ class DiscoveryOAuthClientProvider implements OAuthAuthorizationCodeProvider {
   }
 }
 
+Map<String, dynamic> _statelessMeta() => buildProtocolRequestMeta(
+      protocolVersion: draftProtocolVersion2026_07_28,
+      clientInfo: const Implementation(name: 'TestClient', version: '1.0.0'),
+      clientCapabilities: const ClientCapabilities(),
+    );
+
 void main() {
   late HttpServer testServer;
   late int serverPort;
@@ -1052,6 +1058,134 @@ void main() {
       expect((response as JsonRpcResponse).id, equals(123));
       expect(response.result['success'], isTrue);
       expect(response.result['echo']['data'], equals('test-data'));
+    });
+
+    test('send adds 2026 stateless HTTP metadata headers', () async {
+      final capturedHeaders = <String, String?>{};
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        capturedHeaders['protocolVersion'] =
+            request.headers.value('mcp-protocol-version');
+        capturedHeaders['method'] = request.headers.value('mcp-method');
+        capturedHeaders['name'] = request.headers.value('mcp-name');
+        await request.drain<void>();
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(
+            jsonEncode(
+              const JsonRpcResponse(
+                id: 1,
+                result: {'content': []},
+              ).toJson(),
+            ),
+          );
+        await request.response.close();
+      });
+
+      transport = StreamableHttpClientTransport(
+        Uri.parse('http://localhost:${server.port}/mcp'),
+      )..protocolVersion = draftProtocolVersion2026_07_28;
+      await transport.start();
+
+      final completer = Completer<JsonRpcMessage>();
+      transport.onmessage = completer.complete;
+
+      await transport.send(
+        JsonRpcCallToolRequest(
+          id: 1,
+          params: const {
+            'name': 'echo',
+            'arguments': {'message': 'hello'},
+          },
+          meta: _statelessMeta(),
+        ),
+      );
+      await completer.future.timeout(const Duration(seconds: 5));
+
+      expect(
+        capturedHeaders['protocolVersion'],
+        draftProtocolVersion2026_07_28,
+      );
+      expect(capturedHeaders['method'], Method.toolsCall);
+      expect(capturedHeaders['name'], 'echo');
+    });
+
+    test('send maps 2026 stateless headers for standard request types',
+        () async {
+      final capturedHeaders = <Map<String, String?>>[];
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        capturedHeaders.add({
+          'method': request.headers.value('mcp-method'),
+          'name': request.headers.value('mcp-name'),
+        });
+        final body = jsonDecode(await utf8.decodeStream(request))
+            as Map<String, dynamic>;
+        final id = body['id'];
+        if (id == null) {
+          request.response.statusCode = HttpStatus.accepted;
+        } else {
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..headers.contentType = ContentType.json
+            ..write(
+              jsonEncode(
+                JsonRpcResponse(id: id, result: const {}).toJson(),
+              ),
+            );
+        }
+        await request.response.close();
+      });
+
+      transport = StreamableHttpClientTransport(
+        Uri.parse('http://localhost:${server.port}/mcp'),
+      )..protocolVersion = draftProtocolVersion2026_07_28;
+      await transport.start();
+
+      final responses = <JsonRpcMessage>[];
+      transport.onmessage = responses.add;
+
+      await transport.send(
+        JsonRpcReadResourceRequest(
+          id: 1,
+          readParams: const ReadResourceRequest(uri: 'file:///notes.md'),
+          meta: _statelessMeta(),
+        ),
+      );
+      await transport.send(
+        JsonRpcGetPromptRequest(
+          id: 2,
+          getParams: const GetPromptRequest(name: 'summarize'),
+          meta: _statelessMeta(),
+        ),
+      );
+      await transport.send(
+        JsonRpcNotification(
+          method: Method.notificationsCancelled,
+          params: const {'requestId': 1},
+          meta: _statelessMeta(),
+        ),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(responses, hasLength(2));
+      expect(capturedHeaders, hasLength(3));
+      expect(capturedHeaders[0], {
+        'method': Method.resourcesRead,
+        'name': 'file:///notes.md',
+      });
+      expect(capturedHeaders[1], {
+        'method': Method.promptsGet,
+        'name': 'summarize',
+      });
+      expect(capturedHeaders[2], {
+        'method': Method.notificationsCancelled,
+        'name': null,
+      });
     });
 
     test('send with initialized notification triggers SSE establishment',

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -148,6 +148,12 @@ List<Map<String, dynamic>> _decodeSseJsonMessages(String body) {
   return messages;
 }
 
+Map<String, dynamic> _statelessMeta() => buildProtocolRequestMeta(
+      protocolVersion: draftProtocolVersion2026_07_28,
+      clientInfo: const Implementation(name: 'TestClient', version: '1.0.0'),
+      clientCapabilities: const ClientCapabilities(),
+    );
+
 class _SseEvent {
   final String? id;
   final String? event;
@@ -1783,6 +1789,251 @@ void main() {
       expect(transport.sessionId, isNull);
 
       await transport.close();
+    });
+
+    test('2026 stateless HTTP validates required protocol header', () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => "unused-session-id",
+          enableJsonResponse: true,
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      final response = await HttpClient()
+          .postUrl(
+        Uri.parse('$serverUrlBase/mcp'),
+      )
+          .then((request) async {
+        request.headers
+          ..contentType = ContentType.json
+          ..set(
+            HttpHeaders.acceptHeader,
+            'application/json, text/event-stream',
+          )
+          ..set('Mcp-Method', Method.toolsList);
+        request.write(
+          jsonEncode(JsonRpcListToolsRequest(id: 1, meta: _statelessMeta())),
+        );
+        return request.close();
+      });
+
+      expect(response.statusCode, HttpStatus.badRequest);
+      final body =
+          jsonDecode(await utf8.decodeStream(response)) as Map<String, dynamic>;
+      expect(body['id'], 1);
+      expect(body['error']['code'], ErrorCode.headerMismatch.value);
+      expect(
+        body['error']['message'],
+        contains('MCP-Protocol-Version header is required'),
+      );
+    });
+
+    test('2026 stateless HTTP rejects mismatched method and name headers',
+        () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => "unused-session-id",
+          enableJsonResponse: true,
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+      final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+      request.headers
+        ..contentType = ContentType.json
+        ..set(HttpHeaders.acceptHeader, 'application/json, text/event-stream')
+        ..set('MCP-Protocol-Version', draftProtocolVersion2026_07_28)
+        ..set('Mcp-Method', Method.toolsCall)
+        ..set('Mcp-Name', 'wrong-tool');
+      request.write(
+        jsonEncode(
+          JsonRpcCallToolRequest(
+            id: 2,
+            params: const {
+              'name': 'echo',
+              'arguments': {'message': 'hello'},
+            },
+            meta: _statelessMeta(),
+          ),
+        ),
+      );
+
+      final response = await request.close();
+
+      expect(response.statusCode, HttpStatus.badRequest);
+      final body =
+          jsonDecode(await utf8.decodeStream(response)) as Map<String, dynamic>;
+      expect(body['id'], 2);
+      expect(body['error']['code'], ErrorCode.headerMismatch.value);
+      expect(body['error']['message'], contains('Mcp-Name header value'));
+    });
+
+    test('2026 stateless HTTP accepts matching standard and parameter headers',
+        () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => "unused-session-id",
+          enableJsonResponse: true,
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      transport.onmessage = (message) {
+        if (message is JsonRpcCallToolRequest) {
+          unawaited(
+            transport.send(
+              JsonRpcResponse(
+                id: message.id,
+                result: const CallToolResult(content: []).toJson(),
+              ),
+            ),
+          );
+        }
+      };
+
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+      final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+      request.headers
+        ..contentType = ContentType.json
+        ..set(HttpHeaders.acceptHeader, 'application/json, text/event-stream')
+        ..set('MCP-Protocol-Version', draftProtocolVersion2026_07_28)
+        ..set('Mcp-Method', Method.toolsCall)
+        ..set('Mcp-Name', 'execute')
+        ..set('Mcp-Param-region', 'us-east1');
+      request.write(
+        jsonEncode(
+          JsonRpcCallToolRequest(
+            id: 3,
+            params: const {
+              'name': 'execute',
+              'arguments': {'region': 'us-east1'},
+            },
+            meta: _statelessMeta(),
+          ),
+        ),
+      );
+
+      final response = await request.close();
+
+      expect(response.statusCode, HttpStatus.ok);
+      expect(response.headers.value('mcp-session-id'), isNull);
+      final body =
+          jsonDecode(await utf8.decodeStream(response)) as Map<String, dynamic>;
+      expect(body['id'], 3);
+      expect(body['result']['content'], isEmpty);
+    });
+
+    test('2026 stateless HTTP rejects malformed routing headers', () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => "unused-session-id",
+          enableJsonResponse: true,
+          rejectBatchJsonRpcPayloads: false,
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      Future<Map<String, dynamic>> postJson(
+        Object body, {
+        Map<String, String> headers = const {},
+      }) async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers
+          ..contentType = ContentType.json
+          ..set(
+            HttpHeaders.acceptHeader,
+            'application/json, text/event-stream',
+          );
+        headers.forEach(request.headers.set);
+        request.write(jsonEncode(body));
+
+        final response = await request.close();
+        expect(response.statusCode, HttpStatus.badRequest);
+        return jsonDecode(await utf8.decodeStream(response))
+            as Map<String, dynamic>;
+      }
+
+      var body = await postJson(
+        const JsonRpcListToolsRequest(id: 4).toJson(),
+        headers: {
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+          'Mcp-Method': Method.toolsList,
+        },
+      );
+      expect(
+        body['error']['message'],
+        contains('no matching request _meta protocol version'),
+      );
+
+      body = await postJson(
+        JsonRpcListToolsRequest(id: 5, meta: _statelessMeta()).toJson(),
+        headers: {
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+        },
+      );
+      expect(body['error']['message'], contains('Mcp-Method header'));
+
+      body = await postJson(
+        JsonRpcCallToolRequest(
+          id: 6,
+          params: const {
+            'name': 'execute',
+            'arguments': {'count': 2, 'enabled': true},
+          },
+          meta: _statelessMeta(),
+        ).toJson(),
+        headers: {
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+          'Mcp-Method': Method.toolsCall,
+          'Mcp-Name': 'execute',
+          'Mcp-Param-count': '2',
+          'Mcp-Param-enabled': 'false',
+        },
+      );
+      expect(body['id'], 6);
+      expect(body['error']['message'], contains('mcp-param-enabled'));
+
+      body = await postJson(
+        JsonRpcCallToolRequest(
+          id: 7,
+          params: const {
+            'name': 'execute',
+            'arguments': {},
+          },
+          meta: _statelessMeta(),
+        ).toJson(),
+        headers: {
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+          'Mcp-Method': Method.toolsCall,
+        },
+      );
+      expect(body['id'], 7);
+      expect(body['error']['message'], contains('Mcp-Name header'));
+
+      body = await postJson(
+        [
+          JsonRpcListToolsRequest(id: 8, meta: _statelessMeta()).toJson(),
+          JsonRpcListToolsRequest(id: 9, meta: _statelessMeta()).toJson(),
+        ],
+        headers: {
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+        },
+      );
+      expect(body['error']['message'], contains('must contain one'));
     });
 
     test('stateless mode allows initialization with session header', () async {

--- a/test/server/streamable_mcp_server_test.dart
+++ b/test/server/streamable_mcp_server_test.dart
@@ -65,6 +65,21 @@ Future<_SseEvent> _readSseJsonEvent(StreamIterator<String> lines) async {
   }
 }
 
+List<Map<String, dynamic>> _decodeSseJsonMessages(String body) {
+  final messages = <Map<String, dynamic>>[];
+  for (final event in body.trim().split('\n\n')) {
+    final data = event
+        .split('\n')
+        .where((line) => line.startsWith('data: '))
+        .map((line) => line.substring('data: '.length))
+        .join('\n');
+    if (data.isNotEmpty) {
+      messages.add(jsonDecode(data) as Map<String, dynamic>);
+    }
+  }
+  return messages;
+}
+
 void main() {
   test('OAuthBearerChallenge builds insufficient-scope challenge', () {
     final challenge = OAuthBearerChallenge.insufficientScope(
@@ -100,6 +115,12 @@ void main() {
       contains(r'error_description="Need \"read\" scope \\ admin"'),
     );
   });
+
+  Map<String, dynamic> statelessMeta() => buildProtocolRequestMeta(
+        protocolVersion: draftProtocolVersion2026_07_28,
+        clientInfo: const Implementation(name: 'Client', version: '1.0'),
+        clientCapabilities: const ClientCapabilities(),
+      );
 
   group('StreamableMcpServer', () {
     late StreamableMcpServer server;
@@ -279,6 +300,90 @@ void main() {
       );
 
       expect(res.statusCode, HttpStatus.badRequest);
+    });
+
+    test('handles 2026 stateless request without session ID', () async {
+      await server.stop();
+      server = StreamableMcpServer(
+        serverFactory: (sessionId) {
+          final mcpServer = McpServer(
+            const Implementation(name: 'StatelessServer', version: '1.0.0'),
+          );
+          mcpServer.registerTool(
+            'echo',
+            inputSchema: const ToolInputSchema(),
+            callback: (args, extra) async => const CallToolResult(content: []),
+          );
+          return mcpServer;
+        },
+        host: host,
+        port: port,
+      );
+      await server.start();
+
+      final response = await http.post(
+        Uri.parse(baseUrl),
+        body: jsonEncode(
+          JsonRpcListToolsRequest(id: 1, meta: statelessMeta()).toJson(),
+        ),
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json, text/event-stream',
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+          'Mcp-Method': Method.toolsList,
+        },
+      );
+
+      expect(response.statusCode, HttpStatus.ok);
+      expect(response.headers['mcp-session-id'], isNull);
+      final messages = _decodeSseJsonMessages(response.body);
+      expect(messages.single['result']['tools'][0]['name'], 'echo');
+    });
+
+    test('detects 2026 stateless requests from body metadata', () async {
+      final response = await http.post(
+        Uri.parse(baseUrl),
+        body: jsonEncode(
+          JsonRpcListToolsRequest(id: 10, meta: statelessMeta()).toJson(),
+        ),
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json, text/event-stream',
+          'Mcp-Method': Method.toolsList,
+        },
+      );
+
+      expect(response.statusCode, HttpStatus.badRequest);
+      final body = jsonDecode(response.body) as Map<String, dynamic>;
+      expect(
+        body['error']['message'],
+        contains('MCP-Protocol-Version header is required'),
+      );
+    });
+
+    test('routes 2026 stateless GET and DELETE without a session ID', () async {
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+
+      final getRequest = await client.getUrl(Uri.parse(baseUrl));
+      getRequest.headers.set(
+        'MCP-Protocol-Version',
+        draftProtocolVersion2026_07_28,
+      );
+      final getResponse = await getRequest.close();
+      expect(getResponse.statusCode, HttpStatus.methodNotAllowed);
+      expect(getResponse.headers.value(HttpHeaders.allowHeader), 'POST');
+      await getResponse.drain<void>();
+
+      final deleteRequest = await client.deleteUrl(Uri.parse(baseUrl));
+      deleteRequest.headers.set(
+        'MCP-Protocol-Version',
+        draftProtocolVersion2026_07_28,
+      );
+      final deleteResponse = await deleteRequest.close();
+      expect(deleteResponse.statusCode, HttpStatus.methodNotAllowed);
+      expect(deleteResponse.headers.value(HttpHeaders.allowHeader), 'POST');
+      await deleteResponse.drain<void>();
     });
 
     test('rejects unsupported MCP-Protocol-Version header by default',


### PR DESCRIPTION
## Summary

- add stateless Streamable HTTP header validation for `MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`, and present `Mcp-Param-*` headers
- make the Streamable HTTP client mirror 2026 request metadata into standard HTTP headers
- allow `StreamableMcpServer` to route 2026 stateless POST requests without an `Mcp-Session-Id`, while preserving legacy unknown-session behavior
- keep GET/DELETE on the 2026 stateless path as `405 Method Not Allowed` through the transport

## Stack

Base: #178 (`spec/2026-07-28-rc`)

This is the second PR in the MCP 2026-07-28 RC stack for #177.

## Notes

This PR focuses on the standard Streamable HTTP stateless/header behavior. Full tool-schema-driven `x-mcp-header` discovery/filtering for client-emitted `Mcp-Param-*` headers can land as a separate follow-up if we want that isolated for review.

## Validation

- `dart analyze`
- `dart test test/server/streamable_https_test.dart test/client/streamable_https_test.dart test/server/streamable_mcp_server_test.dart test/mcp_2026_07_28_test.dart`
- `dart test -j 1`
