### PR TITLE
Add MCP 2026 task HTTP routing headers

### DIFF
--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -661,6 +661,10 @@ class StreamableHttpClientTransport
       Method.toolsCall => params['name'],
       Method.resourcesRead => params['uri'],
       Method.promptsGet => params['name'],
+      Method.tasksCancel ||
+      Method.tasksGet ||
+      Method.tasksUpdate =>
+        params['taskId'],
       _ => null,
     };
     return nameField is String ? nameField : null;

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -414,6 +414,10 @@ class StreamableHTTPServerTransport
       Method.toolsCall => params['name'],
       Method.resourcesRead => params['uri'],
       Method.promptsGet => params['name'],
+      Method.tasksCancel ||
+      Method.tasksGet ||
+      Method.tasksUpdate =>
+        params['taskId'],
       _ => null,
     };
     return value is String ? value : null;

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -1188,6 +1188,58 @@ void main() {
       });
     });
 
+    test('send adds task id as 2026 stateless task name header', () async {
+      final capturedHeaders = <String, String?>{};
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        capturedHeaders['protocolVersion'] =
+            request.headers.value('mcp-protocol-version');
+        capturedHeaders['method'] = request.headers.value('mcp-method');
+        capturedHeaders['name'] = request.headers.value('mcp-name');
+        await request.drain<void>();
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(
+            jsonEncode(
+              const JsonRpcResponse(
+                id: 1,
+                result: {'resultType': resultTypeComplete},
+              ).toJson(),
+            ),
+          );
+        await request.response.close();
+      });
+
+      transport = StreamableHttpClientTransport(
+        Uri.parse('http://localhost:${server.port}/mcp'),
+      )..protocolVersion = draftProtocolVersion2026_07_28;
+      await transport.start();
+
+      final completer = Completer<JsonRpcMessage>();
+      transport.onmessage = completer.complete;
+
+      await transport.send(
+        JsonRpcUpdateTaskRequest(
+          id: 1,
+          updateParams: const UpdateTaskRequest(
+            taskId: 'task-1',
+            inputResponses: {},
+          ),
+          meta: _statelessMeta(),
+        ),
+      );
+      await completer.future.timeout(const Duration(seconds: 5));
+
+      expect(
+        capturedHeaders['protocolVersion'],
+        draftProtocolVersion2026_07_28,
+      );
+      expect(capturedHeaders['method'], Method.tasksUpdate);
+      expect(capturedHeaders['name'], 'task-1');
+    });
+
     test('send mirrors mapped tool parameters into 2026 stateless headers',
         () async {
       final capturedHeaders = <String, String?>{};

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -1875,6 +1875,62 @@ void main() {
       expect(body['error']['message'], contains('Mcp-Name header value'));
     });
 
+    test('2026 stateless HTTP requires task id name header for task requests',
+        () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => "unused-session-id",
+          enableJsonResponse: true,
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      transport.onmessage = (message) {
+        if (message is JsonRpcUpdateTaskRequest) {
+          unawaited(
+            transport.send(
+              JsonRpcResponse(
+                id: message.id,
+                result: const TaskExtensionAcknowledgementResult().toJson(),
+              ),
+            ),
+          );
+        }
+      };
+
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+      final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+      request.headers
+        ..contentType = ContentType.json
+        ..set(HttpHeaders.acceptHeader, 'application/json, text/event-stream')
+        ..set('MCP-Protocol-Version', draftProtocolVersion2026_07_28)
+        ..set('Mcp-Method', Method.tasksUpdate);
+      request.write(
+        jsonEncode(
+          JsonRpcUpdateTaskRequest(
+            id: 4,
+            updateParams: const UpdateTaskRequest(
+              taskId: 'task-1',
+              inputResponses: {},
+            ),
+            meta: _statelessMeta(),
+          ),
+        ),
+      );
+
+      final response = await request.close();
+
+      expect(response.statusCode, HttpStatus.badRequest);
+      final body =
+          jsonDecode(await utf8.decodeStream(response)) as Map<String, dynamic>;
+      expect(body['id'], 4);
+      expect(body['error']['code'], ErrorCode.headerMismatch.value);
+      expect(body['error']['message'], contains('Mcp-Name header is required'));
+    });
+
     test('2026 stateless HTTP accepts matching standard and parameter headers',
         () async {
       final transport = StreamableHTTPServerTransport(


### PR DESCRIPTION
## Summary
- map tasks/get, tasks/update, and tasks/cancel to Mcp-Name from params.taskId for 2026 stateless HTTP requests
- enforce the same required task id name header on the Streamable HTTP server
- add client/server regression tests for task HTTP metadata routing

## Validation
- dart analyze
- dart test test/client/streamable_https_test.dart test/server/streamable_https_test.dart test/types/tasks_extension_test.dart
- dart test -j 1
- git diff --check