### PR TITLE
Add MCP 2026 tool parameter headers

### DIFF
--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -96,6 +96,7 @@ class McpClient extends Protocol {
 
   final Map<String, JsonSchema> _cachedToolOutputSchemas = {};
   final Set<String> _cachedRequiredTaskTools = {};
+  final ToolParameterHeaderMappings _cachedToolParameterHeaders = {};
 
   /// Callback for handling elicitation requests from the server.
   ///
@@ -789,16 +790,40 @@ class McpClient extends Protocol {
       options,
     );
 
-    _cacheToolMetadata(result.tools);
+    final tools = _cacheToolMetadata(result.tools);
 
-    return result;
+    if (identical(tools, result.tools)) {
+      return result;
+    }
+
+    return ListToolsResult(
+      tools: tools,
+      nextCursor: result.nextCursor,
+      meta: result.meta,
+    );
   }
 
-  void _cacheToolMetadata(List<Tool> tools) {
+  List<Tool> _cacheToolMetadata(List<Tool> tools) {
     _cachedToolOutputSchemas.clear();
     _cachedRequiredTaskTools.clear();
+    _cachedToolParameterHeaders.clear();
+
+    var filtered = false;
+    final validTools = <Tool>[];
 
     for (final tool in tools) {
+      final headerValidation = _validateToolParameterHeaders(tool);
+      if (headerValidation.rejectionReason != null) {
+        filtered = true;
+        _logger.warn(
+          'Rejecting tool "${tool.name}" from tools/list: '
+          '${headerValidation.rejectionReason}',
+        );
+        continue;
+      }
+
+      validTools.add(tool);
+
       if (tool.outputSchema != null) {
         _cachedToolOutputSchemas[tool.name] = tool.outputSchema!;
       }
@@ -806,7 +831,92 @@ class McpClient extends Protocol {
       if (tool.execution?.taskSupport == 'required') {
         _cachedRequiredTaskTools.add(tool.name);
       }
+
+      if (headerValidation.mappings.isNotEmpty) {
+        _cachedToolParameterHeaders[tool.name] = headerValidation.mappings;
+      }
     }
+
+    final activeTransport = transport;
+    final headerAwareTransport =
+        activeTransport is ToolParameterHeaderAwareTransport
+            ? activeTransport as ToolParameterHeaderAwareTransport
+            : null;
+    if (headerAwareTransport != null) {
+      headerAwareTransport.setToolParameterHeaderMappings(
+        _cachedToolParameterHeaders,
+      );
+    }
+
+    return filtered ? validTools : tools;
+  }
+
+  _ToolParameterHeaderValidation _validateToolParameterHeaders(Tool tool) {
+    final inputSchema = tool.inputSchema;
+    final properties =
+        inputSchema is JsonObject ? inputSchema.properties : null;
+    if (properties == null || properties.isEmpty) {
+      return const _ToolParameterHeaderValidation.valid({});
+    }
+
+    final mappings = <String, String>{};
+    final seenHeaders = <String>{};
+    for (final entry in properties.entries) {
+      final propertyJson = entry.value.toJson();
+      if (!propertyJson.containsKey('x-mcp-header')) {
+        continue;
+      }
+
+      final rawHeader = propertyJson['x-mcp-header'];
+      if (rawHeader is! String) {
+        return _ToolParameterHeaderValidation.invalid(
+          'parameter "${entry.key}" has a non-string x-mcp-header value',
+        );
+      }
+
+      if (rawHeader.isEmpty) {
+        return _ToolParameterHeaderValidation.invalid(
+          'parameter "${entry.key}" has an empty x-mcp-header value',
+        );
+      }
+
+      if (!_isValidMcpHeaderNameSuffix(rawHeader)) {
+        return _ToolParameterHeaderValidation.invalid(
+          'parameter "${entry.key}" has invalid x-mcp-header value '
+          '"$rawHeader"',
+        );
+      }
+
+      final normalizedHeader = rawHeader.toLowerCase();
+      if (!seenHeaders.add(normalizedHeader)) {
+        return _ToolParameterHeaderValidation.invalid(
+          'x-mcp-header value "$rawHeader" is not unique',
+        );
+      }
+
+      if (!_isToolParameterHeaderPrimitive(entry.value)) {
+        return _ToolParameterHeaderValidation.invalid(
+          'parameter "${entry.key}" uses x-mcp-header on a non-primitive type',
+        );
+      }
+
+      mappings[entry.key] = rawHeader;
+    }
+
+    return _ToolParameterHeaderValidation.valid(mappings);
+  }
+
+  bool _isValidMcpHeaderNameSuffix(String value) {
+    return value.codeUnits.every(
+      (unit) => unit >= 0x21 && unit <= 0x7E && unit != 0x3A,
+    );
+  }
+
+  bool _isToolParameterHeaderPrimitive(JsonSchema schema) {
+    return schema is JsonString ||
+        schema is JsonNumber ||
+        schema is JsonInteger ||
+        schema is JsonBoolean;
   }
 
   /// Sends a `notifications/roots/list_changed` notification to the server.
@@ -819,3 +929,14 @@ class McpClient extends Protocol {
 /// Deprecated alias for [McpClient].
 @Deprecated('Use McpClient instead')
 typedef Client = McpClient;
+
+class _ToolParameterHeaderValidation {
+  final Map<String, String> mappings;
+  final String? rejectionReason;
+
+  const _ToolParameterHeaderValidation.valid(this.mappings)
+      : rejectionReason = null;
+
+  const _ToolParameterHeaderValidation.invalid(this.rejectionReason)
+      : mappings = const {};
+}

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -127,13 +127,17 @@ class StreamableHttpClientTransportOptions {
 /// It will connect to a server using HTTP POST for sending messages and HTTP GET with Server-Sent Events
 /// for receiving messages.
 class StreamableHttpClientTransport
-    implements Transport, ProtocolVersionAwareTransport {
+    implements
+        Transport,
+        ProtocolVersionAwareTransport,
+        ToolParameterHeaderAwareTransport {
   StreamController<bool>? _abortController;
   final Uri _url;
   final Map<String, dynamic>? _requestInit;
   final OAuthClientProvider? _authProvider;
   String? _sessionId;
   String? _protocolVersion;
+  ToolParameterHeaderMappings _toolParameterHeaderMappings = const {};
   int _sessionGeneration = 0;
   bool _staleSessionDetected = false;
   final StreamableHttpReconnectionOptions _reconnectionOptions;
@@ -551,7 +555,63 @@ class StreamableHttpClientTransport
       headers['Mcp-Name'] = name;
     }
 
+    if (method == Method.toolsCall && name != null) {
+      headers.addAll(_toolParameterHeaders(name, params));
+    }
+
     return headers;
+  }
+
+  Map<String, String> _toolParameterHeaders(
+    String toolName,
+    Map<String, dynamic>? params,
+  ) {
+    final mappings = _toolParameterHeaderMappings[toolName];
+    final arguments = params?['arguments'];
+    if (mappings == null || arguments is! Map) {
+      return const {};
+    }
+
+    final argumentMap = arguments.cast<String, dynamic>();
+    final headers = <String, String>{};
+    for (final entry in mappings.entries) {
+      if (!argumentMap.containsKey(entry.key)) {
+        continue;
+      }
+
+      final value = _toolParameterHeaderString(argumentMap[entry.key]);
+      if (value == null) {
+        continue;
+      }
+
+      headers['Mcp-Param-${entry.value}'] =
+          _encodeToolParameterHeaderValue(value);
+    }
+    return headers;
+  }
+
+  String? _toolParameterHeaderString(Object? value) {
+    return switch (value) {
+      String() => value,
+      num() => value.toString(),
+      bool() => value.toString(),
+      _ => null,
+    };
+  }
+
+  String _encodeToolParameterHeaderValue(String value) {
+    if (_isPlainToolParameterHeaderValue(value)) {
+      return value;
+    }
+
+    return '=?base64?${base64Encode(utf8.encode(value))}?=';
+  }
+
+  bool _isPlainToolParameterHeaderValue(String value) {
+    return value.trim() == value &&
+        value.codeUnits.every(
+          (unit) => unit == 0x09 || (unit >= 0x20 && unit <= 0x7E),
+        );
   }
 
   String? _methodFrom(JsonRpcMessage message) {
@@ -1206,6 +1266,16 @@ class StreamableHttpClientTransport
   @override
   set protocolVersion(String? value) {
     _protocolVersion = value;
+  }
+
+  @override
+  void setToolParameterHeaderMappings(
+    ToolParameterHeaderMappings mappings,
+  ) {
+    _toolParameterHeaderMappings = {
+      for (final entry in mappings.entries)
+        entry.key: Map.unmodifiable(Map<String, String>.from(entry.value)),
+    };
   }
 
   /// Terminates the current session by sending a DELETE request to the server.

--- a/lib/src/shared/json_schema/json_schema.dart
+++ b/lib/src/shared/json_schema/json_schema.dart
@@ -19,6 +19,10 @@ sealed class JsonSchema {
   }
 
   static JsonSchema _fromJson(Map<String, dynamic> json) {
+    if (_hasMcpHeaderOnNonPrimitiveSchema(json)) {
+      return JsonAny.fromJson(json);
+    }
+
     if (JsonEnum._canParse(json)) {
       return JsonEnum.fromJson(json);
     }
@@ -172,6 +176,19 @@ sealed class JsonSchema {
     'object',
   };
 
+  static bool _hasMcpHeaderOnNonPrimitiveSchema(Map<String, dynamic> json) {
+    if (!json.containsKey('x-mcp-header')) {
+      return false;
+    }
+
+    return !const {
+      'string',
+      'number',
+      'integer',
+      'boolean',
+    }.contains(json['type']);
+  }
+
   static bool _hasOnlyAnnotationAnd(
     Map<String, dynamic> json,
     Set<String> keys,
@@ -195,6 +212,7 @@ sealed class JsonSchema {
     String? title,
     String? description,
     String? defaultValue,
+    String? mcpHeader,
   }) {
     return JsonString(
       minLength: minLength,
@@ -206,6 +224,7 @@ sealed class JsonSchema {
       title: title,
       description: description,
       defaultValue: defaultValue,
+      mcpHeader: mcpHeader,
     );
   }
 
@@ -219,6 +238,7 @@ sealed class JsonSchema {
     String? title,
     String? description,
     num? defaultValue,
+    String? mcpHeader,
   }) {
     return JsonNumber(
       minimum: minimum,
@@ -229,6 +249,7 @@ sealed class JsonSchema {
       title: title,
       description: description,
       defaultValue: defaultValue,
+      mcpHeader: mcpHeader,
     );
   }
 
@@ -242,6 +263,7 @@ sealed class JsonSchema {
     String? title,
     String? description,
     int? defaultValue,
+    String? mcpHeader,
   }) {
     return JsonInteger(
       minimum: minimum,
@@ -252,6 +274,7 @@ sealed class JsonSchema {
       title: title,
       description: description,
       defaultValue: defaultValue,
+      mcpHeader: mcpHeader,
     );
   }
 
@@ -260,11 +283,13 @@ sealed class JsonSchema {
     String? title,
     String? description,
     bool? defaultValue,
+    String? mcpHeader,
   }) {
     return JsonBoolean(
       title: title,
       description: description,
       defaultValue: defaultValue,
+      mcpHeader: mcpHeader,
     );
   }
 
@@ -417,6 +442,8 @@ sealed class JsonSchema {
 /// A schema for string values.
 class JsonString extends JsonSchema {
   final bool _hasDefault;
+  final bool _hasMcpHeader;
+  final Object? _rawMcpHeader;
   final int? minLength;
   final int? maxLength;
   final String? pattern;
@@ -426,6 +453,9 @@ class JsonString extends JsonSchema {
   /// (Legacy) Display names for enum values.
   /// Non-standard according to JSON schema 2020-12.
   final List<String>? enumNames;
+
+  /// MCP `x-mcp-header` extension for mirroring this parameter into HTTP.
+  final String? mcpHeader;
 
   const JsonString({
     this.minLength,
@@ -437,7 +467,10 @@ class JsonString extends JsonSchema {
     super.title,
     super.description,
     this.defaultValue,
-  }) : _hasDefault = defaultValue != null;
+    this.mcpHeader,
+  })  : _hasDefault = defaultValue != null,
+        _hasMcpHeader = mcpHeader != null,
+        _rawMcpHeader = mcpHeader;
 
   const JsonString._({
     this.minLength,
@@ -449,13 +482,19 @@ class JsonString extends JsonSchema {
     super.title,
     super.description,
     this.defaultValue,
+    this.mcpHeader,
+    required Object? rawMcpHeader,
     required bool hasDefault,
-  }) : _hasDefault = hasDefault;
+    required bool hasMcpHeader,
+  })  : _hasDefault = hasDefault,
+        _hasMcpHeader = hasMcpHeader,
+        _rawMcpHeader = rawMcpHeader;
 
   @override
   final String? defaultValue;
 
   factory JsonString.fromJson(Map<String, dynamic> json) {
+    final rawMcpHeader = json['x-mcp-header'];
     return JsonString._(
       minLength: json['minLength'] as int?,
       maxLength: json['maxLength'] as int?,
@@ -467,7 +506,10 @@ class JsonString extends JsonSchema {
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'] as String?,
+      mcpHeader: rawMcpHeader is String ? rawMcpHeader : null,
+      rawMcpHeader: rawMcpHeader,
       hasDefault: json.containsKey('default'),
+      hasMcpHeader: json.containsKey('x-mcp-header'),
     );
   }
 
@@ -484,6 +526,7 @@ class JsonString extends JsonSchema {
       if (format != null) 'format': format,
       if (enumValues != null) 'enum': enumValues,
       if (enumNames != null) 'enumNames': enumNames,
+      if (_hasMcpHeader) 'x-mcp-header': _rawMcpHeader,
     };
   }
 }
@@ -491,11 +534,16 @@ class JsonString extends JsonSchema {
 /// A schema for number values.
 class JsonNumber extends JsonSchema {
   final bool _hasDefault;
+  final bool _hasMcpHeader;
+  final Object? _rawMcpHeader;
   final num? minimum;
   final num? maximum;
   final num? exclusiveMinimum;
   final num? exclusiveMaximum;
   final num? multipleOf;
+
+  /// MCP `x-mcp-header` extension for mirroring this parameter into HTTP.
+  final String? mcpHeader;
 
   const JsonNumber({
     this.minimum,
@@ -506,7 +554,10 @@ class JsonNumber extends JsonSchema {
     this.defaultValue,
     super.title,
     super.description,
-  }) : _hasDefault = defaultValue != null;
+    this.mcpHeader,
+  })  : _hasDefault = defaultValue != null,
+        _hasMcpHeader = mcpHeader != null,
+        _rawMcpHeader = mcpHeader;
 
   const JsonNumber._({
     this.minimum,
@@ -517,13 +568,19 @@ class JsonNumber extends JsonSchema {
     this.defaultValue,
     super.title,
     super.description,
+    this.mcpHeader,
+    required Object? rawMcpHeader,
     required bool hasDefault,
-  }) : _hasDefault = hasDefault;
+    required bool hasMcpHeader,
+  })  : _hasDefault = hasDefault,
+        _hasMcpHeader = hasMcpHeader,
+        _rawMcpHeader = rawMcpHeader;
 
   @override
   final num? defaultValue;
 
   factory JsonNumber.fromJson(Map<String, dynamic> json) {
+    final rawMcpHeader = json['x-mcp-header'];
     return JsonNumber._(
       minimum: json['minimum'] as num?,
       maximum: json['maximum'] as num?,
@@ -533,7 +590,10 @@ class JsonNumber extends JsonSchema {
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'] as num?,
+      mcpHeader: rawMcpHeader is String ? rawMcpHeader : null,
+      rawMcpHeader: rawMcpHeader,
       hasDefault: json.containsKey('default'),
+      hasMcpHeader: json.containsKey('x-mcp-header'),
     );
   }
 
@@ -549,6 +609,7 @@ class JsonNumber extends JsonSchema {
       if (exclusiveMinimum != null) 'exclusiveMinimum': exclusiveMinimum,
       if (exclusiveMaximum != null) 'exclusiveMaximum': exclusiveMaximum,
       if (multipleOf != null) 'multipleOf': multipleOf,
+      if (_hasMcpHeader) 'x-mcp-header': _rawMcpHeader,
     };
   }
 }
@@ -556,11 +617,16 @@ class JsonNumber extends JsonSchema {
 /// A schema for integer values.
 class JsonInteger extends JsonSchema {
   final bool _hasDefault;
+  final bool _hasMcpHeader;
+  final Object? _rawMcpHeader;
   final int? minimum;
   final int? maximum;
   final int? exclusiveMinimum;
   final int? exclusiveMaximum;
   final int? multipleOf;
+
+  /// MCP `x-mcp-header` extension for mirroring this parameter into HTTP.
+  final String? mcpHeader;
 
   const JsonInteger({
     this.minimum,
@@ -571,7 +637,10 @@ class JsonInteger extends JsonSchema {
     this.defaultValue,
     super.title,
     super.description,
-  }) : _hasDefault = defaultValue != null;
+    this.mcpHeader,
+  })  : _hasDefault = defaultValue != null,
+        _hasMcpHeader = mcpHeader != null,
+        _rawMcpHeader = mcpHeader;
 
   const JsonInteger._({
     this.minimum,
@@ -582,13 +651,19 @@ class JsonInteger extends JsonSchema {
     this.defaultValue,
     super.title,
     super.description,
+    this.mcpHeader,
+    required Object? rawMcpHeader,
     required bool hasDefault,
-  }) : _hasDefault = hasDefault;
+    required bool hasMcpHeader,
+  })  : _hasDefault = hasDefault,
+        _hasMcpHeader = hasMcpHeader,
+        _rawMcpHeader = rawMcpHeader;
 
   @override
   final int? defaultValue;
 
   factory JsonInteger.fromJson(Map<String, dynamic> json) {
+    final rawMcpHeader = json['x-mcp-header'];
     return JsonInteger._(
       minimum: json['minimum'] as int?,
       maximum: json['maximum'] as int?,
@@ -598,7 +673,10 @@ class JsonInteger extends JsonSchema {
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'] as int?,
+      mcpHeader: rawMcpHeader is String ? rawMcpHeader : null,
+      rawMcpHeader: rawMcpHeader,
       hasDefault: json.containsKey('default'),
+      hasMcpHeader: json.containsKey('x-mcp-header'),
     );
   }
 
@@ -614,6 +692,7 @@ class JsonInteger extends JsonSchema {
       if (exclusiveMinimum != null) 'exclusiveMinimum': exclusiveMinimum,
       if (exclusiveMaximum != null) 'exclusiveMaximum': exclusiveMaximum,
       if (multipleOf != null) 'multipleOf': multipleOf,
+      if (_hasMcpHeader) 'x-mcp-header': _rawMcpHeader,
     };
   }
 }
@@ -621,29 +700,46 @@ class JsonInteger extends JsonSchema {
 /// A schema for boolean values.
 class JsonBoolean extends JsonSchema {
   final bool _hasDefault;
+  final bool _hasMcpHeader;
+  final Object? _rawMcpHeader;
+
+  /// MCP `x-mcp-header` extension for mirroring this parameter into HTTP.
+  final String? mcpHeader;
 
   const JsonBoolean({
     this.defaultValue,
     super.title,
     super.description,
-  }) : _hasDefault = defaultValue != null;
+    this.mcpHeader,
+  })  : _hasDefault = defaultValue != null,
+        _hasMcpHeader = mcpHeader != null,
+        _rawMcpHeader = mcpHeader;
 
   const JsonBoolean._({
     this.defaultValue,
     super.title,
     super.description,
+    this.mcpHeader,
+    required Object? rawMcpHeader,
     required bool hasDefault,
-  }) : _hasDefault = hasDefault;
+    required bool hasMcpHeader,
+  })  : _hasDefault = hasDefault,
+        _hasMcpHeader = hasMcpHeader,
+        _rawMcpHeader = rawMcpHeader;
 
   @override
   final bool? defaultValue;
 
   factory JsonBoolean.fromJson(Map<String, dynamic> json) {
+    final rawMcpHeader = json['x-mcp-header'];
     return JsonBoolean._(
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'] as bool?,
+      mcpHeader: rawMcpHeader is String ? rawMcpHeader : null,
+      rawMcpHeader: rawMcpHeader,
       hasDefault: json.containsKey('default'),
+      hasMcpHeader: json.containsKey('x-mcp-header'),
     );
   }
 
@@ -654,6 +750,7 @@ class JsonBoolean extends JsonSchema {
       if (description != null) 'description': description,
       if (_hasDefault) 'default': defaultValue,
       'type': 'boolean',
+      if (_hasMcpHeader) 'x-mcp-header': _rawMcpHeader,
     };
   }
 }

