### PR TITLE
Add MCP 2026 MRTR input-required wire types

### DIFF
--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -9,6 +9,7 @@ import 'sampling.dart';
 import 'completion.dart';
 import 'roots.dart';
 import 'tasks.dart';
+import 'validation.dart';
 
 /// The draft/RC MCP protocol version being prepared for the next major release.
 const draftProtocolVersion2026_07_28 = "2026-07-28";
@@ -524,6 +525,260 @@ abstract class BaseResultData {
   /// Implementations must include `_meta` when [meta] is non-null so typed
   /// results preserve the MCP `Result._meta` field during direct serialization.
   Map<String, dynamic> toJson();
+}
+
+/// Result type for completed MCP requests.
+const resultTypeComplete = 'complete';
+
+/// Result type for MCP multi round-trip requests needing more input.
+const resultTypeInputRequired = 'input_required';
+
+/// Map of server-assigned input request keys to requested inputs.
+typedef InputRequests = Map<String, InputRequest>;
+
+/// Map of server-assigned input request keys to client responses.
+typedef InputResponses = Map<String, InputResponse>;
+
+/// A server-to-client request embedded in an MRTR `InputRequiredResult`.
+class InputRequest {
+  /// Request method. Must be one of the MRTR-supported server request methods.
+  final String method;
+
+  /// Request params, when present.
+  final Map<String, dynamic>? params;
+
+  const InputRequest._({required this.method, this.params});
+
+  /// Creates an embedded `elicitation/create` input request.
+  factory InputRequest.elicit(ElicitRequest params) {
+    return InputRequest._(
+      method: Method.elicitationCreate,
+      params: params.toJson(),
+    );
+  }
+
+  /// Creates an embedded `sampling/createMessage` input request.
+  factory InputRequest.createMessage(CreateMessageRequest params) {
+    return InputRequest._(
+      method: Method.samplingCreateMessage,
+      params: params.toJson(),
+    );
+  }
+
+  /// Creates an embedded `roots/list` input request.
+  factory InputRequest.listRoots({Map<String, dynamic>? params}) {
+    return InputRequest._(
+      method: Method.rootsList,
+      params: params,
+    );
+  }
+
+  factory InputRequest.fromJson(Map<String, dynamic> json) {
+    final method = json['method'];
+    if (method is! String) {
+      throw const FormatException('InputRequest.method is required');
+    }
+
+    switch (method) {
+      case Method.elicitationCreate:
+        final params = _readRequiredJsonObject(
+          json['params'],
+          'InputRequest.params',
+        );
+        ElicitRequest.fromJson(params);
+        return InputRequest._(method: method, params: params);
+      case Method.samplingCreateMessage:
+        final params = _readRequiredJsonObject(
+          json['params'],
+          'InputRequest.params',
+        );
+        CreateMessageRequest.fromJson(params);
+        return InputRequest._(method: method, params: params);
+      case Method.rootsList:
+        return InputRequest._(
+          method: method,
+          params: _readOptionalJsonObject(
+            json['params'],
+            'InputRequest.params',
+          ),
+        );
+      default:
+        throw const FormatException(
+          'InputRequest.method must be one of '
+          '${Method.elicitationCreate}, ${Method.samplingCreateMessage}, '
+          'or ${Method.rootsList}',
+        );
+    }
+  }
+
+  /// Parses an input request map.
+  static InputRequests? mapFromJson(Object? value, String field) {
+    if (value == null) {
+      return null;
+    }
+    final json = _readRequiredJsonObject(value, field);
+    return json.map(
+      (key, value) => MapEntry(
+        key,
+        InputRequest.fromJson(_readRequiredJsonObject(value, '$field.$key')),
+      ),
+    );
+  }
+
+  /// Converts an input request map to JSON.
+  static Map<String, dynamic> mapToJson(InputRequests requests) {
+    return requests.map(
+      (key, value) => MapEntry(key, value.toJson()),
+    );
+  }
+
+  /// The typed params for an embedded `elicitation/create` request.
+  ElicitRequest get elicitParams {
+    if (method != Method.elicitationCreate || params == null) {
+      throw StateError('InputRequest is not an elicitation/create request');
+    }
+    return ElicitRequest.fromJson(params!);
+  }
+
+  /// The typed params for an embedded `sampling/createMessage` request.
+  CreateMessageRequest get createMessageParams {
+    if (method != Method.samplingCreateMessage || params == null) {
+      throw StateError('InputRequest is not a sampling/createMessage request');
+    }
+    return CreateMessageRequest.fromJson(params!);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'method': method,
+        if (params != null) 'params': params,
+      };
+}
+
+/// A client response to an MRTR [InputRequest].
+class InputResponse {
+  /// Raw result object for the embedded request.
+  final Map<String, dynamic> value;
+
+  const InputResponse.raw(this.value);
+
+  /// Creates an input response from a typed MCP result.
+  factory InputResponse.fromResult(BaseResultData result) {
+    return InputResponse.raw(result.toJson());
+  }
+
+  factory InputResponse.fromJson(Map<String, dynamic> json) {
+    return InputResponse.raw(Map<String, dynamic>.from(json));
+  }
+
+  /// Parses an input response map.
+  static InputResponses? mapFromJson(Object? value, String field) {
+    if (value == null) {
+      return null;
+    }
+    final json = _readRequiredJsonObject(value, field);
+    return json.map(
+      (key, value) => MapEntry(
+        key,
+        InputResponse.fromJson(_readRequiredJsonObject(value, '$field.$key')),
+      ),
+    );
+  }
+
+  /// Converts an input response map to JSON.
+  static Map<String, dynamic> mapToJson(InputResponses responses) {
+    return responses.map(
+      (key, value) => MapEntry(key, value.toJson()),
+    );
+  }
+
+  Map<String, dynamic> toJson() => Map<String, dynamic>.from(value);
+}
+
+/// Result returned when a request needs extra client input before retry.
+class InputRequiredResult implements BaseResultData {
+  /// Server-to-client requests the client must fulfill before retry.
+  final InputRequests? inputRequests;
+
+  /// Opaque server state to echo exactly on retry.
+  final String? requestState;
+
+  /// Optional metadata.
+  @override
+  final Map<String, dynamic>? meta;
+
+  const InputRequiredResult({
+    this.inputRequests,
+    this.requestState,
+    this.meta,
+  }) : assert(
+          inputRequests != null || requestState != null,
+          'InputRequiredResult requires inputRequests or requestState',
+        );
+
+  factory InputRequiredResult.fromJson(Map<String, dynamic> json) {
+    if (json['resultType'] != resultTypeInputRequired) {
+      throw const FormatException(
+        'InputRequiredResult.resultType must be input_required',
+      );
+    }
+
+    final inputRequests = InputRequest.mapFromJson(
+      json['inputRequests'],
+      'InputRequiredResult.inputRequests',
+    );
+    final requestState = readOptionalString(
+      json['requestState'],
+      'InputRequiredResult.requestState',
+    );
+    if (inputRequests == null && requestState == null) {
+      throw const FormatException(
+        'InputRequiredResult requires inputRequests or requestState',
+      );
+    }
+
+    return InputRequiredResult(
+      inputRequests: inputRequests,
+      requestState: requestState,
+      meta: _readOptionalJsonObject(json['_meta'], 'InputRequiredResult._meta'),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    if (inputRequests == null && requestState == null) {
+      throw StateError(
+        'InputRequiredResult requires inputRequests or requestState',
+      );
+    }
+
+    return {
+      'resultType': resultTypeInputRequired,
+      if (inputRequests != null)
+        'inputRequests': InputRequest.mapToJson(inputRequests!),
+      if (requestState != null) 'requestState': requestState,
+      if (meta != null) '_meta': meta,
+    };
+  }
+}
+
+Map<String, dynamic> _readRequiredJsonObject(Object? value, String field) {
+  if (value is Map<String, dynamic>) {
+    return value;
+  }
+  if (value is Map) {
+    if (value.keys.any((key) => key is! String)) {
+      throw FormatException('$field must be an object with string keys');
+    }
+    return value.cast<String, dynamic>();
+  }
+  throw FormatException('$field must be an object');
+}
+
+Map<String, dynamic>? _readOptionalJsonObject(Object? value, String field) {
+  if (value == null) {
+    return null;
+  }
+  return _readRequiredJsonObject(value, field);
 }
 
 /// Custom error class for MCP specific errors.

--- a/lib/src/types/prompts.dart
+++ b/lib/src/types/prompts.dart
@@ -1,5 +1,6 @@
 import '../types.dart';
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// Describes an argument accepted by a prompt template.
 class PromptArgument {
@@ -186,7 +187,18 @@ class GetPromptRequest {
   /// Arguments to use for templating the prompt.
   final Map<String, String>? arguments;
 
-  const GetPromptRequest({required this.name, this.arguments});
+  /// Client responses to MRTR input requests when retrying this prompt request.
+  final InputResponses? inputResponses;
+
+  /// Opaque MRTR state returned by the server and echoed on retry.
+  final String? requestState;
+
+  const GetPromptRequest({
+    required this.name,
+    this.arguments,
+    this.inputResponses,
+    this.requestState,
+  });
 
   factory GetPromptRequest.fromJson(Map<String, dynamic> json) =>
       GetPromptRequest(
@@ -194,11 +206,22 @@ class GetPromptRequest {
         arguments: (json['arguments'] as Map<String, dynamic>?)?.map(
           (k, v) => MapEntry(k, v as String),
         ),
+        inputResponses: InputResponse.mapFromJson(
+          json['inputResponses'],
+          'GetPromptRequest.inputResponses',
+        ),
+        requestState: readOptionalString(
+          json['requestState'],
+          'GetPromptRequest.requestState',
+        ),
       );
 
   Map<String, dynamic> toJson() => {
         'name': name,
         if (arguments != null) 'arguments': arguments,
+        if (inputResponses != null)
+          'inputResponses': InputResponse.mapToJson(inputResponses!),
+        if (requestState != null) 'requestState': requestState,
       };
 }
 

--- a/lib/src/types/resources.dart
+++ b/lib/src/types/resources.dart
@@ -393,12 +393,37 @@ class ReadResourceRequest {
   /// The URI of the resource to read.
   final String uri;
 
-  const ReadResourceRequest({required this.uri});
+  /// Client responses to MRTR input requests when retrying this read request.
+  final InputResponses? inputResponses;
+
+  /// Opaque MRTR state returned by the server and echoed on retry.
+  final String? requestState;
+
+  const ReadResourceRequest({
+    required this.uri,
+    this.inputResponses,
+    this.requestState,
+  });
 
   factory ReadResourceRequest.fromJson(Map<String, dynamic> json) =>
-      ReadResourceRequest(uri: json['uri'] as String);
+      ReadResourceRequest(
+        uri: json['uri'] as String,
+        inputResponses: InputResponse.mapFromJson(
+          json['inputResponses'],
+          'ReadResourceRequest.inputResponses',
+        ),
+        requestState: readOptionalString(
+          json['requestState'],
+          'ReadResourceRequest.requestState',
+        ),
+      );
 
-  Map<String, dynamic> toJson() => {'uri': uri};
+  Map<String, dynamic> toJson() => {
+        'uri': uri,
+        if (inputResponses != null)
+          'inputResponses': InputResponse.mapToJson(inputResponses!),
+        if (requestState != null) 'requestState': requestState,
+      };
 }
 
 /// Request sent from client to read a specific resource.

--- a/lib/src/types/tools.dart
+++ b/lib/src/types/tools.dart
@@ -320,9 +320,17 @@ class CallToolRequest {
   /// The arguments to pass to the tool.
   final Map<String, dynamic> arguments;
 
+  /// Client responses to MRTR input requests when retrying this tool call.
+  final InputResponses? inputResponses;
+
+  /// Opaque MRTR state returned by the server and echoed on retry.
+  final String? requestState;
+
   const CallToolRequest({
     required this.name,
     this.arguments = const {},
+    this.inputResponses,
+    this.requestState,
   });
 
   factory CallToolRequest.fromJson(Map<String, dynamic> json) {
@@ -332,12 +340,23 @@ class CallToolRequest {
       arguments: arguments == null
           ? const {}
           : (arguments as Map).cast<String, dynamic>(),
+      inputResponses: InputResponse.mapFromJson(
+        json['inputResponses'],
+        'CallToolRequest.inputResponses',
+      ),
+      requestState: readOptionalString(
+        json['requestState'],
+        'CallToolRequest.requestState',
+      ),
     );
   }
 
   Map<String, dynamic> toJson() => {
         'name': name,
         'arguments': arguments,
+        if (inputResponses != null)
+          'inputResponses': InputResponse.mapToJson(inputResponses!),
+        if (requestState != null) 'requestState': requestState,
       };
 }
 

--- a/lib/src/types/validation.dart
+++ b/lib/src/types/validation.dart
@@ -33,3 +33,13 @@ int? readOptionalInteger(Object? value, String field) {
   }
   throw FormatException('$field must be an integer');
 }
+
+String? readOptionalString(Object? value, String field) {
+  if (value == null) {
+    return null;
+  }
+  if (value is String) {
+    return value;
+  }
+  throw FormatException('$field must be a string');
+}

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -220,6 +220,176 @@ void main() {
       );
     });
 
