### PR TITLE
Add MCP 2026 subscriptions listen wire support

### DIFF
--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -517,6 +517,9 @@ class McpClient extends Protocol {
         supported = serverCaps.resources?.subscribe ?? false;
         requiredCapability = 'resources.subscribe';
         break;
+      case Method.subscriptionsListen:
+        supported = true;
+        break;
       case Method.toolsCall:
       case Method.toolsList:
         supported = serverCaps.tools != null;

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -524,6 +524,7 @@ class Server extends Protocol {
 
       case Method.notificationsCancelled:
       case Method.notificationsProgress:
+      case Method.notificationsSubscriptionsAcknowledged:
         break;
 
       default:
@@ -540,6 +541,7 @@ class Server extends Protocol {
       case Method.initialize:
       case Method.ping:
       case Method.completionComplete:
+      case Method.subscriptionsListen:
         break;
 
       case Method.loggingSetLevel:

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -197,6 +197,37 @@ class RequestHandlerExtra {
 
     await sendNotification(notification);
   }
+
+  /// Sends the required first acknowledgment for a `subscriptions/listen` stream.
+  Future<void> sendSubscriptionAcknowledged(
+    SubscriptionFilter notifications,
+  ) {
+    return sendSubscriptionNotification(
+      JsonRpcSubscriptionsAcknowledgedNotification(
+        acknowledgedParams: SubscriptionsAcknowledgedNotification(
+          notifications: notifications,
+        ),
+      ),
+    );
+  }
+
+  /// Sends a notification on a `subscriptions/listen` stream with subscription metadata.
+  Future<void> sendSubscriptionNotification(
+    JsonRpcNotification notification,
+  ) {
+    final meta = <String, dynamic>{
+      ...?notification.meta,
+      McpMetaKey.subscriptionId: requestId,
+    };
+
+    return sendNotification(
+      JsonRpcNotification(
+        method: notification.method,
+        params: notification.params,
+        meta: meta,
+      ),
+    );
+  }
 }
 
 /// Internal class holding timeout state for a request.

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,5 +1,6 @@
 export 'types/content.dart';
 export 'types/resources.dart';
+export 'types/subscriptions.dart';
 export 'types/prompts.dart';
 export 'types/tools.dart';
 export 'types/tasks.dart';

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -8,6 +8,7 @@ import 'logging.dart';
 import 'sampling.dart';
 import 'completion.dart';
 import 'roots.dart';
+import 'subscriptions.dart';
 import 'tasks.dart';
 import 'validation.dart';
 
@@ -68,6 +69,7 @@ class McpMetaKey {
   static const clientCapabilities =
       'io.modelcontextprotocol/clientCapabilities';
   static const logLevel = 'io.modelcontextprotocol/logLevel';
+  static const subscriptionId = 'io.modelcontextprotocol/subscriptionId';
 
   const McpMetaKey._();
 }
@@ -102,6 +104,7 @@ class Method {
   static const resourcesTemplatesList = "resources/templates/list";
   static const resourcesSubscribe = "resources/subscribe";
   static const resourcesUnsubscribe = "resources/unsubscribe";
+  static const subscriptionsListen = "subscriptions/listen";
   static const promptsList = "prompts/list";
   static const promptsGet = "prompts/get";
   static const elicitationCreate = "elicitation/create";
@@ -123,6 +126,8 @@ class Method {
       "notifications/resources/list_changed";
   static const notificationsResourcesUpdated =
       "notifications/resources/updated";
+  static const notificationsSubscriptionsAcknowledged =
+      "notifications/subscriptions/acknowledged";
   static const notificationsPromptsListChanged =
       "notifications/prompts/list_changed";
   static const notificationsToolsListChanged =
@@ -263,6 +268,8 @@ sealed class JsonRpcMessage {
           Method.resourcesSubscribe => JsonRpcSubscribeRequest.fromJson(json),
           Method.resourcesUnsubscribe =>
             JsonRpcUnsubscribeRequest.fromJson(json),
+          Method.subscriptionsListen =>
+            JsonRpcSubscriptionsListenRequest.fromJson(json),
           Method.promptsList => JsonRpcListPromptsRequest.fromJson(json),
           Method.promptsGet => JsonRpcGetPromptRequest.fromJson(json),
           Method.elicitationCreate => JsonRpcElicitRequest.fromJson(json),
@@ -300,6 +307,8 @@ sealed class JsonRpcMessage {
             JsonRpcResourceListChangedNotification.fromJson(json),
           Method.notificationsResourcesUpdated =>
             JsonRpcResourceUpdatedNotification.fromJson(json),
+          Method.notificationsSubscriptionsAcknowledged =>
+            JsonRpcSubscriptionsAcknowledgedNotification.fromJson(json),
           Method.notificationsPromptsListChanged =>
             JsonRpcPromptListChangedNotification.fromJson(json),
           Method.notificationsToolsListChanged =>

--- a/lib/src/types/subscriptions.dart
+++ b/lib/src/types/subscriptions.dart
@@ -1,0 +1,238 @@
+import 'initialization.dart';
+import 'json_rpc.dart';
+
+/// Notification filter requested by `subscriptions/listen`.
+class SubscriptionFilter {
+  /// Subscribe to `notifications/tools/list_changed`.
+  final bool? toolsListChanged;
+
+  /// Subscribe to `notifications/prompts/list_changed`.
+  final bool? promptsListChanged;
+
+  /// Subscribe to `notifications/resources/list_changed`.
+  final bool? resourcesListChanged;
+
+  /// Subscribe to `notifications/resources/updated` for the given URIs.
+  final List<String>? resourceSubscriptions;
+
+  const SubscriptionFilter({
+    this.toolsListChanged,
+    this.promptsListChanged,
+    this.resourcesListChanged,
+    this.resourceSubscriptions,
+  });
+
+  factory SubscriptionFilter.fromJson(Map<String, dynamic> json) {
+    return SubscriptionFilter(
+      toolsListChanged: _readOptionalBool(
+        json['toolsListChanged'],
+        'SubscriptionFilter.toolsListChanged',
+      ),
+      promptsListChanged: _readOptionalBool(
+        json['promptsListChanged'],
+        'SubscriptionFilter.promptsListChanged',
+      ),
+      resourcesListChanged: _readOptionalBool(
+        json['resourcesListChanged'],
+        'SubscriptionFilter.resourcesListChanged',
+      ),
+      resourceSubscriptions: _readOptionalStringList(
+        json['resourceSubscriptions'],
+        'SubscriptionFilter.resourceSubscriptions',
+      ),
+    );
+  }
+
+  /// Returns the subset this server can honor from this requested filter.
+  SubscriptionFilter acknowledgedBy(ServerCapabilities capabilities) {
+    return SubscriptionFilter(
+      toolsListChanged:
+          toolsListChanged == true && (capabilities.tools?.listChanged ?? false)
+              ? true
+              : null,
+      promptsListChanged: promptsListChanged == true &&
+              (capabilities.prompts?.listChanged ?? false)
+          ? true
+          : null,
+      resourcesListChanged: resourcesListChanged == true &&
+              (capabilities.resources?.listChanged ?? false)
+          ? true
+          : null,
+      resourceSubscriptions:
+          resourceSubscriptions != null && capabilities.resources != null
+              ? List<String>.unmodifiable(resourceSubscriptions!)
+              : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        if (toolsListChanged != null) 'toolsListChanged': toolsListChanged,
+        if (promptsListChanged != null)
+          'promptsListChanged': promptsListChanged,
+        if (resourcesListChanged != null)
+          'resourcesListChanged': resourcesListChanged,
+        if (resourceSubscriptions != null)
+          'resourceSubscriptions': resourceSubscriptions,
+      };
+}
+
+/// Parameters for a `subscriptions/listen` request.
+class SubscriptionsListenRequest {
+  /// Notifications the client opts into on this stream.
+  final SubscriptionFilter notifications;
+
+  const SubscriptionsListenRequest({required this.notifications});
+
+  factory SubscriptionsListenRequest.fromJson(Map<String, dynamic> json) {
+    final notifications = json['notifications'];
+    if (notifications is! Map) {
+      throw const FormatException(
+        'SubscriptionsListenRequest.notifications is required',
+      );
+    }
+
+    return SubscriptionsListenRequest(
+      notifications: SubscriptionFilter.fromJson(
+        notifications.cast<String, dynamic>(),
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'notifications': notifications.toJson(),
+      };
+}
+
+/// Request sent by a client to open a long-lived notification stream.
+class JsonRpcSubscriptionsListenRequest extends JsonRpcRequest {
+  /// The listen request parameters.
+  final SubscriptionsListenRequest listenParams;
+
+  JsonRpcSubscriptionsListenRequest({
+    required super.id,
+    required this.listenParams,
+    super.meta,
+  }) : super(
+          method: Method.subscriptionsListen,
+          params: listenParams.toJson(),
+        );
+
+  factory JsonRpcSubscriptionsListenRequest.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    final paramsMap = json['params'] as Map<String, dynamic>?;
+    if (paramsMap == null) {
+      throw const FormatException(
+        'Missing params for subscriptions/listen request',
+      );
+    }
+
+    return JsonRpcSubscriptionsListenRequest(
+      id: parseRequestId(json['id']),
+      listenParams: SubscriptionsListenRequest.fromJson(paramsMap),
+      meta: extractRequestMeta(json),
+    );
+  }
+}
+
+/// Parameters for `notifications/subscriptions/acknowledged`.
+class SubscriptionsAcknowledgedNotification {
+  /// The subset of the requested filter the server agreed to honor.
+  final SubscriptionFilter notifications;
+
+  const SubscriptionsAcknowledgedNotification({required this.notifications});
+
+  factory SubscriptionsAcknowledgedNotification.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    final notifications = json['notifications'];
+    if (notifications is! Map) {
+      throw const FormatException(
+        'SubscriptionsAcknowledgedNotification.notifications is required',
+      );
+    }
+
+    return SubscriptionsAcknowledgedNotification(
+      notifications: SubscriptionFilter.fromJson(
+        notifications.cast<String, dynamic>(),
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'notifications': notifications.toJson(),
+      };
+}
+
+/// Notification acknowledging a `subscriptions/listen` stream.
+class JsonRpcSubscriptionsAcknowledgedNotification extends JsonRpcNotification {
+  /// The acknowledgment parameters.
+  final SubscriptionsAcknowledgedNotification acknowledgedParams;
+
+  JsonRpcSubscriptionsAcknowledgedNotification({
+    required this.acknowledgedParams,
+    super.meta,
+  }) : super(
+          method: Method.notificationsSubscriptionsAcknowledged,
+          params: acknowledgedParams.toJson(),
+        );
+
+  factory JsonRpcSubscriptionsAcknowledgedNotification.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    final paramsMap = json['params'] as Map<String, dynamic>?;
+    if (paramsMap == null) {
+      throw const FormatException(
+        'Missing params for subscriptions acknowledged notification',
+      );
+    }
+
+    return JsonRpcSubscriptionsAcknowledgedNotification(
+      acknowledgedParams:
+          SubscriptionsAcknowledgedNotification.fromJson(paramsMap),
+      meta: _readOptionalJsonObject(
+        paramsMap['_meta'],
+        'SubscriptionsAcknowledgedNotification._meta',
+      ),
+    );
+  }
+}
+
+bool? _readOptionalBool(Object? value, String field) {
+  if (value == null) {
+    return null;
+  }
+  if (value is bool) {
+    return value;
+  }
+  throw FormatException('$field must be a boolean');
+}
+
+List<String>? _readOptionalStringList(Object? value, String field) {
+  if (value == null) {
+    return null;
+  }
+  if (value is! List) {
+    throw FormatException('$field must be an array');
+  }
+  if (value.any((item) => item is! String)) {
+    throw FormatException('$field must contain only strings');
+  }
+  return value.cast<String>();
+}
+
+Map<String, dynamic>? _readOptionalJsonObject(Object? value, String field) {
+  if (value == null) {
+    return null;
+  }
+  if (value is Map<String, dynamic>) {
+    return value;
+  }
+  if (value is Map) {
+    if (value.keys.any((key) => key is! String)) {
+      throw FormatException('$field must be an object with string keys');
+    }
+    return value.cast<String, dynamic>();
+  }
+  throw FormatException('$field must be an object');
+}

--- a/test/client/client_test.dart
+++ b/test/client/client_test.dart
@@ -167,6 +167,10 @@ void main() {
         () => client.assertCapabilityForMethod("tools/call"),
         returnsNormally,
       );
+      expect(
+        () => client.assertCapabilityForMethod(Method.subscriptionsListen),
+        returnsNormally,
+      );
 
       // Create a client with limited capabilities
       final limitedClient = Client(clientInfo);
@@ -186,6 +190,12 @@ void main() {
       expect(
         () => limitedClient.assertCapabilityForMethod("prompts/list"),
         throwsA(isA<McpError>()),
+      );
+      expect(
+        () => limitedClient.assertCapabilityForMethod(
+          Method.subscriptionsListen,
+        ),
+        returnsNormally,
       );
     });
 

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -390,6 +390,72 @@ void main() {
       );
     });
 
+    test('server acknowledges subscriptions/listen with subscription id',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            tools: ServerCapabilitiesTools(listChanged: true),
+            resources: ServerCapabilitiesResources(),
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcSubscriptionsListenRequest>(
+        Method.subscriptionsListen,
+        (request, extra) async {
+          await extra.sendSubscriptionAcknowledged(
+            request.listenParams.notifications.acknowledgedBy(
+              const ServerCapabilities(
+                tools: ServerCapabilitiesTools(listChanged: true),
+                resources: ServerCapabilitiesResources(),
+              ),
+            ),
+          );
+          return const EmptyResult();
+        },
+        (id, params, meta) => JsonRpcSubscriptionsListenRequest(
+          id: id,
+          listenParams: SubscriptionsListenRequest.fromJson(params!),
+          meta: meta,
+        ),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcSubscriptionsListenRequest(
+          id: 'sub-1',
+          listenParams: const SubscriptionsListenRequest(
+            notifications: SubscriptionFilter(
+              toolsListChanged: true,
+              promptsListChanged: true,
+              resourceSubscriptions: ['file:///project/config.json'],
+            ),
+          ),
+          meta: _clientMeta(),
+        ),
+      );
+      await _pump();
+
+      final acknowledged = JsonRpcMessage.fromJson(
+        transport.sentMessages.first.toJson(),
+      ) as JsonRpcSubscriptionsAcknowledgedNotification;
+      expect(
+        acknowledged.method,
+        Method.notificationsSubscriptionsAcknowledged,
+      );
+      expect(acknowledged.meta?[McpMetaKey.subscriptionId], 'sub-1');
+      expect(
+        acknowledged.acknowledgedParams.notifications.toJson(),
+        {
+          'toolsListChanged': true,
+          'resourceSubscriptions': ['file:///project/config.json'],
+        },
+      );
+      expect(transport.sentMessages.last, isA<JsonRpcResponse>());
+    });
+
     test('server handles server/discover before legacy initialization',
         () async {
       final server = Server(

--- a/test/server/server_test.dart
+++ b/test/server/server_test.dart
@@ -964,7 +964,8 @@ void _addCriticalPathTests() {
       );
     });
 
-    test('initialize, ping, completion/complete always allowed', () {
+    test('initialize, ping, completion/complete, subscriptions/listen allowed',
+        () {
       server = Server(
         const Implementation(name: 'TestServer', version: '1.0.0'),
         // No special capabilities
@@ -980,6 +981,10 @@ void _addCriticalPathTests() {
       );
       expect(
         () => server.assertRequestHandlerCapability('completion/complete'),
+        returnsNormally,
+      );
+      expect(
+        () => server.assertRequestHandlerCapability(Method.subscriptionsListen),
         returnsNormally,
       );
     });

--- a/test/types/subscriptions_test.dart
+++ b/test/types/subscriptions_test.dart
@@ -1,0 +1,156 @@
+import 'package:mcp_dart/src/types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SubscriptionFilter', () {
+    test('serializes and parses requested notification filters', () {
+      const filter = SubscriptionFilter(
+        toolsListChanged: true,
+        promptsListChanged: false,
+        resourceSubscriptions: ['file:///project/config.json'],
+      );
+
+      final json = filter.toJson();
+      expect(json['toolsListChanged'], isTrue);
+      expect(json['promptsListChanged'], isFalse);
+      expect(json['resourceSubscriptions'], ['file:///project/config.json']);
+      expect(json.containsKey('resourcesListChanged'), isFalse);
+
+      final parsed = SubscriptionFilter.fromJson(json);
+      expect(parsed.toolsListChanged, isTrue);
+      expect(parsed.promptsListChanged, isFalse);
+      expect(parsed.resourceSubscriptions, ['file:///project/config.json']);
+    });
+
+    test('acknowledgedBy returns only supported requested filters', () {
+      const requested = SubscriptionFilter(
+        toolsListChanged: true,
+        promptsListChanged: true,
+        resourcesListChanged: true,
+        resourceSubscriptions: ['file:///project/config.json'],
+      );
+      const capabilities = ServerCapabilities(
+        tools: ServerCapabilitiesTools(listChanged: true),
+        resources: ServerCapabilitiesResources(),
+      );
+
+      final acknowledged = requested.acknowledgedBy(capabilities);
+      expect(acknowledged.toJson(), {
+        'toolsListChanged': true,
+        'resourceSubscriptions': ['file:///project/config.json'],
+      });
+    });
+
+    test('rejects malformed filters', () {
+      expect(
+        () => SubscriptionFilter.fromJson(
+          const {'toolsListChanged': 'yes'},
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => SubscriptionFilter.fromJson(
+          const {
+            'resourceSubscriptions': [1],
+          },
+        ),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('JsonRpcSubscriptionsListenRequest', () {
+    test('serializes and parses subscriptions/listen requests', () {
+      final request = JsonRpcSubscriptionsListenRequest(
+        id: 'sub-1',
+        listenParams: const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(
+            toolsListChanged: true,
+            resourceSubscriptions: ['file:///project/config.json'],
+          ),
+        ),
+        meta: const {
+          McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
+        },
+      );
+
+      final json = request.toJson();
+      expect(json['method'], Method.subscriptionsListen);
+      expect(json['params']['notifications']['toolsListChanged'], isTrue);
+      expect(
+        json['params']['_meta'][McpMetaKey.protocolVersion],
+        draftProtocolVersion2026_07_28,
+      );
+
+      final parsed = JsonRpcMessage.fromJson(json);
+      expect(parsed, isA<JsonRpcSubscriptionsListenRequest>());
+      final listen = parsed as JsonRpcSubscriptionsListenRequest;
+      expect(listen.id, 'sub-1');
+      expect(listen.listenParams.notifications.toolsListChanged, isTrue);
+      expect(
+        listen.meta?[McpMetaKey.protocolVersion],
+        draftProtocolVersion2026_07_28,
+      );
+    });
+
+    test('rejects missing notifications', () {
+      expect(
+        () => JsonRpcSubscriptionsListenRequest.fromJson(
+          const {
+            'id': 1,
+            'method': Method.subscriptionsListen,
+            'params': <String, dynamic>{},
+          },
+        ),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('JsonRpcSubscriptionsAcknowledgedNotification', () {
+    test('serializes and parses subscription acknowledgments', () {
+      final notification = JsonRpcSubscriptionsAcknowledgedNotification(
+        acknowledgedParams: const SubscriptionsAcknowledgedNotification(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+        meta: const {McpMetaKey.subscriptionId: 'sub-1'},
+      );
+
+      final json = notification.toJson();
+      expect(json['method'], Method.notificationsSubscriptionsAcknowledged);
+      expect(json['params']['notifications']['toolsListChanged'], isTrue);
+      expect(json['params']['_meta'][McpMetaKey.subscriptionId], 'sub-1');
+
+      final parsed = JsonRpcMessage.fromJson(json);
+      expect(parsed, isA<JsonRpcSubscriptionsAcknowledgedNotification>());
+      final acknowledged =
+          parsed as JsonRpcSubscriptionsAcknowledgedNotification;
+      expect(
+        acknowledged.acknowledgedParams.notifications.toolsListChanged,
+        isTrue,
+      );
+      expect(acknowledged.meta?[McpMetaKey.subscriptionId], 'sub-1');
+    });
+
+    test('rejects malformed acknowledgments', () {
+      expect(
+        () => JsonRpcSubscriptionsAcknowledgedNotification.fromJson(
+          const {'method': Method.notificationsSubscriptionsAcknowledged},
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => JsonRpcSubscriptionsAcknowledgedNotification.fromJson(
+          const {
+            'method': Method.notificationsSubscriptionsAcknowledged,
+            'params': {
+              'notifications': {'toolsListChanged': true},
+              '_meta': false,
+            },
+          },
+        ),
+        throwsFormatException,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add typed `subscriptions/listen` request, `SubscriptionFilter`, and `notifications/subscriptions/acknowledged` wire support
- add subscription id metadata helpers for server request handlers so streamed notifications can carry `io.modelcontextprotocol/subscriptionId`
- allow `subscriptions/listen` through capability checks without tying it to legacy `resources.subscribe`

## Stack
- Stacked on #181 (`spec/2026-mrtr-input-required`)
- Part of #177 / MCP 2026-07-28 RC support

## Validation
- `dart format lib/src/types/subscriptions.dart lib/src/types.dart lib/src/types/json_rpc.dart lib/src/shared/protocol.dart lib/src/client/client.dart lib/src/server/server.dart test/types/subscriptions_test.dart test/mcp_2026_07_28_test.dart test/client/client_test.dart test/server/server_test.dart`
- `dart analyze`
- `dart test test/types/subscriptions_test.dart test/mcp_2026_07_28_test.dart test/client/client_test.dart test/server/server_test.dart`
- `dart test -j 1`
- `git diff --check`