--- a/lib/src/shared/transport.dart
+++ b/lib/src/shared/transport.dart
@@ -92,3 +92,15 @@ abstract class ProtocolVersionAwareTransport {
   /// Updates the negotiated MCP protocol version.
   set protocolVersion(String? value);
 }
+
+/// Maps tool names to argument names and their `Mcp-Param-*` header suffixes.
+typedef ToolParameterHeaderMappings = Map<String, Map<String, String>>;
+
+/// Optional capability for transports that can mirror tool arguments into
+/// stateless HTTP headers.
+abstract class ToolParameterHeaderAwareTransport {
+  /// Updates the currently advertised tool parameter header mappings.
+  void setToolParameterHeaderMappings(
+    ToolParameterHeaderMappings mappings,
+  );
+}

--- a/test/client/client_tool_validation_test.dart
+++ b/test/client/client_tool_validation_test.dart
@@ -3,15 +3,19 @@ import 'dart:async';
 import 'package:mcp_dart/mcp_dart.dart';
 import 'package:test/test.dart';
 
-class MockTransport extends Transport {
+class MockTransport extends Transport
+    implements ToolParameterHeaderAwareTransport {
   final List<JsonRpcMessage> sentMessages = [];
   ServerCapabilities serverCapabilities;
+  List<Tool> advertisedTools;
+  ToolParameterHeaderMappings toolParameterHeaderMappings = const {};
 
   MockTransport({
     this.serverCapabilities = const ServerCapabilities(
       tools: ServerCapabilitiesTools(),
     ),
-  });
+    List<Tool>? advertisedTools,
+  }) : advertisedTools = advertisedTools ?? _defaultAdvertisedTools();
 
   @override
   String? get sessionId => null;