+    test('serializes MRTR input required results', () {
+      final result = InputRequiredResult(
+        inputRequests: {
+          'github_login': InputRequest.elicit(
+            ElicitRequest.form(
+              message: 'Please provide your GitHub username',
+              requestedSchema: JsonSchema.object(
+                properties: {'name': JsonSchema.string()},
+                required: ['name'],
+              ),
+            ),
+          ),
+          'capital_of_france': InputRequest.createMessage(
+            const CreateMessageRequest(
+              messages: [
+                SamplingMessage(
+                  role: SamplingMessageRole.user,
+                  content: SamplingTextContent(
+                    text: 'What is the capital of France?',
+                  ),
+                ),
+              ],
+              maxTokens: 100,
+            ),
+          ),
+          'roots': InputRequest.listRoots(),
+        },
+        requestState: 'AEAD-protected blob',
+        meta: const {'trace': 'abc'},
+      );
+
+      final json = result.toJson();
+      expect(json['resultType'], resultTypeInputRequired);
+      expect(json['requestState'], 'AEAD-protected blob');
+      expect(json['_meta'], {'trace': 'abc'});
+      expect(
+        json['inputRequests']['github_login']['method'],
+        Method.elicitationCreate,
+      );
+      expect(
+        json['inputRequests']['capital_of_france']['method'],
+        Method.samplingCreateMessage,
+      );
+      expect(json['inputRequests']['roots'], {'method': Method.rootsList});
+
+      final parsed = InputRequiredResult.fromJson(json);
+      expect(parsed.requestState, 'AEAD-protected blob');
+      expect(
+        parsed.inputRequests!['github_login']!.elicitParams.message,
+        'Please provide your GitHub username',
+      );
+      expect(
+        parsed
+            .inputRequests!['capital_of_france']!.createMessageParams.maxTokens,
+        100,
+      );
+    });
+
+    test('serializes MRTR retry fields on supported client requests', () {
+      final inputResponses = {
+        'github_login': InputResponse.fromResult(
+          const ElicitResult(
+            action: 'accept',
+            content: {'name': 'octocat'},
+          ),
+        ),
+        'roots': InputResponse.fromResult(
+          ListRootsResult(roots: [Root(uri: 'file:///repo')]),
+        ),
+      };
+
+      final toolRequest = CallToolRequest(
+        name: 'deploy',
+        arguments: const {'service': 'api'},
+        inputResponses: inputResponses,
+        requestState: 'opaque-state',
+      );
+      final toolJson = toolRequest.toJson();
+      expect(toolJson['inputResponses']['github_login']['action'], 'accept');
+      expect(toolJson['requestState'], 'opaque-state');
+
+      final parsedToolRequest = CallToolRequest.fromJson(toolJson);
+      expect(parsedToolRequest.requestState, 'opaque-state');
+      expect(
+        parsedToolRequest.inputResponses!['roots']!.toJson()['roots'][0]['uri'],
+        'file:///repo',
+      );
+
+      final promptJson = GetPromptRequest(
+        name: 'summary',
+        inputResponses: inputResponses,
+        requestState: 'prompt-state',
+      ).toJson();
+      expect(promptJson['inputResponses']['github_login']['content'], {
+        'name': 'octocat',
+      });
+      expect(
+        GetPromptRequest.fromJson(promptJson).requestState,
+        'prompt-state',
+      );
+
+      final resourceJson = ReadResourceRequest(
+        uri: 'file:///repo/README.md',
+        inputResponses: inputResponses,
+        requestState: 'resource-state',
+      ).toJson();
+      expect(
+        resourceJson['inputResponses']['roots']['roots'][0]['uri'],
+        'file:///repo',
+      );
+      expect(
+        ReadResourceRequest.fromJson(resourceJson).requestState,
+        'resource-state',
+      );
+    });
+
+    test('rejects malformed MRTR wire shapes', () {
+      expect(
+        () => InputRequiredResult.fromJson(
+          const {'resultType': resultTypeInputRequired},
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => InputRequiredResult.fromJson(
+          const {
+            'resultType': resultTypeInputRequired,
+            'requestState': 1,
+          },
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => InputRequiredResult.fromJson(
+          const {
+            'resultType': resultTypeInputRequired,
+            'requestState': 'state',
+            '_meta': false,
+          },
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => InputRequiredResult.fromJson(
+          const {
+            'resultType': resultTypeInputRequired,
+            'inputRequests': {
+              'unsupported': {'method': Method.toolsCall},
+            },
+          },
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => CallToolRequest.fromJson(
+          const {'name': 'deploy', 'requestState': 1},
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => ReadResourceRequest.fromJson(
+          const {
+            'uri': 'file:///repo/README.md',
+            'inputResponses': {'roots': []},
+          },
+        ),
+        throwsFormatException,
+      );
+    });
+
     test('server handles server/discover before legacy initialization',
         () async {
       final server = Server(


### PR DESCRIPTION
## Summary
- add MRTR `InputRequiredResult`, `InputRequest`, and `InputResponse` wire types for the 2026-07-28 RC spec
- add `inputResponses` and `requestState` retry fields to `tools/call`, `prompts/get`, and `resources/read` params
- validate malformed MRTR request/result shapes with regression coverage

## Stack
- Stacked on #180 (`spec/2026-tool-param-headers`)
- Part of #177 / MCP 2026-07-28 RC support

## Validation
- `dart format lib/src/types/validation.dart lib/src/types/json_rpc.dart lib/src/types/prompts.dart lib/src/types/resources.dart lib/src/types/tools.dart test/mcp_2026_07_28_test.dart`
- `dart analyze`
- `dart test test/mcp_2026_07_28_test.dart test/types_test.dart test/types/resources_test.dart test/types/sampling_test.dart test/elicitation_test.dart test/tool_schema_test.dart`
- `dart test -j 1`
- `git diff --check`
