### PR TITLE
Add MCP 2026 task extension wire support

### DIFF
--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -525,6 +525,21 @@ class McpClient extends Protocol {
         supported = serverCaps.tools != null;
         requiredCapability = 'tools';
         break;
+      case Method.tasksGet:
+      case Method.tasksCancel:
+        supported =
+            serverCaps.tasks != null || serverCaps.supportsTasksExtension;
+        requiredCapability = 'tasks or $mcpTasksExtensionId';
+        break;
+      case Method.tasksUpdate:
+        supported = serverCaps.supportsTasksExtension;
+        requiredCapability = mcpTasksExtensionId;
+        break;
+      case Method.tasksList:
+      case Method.tasksResult:
+        supported = serverCaps.tasks != null;
+        requiredCapability = 'tasks';
+        break;
       case Method.completionComplete:
         supported = serverCaps.completions != null;
         requiredCapability = 'completions';

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -184,10 +184,52 @@ class Server extends Protocol {
     return null;
   }
 
+  McpError? _validateTaskSubscriptionCapabilities(JsonRpcRequest request) {
+    if (request is! JsonRpcSubscriptionsListenRequest ||
+        request.listenParams.notifications.taskIds == null) {
+      return null;
+    }
+
+    final clientCapabilitiesValue =
+        request.meta?[McpMetaKey.clientCapabilities];
+    final ClientCapabilities? clientCapabilities;
+    try {
+      clientCapabilities = clientCapabilitiesValue is Map
+          ? ClientCapabilities.fromJson(
+              clientCapabilitiesValue.cast<String, dynamic>(),
+            )
+          : _clientCapabilities;
+    } catch (error) {
+      return McpError(
+        ErrorCode.invalidRequest.value,
+        'Invalid request client capabilities metadata.',
+        error.toString(),
+      );
+    }
+
+    if (clientCapabilities?.supportsTasksExtension ?? false) {
+      return null;
+    }
+
+    return McpError(
+      ErrorCode.missingRequiredClientCapability.value,
+      'Missing required client capability',
+      {
+        'requiredCapabilities': {
+          'extensions': {mcpTasksExtensionId: <String, dynamic>{}},
+        },
+      },
+    );
+  }
+
   @override
   McpError? validateIncomingRequest(JsonRpcRequest request) {
     if (request.method == Method.serverDiscover) {
-      return _validateStatelessRequestMetadata(request);
+      final metadataError = _validateStatelessRequestMetadata(request);
+      if (metadataError != null) {
+        return metadataError;
+      }
+      return null;
     }
 
     final requestedProtocolVersion = request.meta?[McpMetaKey.protocolVersion];
@@ -198,7 +240,11 @@ class Server extends Protocol {
     }
     if (requestedProtocolVersion is String &&
         isStatelessProtocolVersion(requestedProtocolVersion)) {
-      return _validateStatelessRequestMetadata(request);
+      final metadataError = _validateStatelessRequestMetadata(request);
+      if (metadataError != null) {
+        return metadataError;
+      }
+      return _validateTaskSubscriptionCapabilities(request);
     }
 
     if (request.method == Method.initialize) {
@@ -229,7 +275,7 @@ class Server extends Protocol {
       );
     }
 
-    return null;
+    return _validateTaskSubscriptionCapabilities(request);
   }
 
   @override
@@ -514,6 +560,14 @@ class Server extends Protocol {
         }
         break;
 
+      case Method.notificationsTasks:
+        if (!_capabilities.supportsTasksExtension) {
+          throw StateError(
+            "Server does not support the $mcpTasksExtensionId extension (required for sending $method)",
+          );
+        }
+        break;
+
       case Method.notificationsElicitationComplete:
         if (!(_clientCapabilities?.elicitation?.url != null)) {
           throw StateError(
@@ -590,12 +644,21 @@ class Server extends Protocol {
         break;
 
       case Method.tasksList:
-      case Method.tasksCancel:
-      case Method.tasksGet:
       case Method.tasksResult:
         if (!(_capabilities.tasks != null)) {
           throw StateError(
             "Server setup error: Cannot handle '$method' without 'tasks' capability",
+          );
+        }
+        break;
+
+      case Method.tasksCancel:
+      case Method.tasksGet:
+      case Method.tasksUpdate:
+        if (!(_capabilities.tasks != null ||
+            _capabilities.supportsTasksExtension)) {
+          throw StateError(
+            "Server setup error: Cannot handle '$method' without 'tasks' capability or '$mcpTasksExtensionId' extension",
           );
         }
         break;

--- a/lib/src/types/initialization.dart
+++ b/lib/src/types/initialization.dart
@@ -37,6 +37,19 @@ Map<String, dynamic>? _serializeCapabilityObject(bool? declared) {
   return null;
 }
 
+/// MCP Tasks extension identifier.
+const mcpTasksExtensionId = 'io.modelcontextprotocol/tasks';
+
+/// Returns [extensions] with the MCP Tasks extension capability declared.
+Map<String, Map<String, dynamic>> withMcpTasksExtension([
+  Map<String, Map<String, dynamic>>? extensions,
+]) {
+  return {
+    ...?extensions,
+    mcpTasksExtensionId: <String, dynamic>{},
+  };
+}
+
 /// Describes an MCP implementation (client or server).
 class Implementation {
   /// The name of the implementation.
@@ -429,6 +442,10 @@ class ClientCapabilities {
         if (tasks != null) 'tasks': tasks!.toJson(),
         if (extensions != null) 'extensions': extensions,
       };
+
+  /// Whether the MCP Tasks extension is declared.
+  bool get supportsTasksExtension =>
+      extensions?.containsKey(mcpTasksExtensionId) ?? false;
 }
 
 /// Parameters for the `initialize` request.
@@ -844,6 +861,10 @@ class ServerCapabilities {
         if (tasks != null) 'tasks': tasks!.toJson(),
         if (extensions != null) 'extensions': extensions,
       };
+
+  /// Whether the MCP Tasks extension is declared.
+  bool get supportsTasksExtension =>
+      extensions?.containsKey(mcpTasksExtensionId) ?? false;
 }
 
 /// Result data for a successful `initialize` request.

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -118,6 +118,7 @@ class Method {
   static const tasksCancel = "tasks/cancel";
   static const tasksGet = "tasks/get";
   static const tasksResult = "tasks/result";
+  static const tasksUpdate = "tasks/update";
 
   static const notificationsInitialized = "notifications/initialized";
   static const notificationsCancelled = "notifications/cancelled";
@@ -144,6 +145,7 @@ class Method {
   static const notificationsRootsListChanged =
       "notifications/roots/list_changed";
   static const notificationsTasksStatus = "notifications/tasks/status";
+  static const notificationsTasks = "notifications/tasks";
   static const notificationsElicitationComplete =
       "notifications/elicitation/complete";
 
@@ -285,6 +287,7 @@ sealed class JsonRpcMessage {
           Method.tasksCancel => JsonRpcCancelTaskRequest.fromJson(json),
           Method.tasksGet => JsonRpcGetTaskRequest.fromJson(json),
           Method.tasksResult => JsonRpcTaskResultRequest.fromJson(json),
+          Method.tasksUpdate => JsonRpcUpdateTaskRequest.fromJson(json),
           _ => JsonRpcRequest(
               id: parseRequestId(json['id']),
               method: method,
@@ -323,6 +326,7 @@ sealed class JsonRpcMessage {
             JsonRpcRootsListChangedNotification.fromJson(json),
           Method.notificationsTasksStatus =>
             JsonRpcTaskStatusNotification.fromJson(json),
+          Method.notificationsTasks => JsonRpcTaskNotification.fromJson(json),
           Method.notificationsElicitationComplete =>
             JsonRpcElicitationCompleteNotification.fromJson(json),
           _ => JsonRpcNotification(
@@ -541,6 +545,9 @@ const resultTypeComplete = 'complete';
 
 /// Result type for MCP multi round-trip requests needing more input.
 const resultTypeInputRequired = 'input_required';
+
+/// Result type for MCP task extension task creation results.
+const resultTypeTask = 'task';
 
 /// Map of server-assigned input request keys to requested inputs.
 typedef InputRequests = Map<String, InputRequest>;

--- a/lib/src/types/subscriptions.dart
+++ b/lib/src/types/subscriptions.dart
@@ -15,11 +15,15 @@ class SubscriptionFilter {
   /// Subscribe to `notifications/resources/updated` for the given URIs.
   final List<String>? resourceSubscriptions;
 
+  /// Subscribe to `notifications/tasks` for the given task ids.
+  final List<String>? taskIds;
+
   const SubscriptionFilter({
     this.toolsListChanged,
     this.promptsListChanged,
     this.resourcesListChanged,
     this.resourceSubscriptions,
+    this.taskIds,
   });
 
   factory SubscriptionFilter.fromJson(Map<String, dynamic> json) {
@@ -39,6 +43,10 @@ class SubscriptionFilter {
       resourceSubscriptions: _readOptionalStringList(
         json['resourceSubscriptions'],
         'SubscriptionFilter.resourceSubscriptions',
+      ),
+      taskIds: _readOptionalStringList(
+        json['taskIds'],
+        'SubscriptionFilter.taskIds',
       ),
     );
   }
@@ -62,6 +70,9 @@ class SubscriptionFilter {
           resourceSubscriptions != null && capabilities.resources != null
               ? List<String>.unmodifiable(resourceSubscriptions!)
               : null,
+      taskIds: taskIds != null && capabilities.supportsTasksExtension
+          ? List<String>.unmodifiable(taskIds!)
+          : null,
     );
   }
 
@@ -73,6 +84,7 @@ class SubscriptionFilter {
           'resourcesListChanged': resourcesListChanged,
         if (resourceSubscriptions != null)
           'resourceSubscriptions': resourceSubscriptions,
+        if (taskIds != null) 'taskIds': taskIds,
       };
 }
 

--- a/lib/src/types/tasks.dart
+++ b/lib/src/types/tasks.dart
@@ -366,6 +366,71 @@ class JsonRpcTaskResultRequest extends JsonRpcRequest {
   }
 }
 
+/// Parameters for the MCP Tasks extension `tasks/update` request.
+class UpdateTaskRequest {
+  /// The ID of the task to update.
+  final String taskId;
+
+  /// Responses to outstanding task input requests.
+  final InputResponses inputResponses;
+
+  const UpdateTaskRequest({
+    required this.taskId,
+    required this.inputResponses,
+  });
+
+  factory UpdateTaskRequest.fromJson(Map<String, dynamic> json) {
+    final inputResponses = InputResponse.mapFromJson(
+      json['inputResponses'],
+      'UpdateTaskRequest.inputResponses',
+    );
+    if (inputResponses == null) {
+      throw const FormatException(
+        'UpdateTaskRequest.inputResponses is required',
+      );
+    }
+
+    return UpdateTaskRequest(
+      taskId: _readRequiredTaskString(
+        json,
+        'taskId',
+        owner: 'UpdateTaskRequest',
+      ),
+      inputResponses: inputResponses,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'taskId': taskId,
+        'inputResponses': InputResponse.mapToJson(inputResponses),
+      };
+}
+
+/// Request sent by a client to provide input for a task.
+class JsonRpcUpdateTaskRequest extends JsonRpcRequest {
+  /// The update parameters.
+  final UpdateTaskRequest updateParams;
+
+  JsonRpcUpdateTaskRequest({
+    required super.id,
+    required this.updateParams,
+    super.meta,
+  }) : super(method: Method.tasksUpdate, params: updateParams.toJson());
+
+  factory JsonRpcUpdateTaskRequest.fromJson(Map<String, dynamic> json) {
+    final paramsMap = json['params'] as Map<String, dynamic>?;
+    if (paramsMap == null) {
+      throw const FormatException("Missing params for update task request");
+    }
+    final meta = extractRequestMeta(json);
+    return JsonRpcUpdateTaskRequest(
+      id: parseRequestId(json['id']),
+      updateParams: UpdateTaskRequest.fromJson(paramsMap),
+      meta: meta,
+    );
+  }
+}
+
 /// Parameters for task creation when augmenting requests.
 class TaskCreation {
   /// Requested duration in milliseconds to retain task from creation.
@@ -431,6 +496,219 @@ class TaskResultMessage extends TaskStreamMessage {
 class TaskErrorMessage extends TaskStreamMessage {
   final Object error;
   const TaskErrorMessage(this.error) : super('error');
+}
+
+/// Task state shape used by the MCP Tasks extension.
+class TaskExtensionTask {
+  /// Unique identifier for the task.
+  final String taskId;
+
+  /// Current state of the task execution.
+  final TaskStatus status;
+
+  /// Optional human-readable message describing the current state.
+  final String? statusMessage;
+
+  /// ISO 8601 timestamp when the task was created.
+  final String createdAt;
+
+  /// ISO 8601 timestamp when the task was last updated.
+  final String lastUpdatedAt;
+
+  /// Time in milliseconds from creation before task may be deleted.
+  final int? ttlMs;
+
+  /// Suggested time in milliseconds between status checks.
+  final int? pollIntervalMs;
+
+  /// Outstanding input requests when [status] is `input_required`.
+  final InputRequests? inputRequests;
+
+  /// Final result when [status] is `completed`.
+  final Map<String, dynamic>? result;
+
+  /// JSON-RPC error when [status] is `failed`.
+  final JsonRpcErrorData? error;
+
+  const TaskExtensionTask({
+    required this.taskId,
+    required this.status,
+    required this.createdAt,
+    required this.lastUpdatedAt,
+    required this.ttlMs,
+    this.statusMessage,
+    this.pollIntervalMs,
+    this.inputRequests,
+    this.result,
+    this.error,
+  });
+
+  factory TaskExtensionTask.fromJson(Map<String, dynamic> json) {
+    return TaskExtensionTask(
+      taskId: _readRequiredTaskString(
+        json,
+        'taskId',
+        owner: 'TaskExtensionTask',
+      ),
+      status: TaskStatusName.fromString(
+        _readRequiredTaskString(json, 'status', owner: 'TaskExtensionTask'),
+      ),
+      statusMessage: _readOptionalTaskString(
+        json,
+        'statusMessage',
+        owner: 'TaskExtensionTask',
+      ),
+      createdAt: _readRequiredTaskString(
+        json,
+        'createdAt',
+        owner: 'TaskExtensionTask',
+      ),
+      lastUpdatedAt: _readRequiredTaskString(
+        json,
+        'lastUpdatedAt',
+        owner: 'TaskExtensionTask',
+      ),
+      ttlMs: _readTaskInt(
+        json,
+        'ttlMs',
+        requiredField: true,
+        owner: 'TaskExtensionTask',
+      ),
+      pollIntervalMs: _readTaskInt(
+        json,
+        'pollIntervalMs',
+        owner: 'TaskExtensionTask',
+      ),
+      inputRequests: InputRequest.mapFromJson(
+        json['inputRequests'],
+        'TaskExtensionTask.inputRequests',
+      ),
+      result: _readOptionalJsonObject(
+        json['result'],
+        'TaskExtensionTask.result',
+      ),
+      error: json['error'] == null
+          ? null
+          : JsonRpcErrorData.fromJson(
+              _readRequiredJsonObject(
+                json['error'],
+                'TaskExtensionTask.error',
+              ),
+            ),
+    );
+  }
+
+  Map<String, dynamic> toJson({String? resultType}) => {
+        if (resultType != null) 'resultType': resultType,
+        'taskId': taskId,
+        'status': status.name,
+        if (statusMessage != null) 'statusMessage': statusMessage,
+        'createdAt': createdAt,
+        'lastUpdatedAt': lastUpdatedAt,
+        'ttlMs': ttlMs,
+        if (pollIntervalMs != null) 'pollIntervalMs': pollIntervalMs,
+        if (inputRequests != null)
+          'inputRequests': InputRequest.mapToJson(inputRequests!),
+        if (result != null) 'result': result,
+        if (error != null) 'error': error!.toJson(),
+      };
+}
+
+/// `resultType: "task"` response from the MCP Tasks extension.
+class CreateTaskExtensionResult implements BaseResultData {
+  /// The created task state.
+  final TaskExtensionTask task;
+
+  /// Optional metadata.
+  @override
+  final Map<String, dynamic>? meta;
+
+  const CreateTaskExtensionResult({required this.task, this.meta});
+
+  factory CreateTaskExtensionResult.fromJson(Map<String, dynamic> json) {
+    if (json['resultType'] != resultTypeTask) {
+      throw const FormatException(
+        'CreateTaskExtensionResult.resultType must be task',
+      );
+    }
+    return CreateTaskExtensionResult(
+      task: TaskExtensionTask.fromJson(json),
+      meta: _readOptionalJsonObject(
+        json['_meta'],
+        'CreateTaskExtensionResult._meta',
+      ),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+        ...task.toJson(resultType: resultTypeTask),
+        if (meta != null) '_meta': meta,
+      };
+}
+
+/// `tasks/get` result from the MCP Tasks extension.
+class GetTaskExtensionResult implements BaseResultData {
+  /// The current task state.
+  final TaskExtensionTask task;
+
+  /// Optional metadata.
+  @override
+  final Map<String, dynamic>? meta;
+
+  const GetTaskExtensionResult({required this.task, this.meta});
+
+  factory GetTaskExtensionResult.fromJson(Map<String, dynamic> json) {
+    if (json['resultType'] != resultTypeComplete) {
+      throw const FormatException(
+        'GetTaskExtensionResult.resultType must be complete',
+      );
+    }
+    return GetTaskExtensionResult(
+      task: TaskExtensionTask.fromJson(json),
+      meta: _readOptionalJsonObject(
+        json['_meta'],
+        'GetTaskExtensionResult._meta',
+      ),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+        ...task.toJson(resultType: resultTypeComplete),
+        if (meta != null) '_meta': meta,
+      };
+}
+
+/// Empty `tasks/update` or `tasks/cancel` acknowledgement result.
+class TaskExtensionAcknowledgementResult implements BaseResultData {
+  /// Optional metadata.
+  @override
+  final Map<String, dynamic>? meta;
+
+  const TaskExtensionAcknowledgementResult({this.meta});
+
+  factory TaskExtensionAcknowledgementResult.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['resultType'] != resultTypeComplete) {
+      throw const FormatException(
+        'TaskExtensionAcknowledgementResult.resultType must be complete',
+      );
+    }
+    return TaskExtensionAcknowledgementResult(
+      meta: _readOptionalJsonObject(
+        json['_meta'],
+        'TaskExtensionAcknowledgementResult._meta',
+      ),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'resultType': resultTypeComplete,
+        if (meta != null) '_meta': meta,
+      };
 }
 
 /// Parameters for the `notifications/tasks/status` notification.
@@ -566,6 +844,49 @@ class JsonRpcTaskStatusNotification extends JsonRpcNotification {
       meta: meta,
     );
   }
+}
+
+/// `notifications/tasks` notification from the MCP Tasks extension.
+class JsonRpcTaskNotification extends JsonRpcNotification {
+  /// The task state carried by the notification.
+  final TaskExtensionTask task;
+
+  JsonRpcTaskNotification({required this.task, super.meta})
+      : super(method: Method.notificationsTasks, params: task.toJson());
+
+  factory JsonRpcTaskNotification.fromJson(Map<String, dynamic> json) {
+    final paramsMap = json['params'] as Map<String, dynamic>?;
+    if (paramsMap == null) {
+      throw const FormatException("Missing params for task notification");
+    }
+    return JsonRpcTaskNotification(
+      task: TaskExtensionTask.fromJson(paramsMap),
+      meta: _readOptionalJsonObject(
+        paramsMap['_meta'],
+        'JsonRpcTaskNotification._meta',
+      ),
+    );
+  }
+}
+
+Map<String, dynamic> _readRequiredJsonObject(Object? value, String field) {
+  if (value is Map<String, dynamic>) {
+    return value;
+  }
+  if (value is Map) {
+    if (value.keys.any((key) => key is! String)) {
+      throw FormatException('$field must be an object with string keys');
+    }
+    return value.cast<String, dynamic>();
+  }
+  throw FormatException('$field must be an object');
+}
+
+Map<String, dynamic>? _readOptionalJsonObject(Object? value, String field) {
+  if (value == null) {
+    return null;
+  }
+  return _readRequiredJsonObject(value, field);
 }
 
 /// Deprecated alias for [ListTasksRequest].

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -141,11 +141,14 @@ class LegacyFallbackTransport extends Transport
   Future<void> start() async {}
 }
 
-Map<String, dynamic> _clientMeta({String? protocolVersion}) {
+Map<String, dynamic> _clientMeta({
+  String? protocolVersion,
+  ClientCapabilities clientCapabilities = const ClientCapabilities(),
+}) {
   return buildProtocolRequestMeta(
     protocolVersion: protocolVersion ?? draftProtocolVersion2026_07_28,
     clientInfo: const Implementation(name: 'client', version: '1.0.0'),
-    clientCapabilities: const ClientCapabilities(),
+    clientCapabilities: clientCapabilities,
   );
 }
 
@@ -454,6 +457,51 @@ void main() {
         },
       );
       expect(transport.sentMessages.last, isA<JsonRpcResponse>());
+    });
+
+    test('server rejects task subscriptions without task extension capability',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            extensions: {mcpTasksExtensionId: {}},
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcSubscriptionsListenRequest>(
+        Method.subscriptionsListen,
+        (request, extra) async => const EmptyResult(),
+        (id, params, meta) => JsonRpcSubscriptionsListenRequest(
+          id: id,
+          listenParams: SubscriptionsListenRequest.fromJson(params!),
+          meta: meta,
+        ),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcSubscriptionsListenRequest(
+          id: 'sub-task',
+          listenParams: const SubscriptionsListenRequest(
+            notifications: SubscriptionFilter(taskIds: ['task-1']),
+          ),
+          meta: _clientMeta(),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcError;
+      expect(
+        response.error.code,
+        ErrorCode.missingRequiredClientCapability.value,
+      );
+      expect(
+        response.error.data['requiredCapabilities']['extensions']
+            [mcpTasksExtensionId],
+        isEmpty,
+      );
     });
 
     test('server handles server/discover before legacy initialization',

--- a/test/types/subscriptions_test.dart
+++ b/test/types/subscriptions_test.dart
@@ -8,18 +8,21 @@ void main() {
         toolsListChanged: true,
         promptsListChanged: false,
         resourceSubscriptions: ['file:///project/config.json'],
+        taskIds: ['task-1'],
       );
 
       final json = filter.toJson();
       expect(json['toolsListChanged'], isTrue);
       expect(json['promptsListChanged'], isFalse);
       expect(json['resourceSubscriptions'], ['file:///project/config.json']);
+      expect(json['taskIds'], ['task-1']);
       expect(json.containsKey('resourcesListChanged'), isFalse);
 
       final parsed = SubscriptionFilter.fromJson(json);
       expect(parsed.toolsListChanged, isTrue);
       expect(parsed.promptsListChanged, isFalse);
       expect(parsed.resourceSubscriptions, ['file:///project/config.json']);
+      expect(parsed.taskIds, ['task-1']);
     });
 
     test('acknowledgedBy returns only supported requested filters', () {
@@ -28,8 +31,10 @@ void main() {
         promptsListChanged: true,
         resourcesListChanged: true,
         resourceSubscriptions: ['file:///project/config.json'],
+        taskIds: ['task-1'],
       );
       const capabilities = ServerCapabilities(
+        extensions: {mcpTasksExtensionId: {}},
         tools: ServerCapabilitiesTools(listChanged: true),
         resources: ServerCapabilitiesResources(),
       );
@@ -38,7 +43,16 @@ void main() {
       expect(acknowledged.toJson(), {
         'toolsListChanged': true,
         'resourceSubscriptions': ['file:///project/config.json'],
+        'taskIds': ['task-1'],
       });
+    });
+
+    test('acknowledgedBy omits task filters without task extension support',
+        () {
+      const requested = SubscriptionFilter(taskIds: ['task-1']);
+
+      final acknowledged = requested.acknowledgedBy(const ServerCapabilities());
+      expect(acknowledged.toJson(), isEmpty);
     });
 
     test('rejects malformed filters', () {
@@ -52,6 +66,14 @@ void main() {
         () => SubscriptionFilter.fromJson(
           const {
             'resourceSubscriptions': [1],
+          },
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => SubscriptionFilter.fromJson(
+          const {
+            'taskIds': [1],
           },
         ),
         throwsFormatException,

--- a/test/types/tasks_extension_test.dart
+++ b/test/types/tasks_extension_test.dart
@@ -1,0 +1,182 @@
+import 'package:mcp_dart/src/types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MCP Tasks extension capabilities', () {
+    test('declares task extension support', () {
+      final extensions = withMcpTasksExtension({
+        'example/extension': {'enabled': true},
+      });
+
+      expect(extensions[mcpTasksExtensionId], <String, dynamic>{});
+      expect(extensions['example/extension'], {'enabled': true});
+      expect(
+        ClientCapabilities(extensions: extensions).supportsTasksExtension,
+        isTrue,
+      );
+      expect(
+        ServerCapabilities(extensions: extensions).supportsTasksExtension,
+        isTrue,
+      );
+    });
+  });
+
+  group('Task extension wire types', () {
+    test('serializes create task results with flat resultType task shape', () {
+      const result = CreateTaskExtensionResult(
+        task: TaskExtensionTask(
+          taskId: 'task-1',
+          status: TaskStatus.working,
+          createdAt: '2026-07-28T00:00:00Z',
+          lastUpdatedAt: '2026-07-28T00:00:00Z',
+          ttlMs: 60000,
+          pollIntervalMs: 5000,
+        ),
+        meta: {'trace': 'abc'},
+      );
+
+      final json = result.toJson();
+      expect(json['resultType'], resultTypeTask);
+      expect(json['taskId'], 'task-1');
+      expect(json['ttlMs'], 60000);
+      expect(json['pollIntervalMs'], 5000);
+      expect(json['_meta'], {'trace': 'abc'});
+
+      final parsed = CreateTaskExtensionResult.fromJson(json);
+      expect(parsed.task.status, TaskStatus.working);
+      expect(parsed.task.ttlMs, 60000);
+    });
+
+    test('serializes tasks/get input required results', () {
+      final result = GetTaskExtensionResult(
+        task: TaskExtensionTask(
+          taskId: 'task-1',
+          status: TaskStatus.inputRequired,
+          createdAt: '2026-07-28T00:00:00Z',
+          lastUpdatedAt: '2026-07-28T00:01:00Z',
+          ttlMs: null,
+          inputRequests: {
+            'approval': InputRequest.elicit(
+              ElicitRequest.form(
+                message: 'Approve deployment?',
+                requestedSchema: JsonSchema.object(
+                  properties: {'approved': JsonSchema.boolean()},
+                  required: ['approved'],
+                ),
+              ),
+            ),
+          },
+        ),
+      );
+
+      final json = result.toJson();
+      expect(json['resultType'], resultTypeComplete);
+      expect(json['status'], 'input_required');
+      expect(json['ttlMs'], isNull);
+      expect(
+        json['inputRequests']['approval']['method'],
+        Method.elicitationCreate,
+      );
+
+      final parsed = GetTaskExtensionResult.fromJson(json);
+      expect(
+        parsed.task.inputRequests!['approval']!.elicitParams.message,
+        'Approve deployment?',
+      );
+    });
+
+    test('serializes tasks/update requests with input responses', () {
+      final request = JsonRpcUpdateTaskRequest(
+        id: 7,
+        updateParams: UpdateTaskRequest(
+          taskId: 'task-1',
+          inputResponses: {
+            'approval': InputResponse.fromResult(
+              const ElicitResult(
+                action: 'accept',
+                content: {'approved': true},
+              ),
+            ),
+          },
+        ),
+      );
+
+      final json = request.toJson();
+      expect(json['method'], Method.tasksUpdate);
+      expect(json['params']['taskId'], 'task-1');
+      expect(json['params']['inputResponses']['approval']['action'], 'accept');
+
+      final parsed = JsonRpcMessage.fromJson(json) as JsonRpcUpdateTaskRequest;
+      expect(parsed.updateParams.taskId, 'task-1');
+      expect(
+        parsed.updateParams.inputResponses['approval']!.toJson()['content'],
+        {'approved': true},
+      );
+    });
+
+    test('serializes task update and cancel acknowledgements', () {
+      const result = TaskExtensionAcknowledgementResult(
+        meta: {'trace': 'abc'},
+      );
+
+      final json = result.toJson();
+      expect(json['resultType'], resultTypeComplete);
+      expect(json['_meta'], {'trace': 'abc'});
+
+      final parsed = TaskExtensionAcknowledgementResult.fromJson(json);
+      expect(parsed.meta, {'trace': 'abc'});
+    });
+
+    test('serializes notifications/tasks with detailed task state', () {
+      final notification = JsonRpcTaskNotification(
+        task: const TaskExtensionTask(
+          taskId: 'task-1',
+          status: TaskStatus.completed,
+          createdAt: '2026-07-28T00:00:00Z',
+          lastUpdatedAt: '2026-07-28T00:02:00Z',
+          ttlMs: 60000,
+          result: {
+            'content': [
+              {'type': 'text', 'text': 'done'},
+            ],
+          },
+        ),
+        meta: const {McpMetaKey.subscriptionId: 'sub-1'},
+      );
+
+      final json = notification.toJson();
+      expect(json['method'], Method.notificationsTasks);
+      expect(json['params']['resultType'], isNull);
+      expect(json['params']['result']['content'][0]['text'], 'done');
+      expect(json['params']['_meta'][McpMetaKey.subscriptionId], 'sub-1');
+
+      final parsed = JsonRpcMessage.fromJson(json) as JsonRpcTaskNotification;
+      expect(parsed.task.status, TaskStatus.completed);
+      expect(parsed.task.result!['content'][0]['text'], 'done');
+    });
+
+    test('rejects malformed task extension payloads', () {
+      expect(
+        () => CreateTaskExtensionResult.fromJson(
+          const {
+            'resultType': resultTypeComplete,
+            'taskId': 'task-1',
+          },
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => UpdateTaskRequest.fromJson(
+          const {'taskId': 'task-1'},
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => TaskExtensionAcknowledgementResult.fromJson(
+          const {'resultType': resultTypeInputRequired},
+        ),
+        throwsFormatException,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add the MCP Tasks extension capability helper and task extension wire/result types
- parse tasks/update and notifications/tasks, including detailed task status payloads
- add taskIds to subscriptions/listen filters and reject task subscriptions without the tasks extension capability

## Validation
- dart analyze
- dart test test/types/tasks_extension_test.dart test/types/subscriptions_test.dart test/mcp_2026_07_28_test.dart test/types_test.dart test/server/server_test.dart test/client/client_test.dart
- dart test -j 1
- git diff --check