@@ -41,35 +45,7 @@ class MockTransport extends Transport {
       _respond(
         JsonRpcResponse(
           id: message.id,
-          result: ListToolsResult(
-            tools: [
-              Tool(
-                name: 'validated_tool',
-                inputSchema: JsonSchema.object(properties: {}),
-                outputSchema: ToolOutputSchema(
-                  properties: {
-                    'result': JsonSchema.string(),
-                  },
-                  required: ['result'],
-                ),
-              ),
-              Tool(
-                name: 'broken_tool', // Tool that returns invalid data
-                inputSchema: const ToolInputSchema(),
-                outputSchema: ToolOutputSchema(
-                  properties: {
-                    'result': JsonSchema.string(),
-                  },
-                  required: ['result'],
-                ),
-              ),
-              const Tool(
-                name: 'task_required_tool',
-                inputSchema: ToolInputSchema(),
-                execution: ToolExecution(taskSupport: 'required'),
-              ),
-            ],
-          ).toJson(),
+          result: ListToolsResult(tools: advertisedTools).toJson(),
         ),
       );
     } else if (message is JsonRpcRequest &&
@@ -104,6 +80,46 @@ class MockTransport extends Transport {
 
   @override
   Future<void> start() async {}
+
+  @override
+  void setToolParameterHeaderMappings(
+    ToolParameterHeaderMappings mappings,
+  ) {
+    toolParameterHeaderMappings = {
+      for (final entry in mappings.entries)
+        entry.key: Map.unmodifiable(Map<String, String>.from(entry.value)),
+    };
+  }
+
+  static List<Tool> _defaultAdvertisedTools() {
+    return [
+      Tool(
+        name: 'validated_tool',
+        inputSchema: JsonSchema.object(properties: {}),
+        outputSchema: ToolOutputSchema(
+          properties: {
+            'result': JsonSchema.string(),
+          },
+          required: ['result'],
+        ),
+      ),
+      Tool(
+        name: 'broken_tool', // Tool that returns invalid data
+        inputSchema: const ToolInputSchema(),
+        outputSchema: ToolOutputSchema(
+          properties: {
+            'result': JsonSchema.string(),
+          },
+          required: ['result'],
+        ),
+      ),
+      const Tool(
+        name: 'task_required_tool',
+        inputSchema: ToolInputSchema(),
+        execution: ToolExecution(taskSupport: 'required'),
+      ),
+    ];
+  }
 }
 
 void main() {
@@ -115,6 +131,90 @@ void main() {
       transport = MockTransport();
       client = Client(
         const Implementation(name: 'TestClient', version: '1.0.0'),
+      );
+    });
+
+    test('listTools filters invalid x-mcp-header definitions', () async {
+      final warnings = <String>[];
+      setMcpLogHandler((loggerName, level, message) {
+        if (level == LogLevel.warn) {
+          warnings.add(message);
+        }
+      });
+      addTearDown(resetMcpLogHandler);
+
+      transport = MockTransport(
+        advertisedTools: [
+          Tool(
+            name: 'valid_headers',
+            inputSchema: JsonSchema.object(
+              properties: {
+                'region': JsonSchema.string(mcpHeader: 'Region'),
+                'limit': JsonSchema.number(mcpHeader: 'Limit'),
+                'dryRun': JsonSchema.boolean(mcpHeader: 'Dry-Run'),
+                'count': JsonSchema.integer(mcpHeader: 'Count'),
+              },
+            ),
+          ),
+          Tool(
+            name: 'duplicate_headers',
+            inputSchema: JsonSchema.object(
+              properties: {
+                'primary': JsonSchema.string(mcpHeader: 'Region'),
+                'secondary': JsonSchema.string(mcpHeader: 'region'),
+              },
+            ),
+          ),
+          Tool(
+            name: 'empty_header',
+            inputSchema: JsonSchema.object(
+              properties: {
+                'region': JsonSchema.string(mcpHeader: ''),
+              },
+            ),
+          ),
+          Tool.fromJson({
+            'name': 'non_string_header',
+            'inputSchema': {
+              'type': 'object',
+              'properties': {
+                'region': {
+                  'type': 'string',
+                  'x-mcp-header': 1,
+                },
+              },
+            },
+          }),
+          Tool.fromJson({
+            'name': 'object_header',
+            'inputSchema': {
+              'type': 'object',
+              'properties': {
+                'payload': {
+                  'type': 'object',
+                  'x-mcp-header': 'Payload',
+                },
+              },
+            },
+          }),
+        ],
+      );
+
+      await client.connect(transport);
+      final result = await client.listTools();
+
+      expect(result.tools.map((tool) => tool.name), ['valid_headers']);
+      expect(transport.toolParameterHeaderMappings, {
+        'valid_headers': {
+          'region': 'Region',
+          'limit': 'Limit',
+          'dryRun': 'Dry-Run',
+          'count': 'Count',
+        },
+      });
+      expect(
+        warnings.where((message) => message.contains('Rejecting tool')),
+        hasLength(4),
       );
     });
 

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -1188,6 +1188,85 @@ void main() {
       });
     });
 
+    test('send mirrors mapped tool parameters into 2026 stateless headers',
+        () async {
+      final capturedHeaders = <String, String?>{};
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        capturedHeaders['region'] = request.headers.value('mcp-param-region');
+        capturedHeaders['greeting'] =
+            request.headers.value('mcp-param-greeting');
+        capturedHeaders['limit'] = request.headers.value('mcp-param-limit');
+        capturedHeaders['dryRun'] = request.headers.value('mcp-param-dry-run');
+        capturedHeaders['text'] = request.headers.value('mcp-param-text');
+        capturedHeaders['payload'] = request.headers.value('mcp-param-payload');
+        await request.drain<void>();
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(
+            jsonEncode(
+              const JsonRpcResponse(
+                id: 1,
+                result: {'content': []},
+              ).toJson(),
+            ),
+          );
+        await request.response.close();
+      });
+
+      transport = StreamableHttpClientTransport(
+        Uri.parse('http://localhost:${server.port}/mcp'),
+      )
+        ..protocolVersion = draftProtocolVersion2026_07_28
+        ..setToolParameterHeaderMappings(
+          {
+            'execute_sql': {
+              'region': 'Region',
+              'greeting': 'Greeting',
+              'limit': 'Limit',
+              'dryRun': 'Dry-Run',
+              'text': 'Text',
+              'payload': 'Payload',
+            },
+          },
+        );
+      await transport.start();
+
+      final completer = Completer<JsonRpcMessage>();
+      transport.onmessage = completer.complete;
+
+      await transport.send(
+        JsonRpcCallToolRequest(
+          id: 1,
+          params: const {
+            'name': 'execute_sql',
+            'arguments': {
+              'region': 'us-west1',
+              'greeting': 'Hello, 世界',
+              'limit': 42,
+              'dryRun': false,
+              'text': ' padded ',
+              'payload': {'nested': true},
+            },
+          },
+          meta: _statelessMeta(),
+        ),
+      );
+      await completer.future.timeout(const Duration(seconds: 5));
+
+      expect(capturedHeaders['region'], 'us-west1');
+      expect(
+        capturedHeaders['greeting'],
+        '=?base64?${base64Encode(utf8.encode('Hello, 世界'))}?=',
+      );
+      expect(capturedHeaders['limit'], '42');
+      expect(capturedHeaders['dryRun'], 'false');
+      expect(capturedHeaders['text'], '=?base64?IHBhZGRlZCA=?=');
+      expect(capturedHeaders['payload'], isNull);
+    });
+
     test('send with initialized notification triggers SSE establishment',
         () async {
       transport = StreamableHttpClientTransport(serverUrl);

--- a/test/tool_schema_test.dart
+++ b/test/tool_schema_test.dart
@@ -2,6 +2,47 @@ import 'package:mcp_dart/mcp_dart.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('Tool parameter header annotations', () {
+    test('primitive schemas preserve x-mcp-header round-trip', () {
+      final schema = JsonSchema.object(
+        properties: {
+          'region': JsonSchema.string(mcpHeader: 'Region'),
+          'limit': JsonSchema.number(mcpHeader: 'Limit'),
+          'count': JsonSchema.integer(mcpHeader: 'Count'),
+          'dryRun': JsonSchema.boolean(mcpHeader: 'Dry-Run'),
+        },
+      );
+
+      final json = schema.toJson();
+      final properties = json['properties'] as Map<String, dynamic>;
+      expect(properties['region']['x-mcp-header'], 'Region');
+      expect(properties['limit']['x-mcp-header'], 'Limit');
+      expect(properties['count']['x-mcp-header'], 'Count');
+      expect(properties['dryRun']['x-mcp-header'], 'Dry-Run');
+
+      final parsed = JsonSchema.fromJson(json) as JsonObject;
+      final parsedProperties = parsed.properties!;
+      expect((parsedProperties['region'] as JsonString).mcpHeader, 'Region');
+      expect((parsedProperties['limit'] as JsonNumber).mcpHeader, 'Limit');
+      expect((parsedProperties['count'] as JsonInteger).mcpHeader, 'Count');
+      expect(
+        (parsedProperties['dryRun'] as JsonBoolean).mcpHeader,
+        'Dry-Run',
+      );
+      expect(parsed.toJson(), json);
+    });
+
+    test('non-primitive x-mcp-header annotations remain visible', () {
+      final schema = JsonSchema.fromJson({
+        'type': 'object',
+        'x-mcp-header': 'Payload',
+      });
+
+      expect(schema, isA<JsonAny>());
+      expect(schema.toJson()['x-mcp-header'], 'Payload');
+    });
+  });
+
   group('Tool Schema Required Fields Tests', () {
     test('ToolInputSchema preserves required fields during serialization', () {
       final schema = JsonObject(


### PR DESCRIPTION
## Summary
- Preserve `x-mcp-header` tool parameter annotations in JSON schema helpers and parsed tool schemas.
- Filter invalid `x-mcp-header` tool definitions out of `client.listTools()` with warnings while keeping valid tools usable.
- Mirror mapped `tools/call` arguments into `Mcp-Param-*` headers for 2026 stateless Streamable HTTP, including Base64 wrapping for unsafe header values.

## Stack
- Stacked on #179 (`spec/2026-stateless-http-headers`).
- Part of #177 / MCP 2026-07-28 RC work.

## Validation
- `dart analyze`
- `dart test test/tool_schema_test.dart test/client/client_tool_validation_test.dart test/client/streamable_https_test.dart test/mcp_2026_07_28_test.dart`
- `dart test -j 1`