### PR TITLE
Enforce MCP 2026 task extension capabilities

### DIFF
--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -592,7 +592,7 @@ class _RegisteredToolImpl implements RegisteredTool {
     _server._registeredTools[name] = this;
   }
 
-  Tool toTool() {
+  Tool toTool({bool includeExecution = true}) {
     return Tool(
       name: name,
       title: title,
@@ -602,7 +602,7 @@ class _RegisteredToolImpl implements RegisteredTool {
       annotations: annotations,
       icon: icon,
       icons: _iconsFromLegacyImage(icon),
-      execution: execution,
+      execution: includeExecution ? execution : null,
       meta: meta,
     );
   }
@@ -1156,12 +1156,22 @@ class McpServer {
 
     server.setRequestHandler<JsonRpcListToolsRequest>(
       Method.toolsList,
-      (request, extra) async => ListToolsResult(
-        tools: _registeredTools.values
-            .where((t) => t.enabled)
-            .map((e) => e.toTool())
-            .toList(),
-      ),
+      (request, extra) async {
+        final protocolVersion = request.meta?[McpMetaKey.protocolVersion];
+        final includeLegacyTaskExecution = protocolVersion is! String ||
+            !isStatelessProtocolVersion(protocolVersion);
+
+        return ListToolsResult(
+          tools: _registeredTools.values
+              .where((t) => t.enabled)
+              .map(
+                (e) => e.toTool(
+                  includeExecution: includeLegacyTaskExecution,
+                ),
+              )
+              .toList(),
+        );
+      },
       (id, params, meta) => JsonRpcListToolsRequest.fromJson({
         'id': id,
         'params': params,
@@ -1201,7 +1211,10 @@ class McpServer {
         }
 
         try {
-          final isTaskRequest = request.isTaskAugmented;
+          final protocolVersion = request.meta?[McpMetaKey.protocolVersion];
+          final isStatelessRequest = protocolVersion is String &&
+              isStatelessProtocolVersion(protocolVersion);
+          final isTaskRequest = !isStatelessRequest && request.isTaskAugmented;
           final taskSupport =
               registeredTool.execution?.taskSupport ?? 'forbidden';
 
@@ -1220,14 +1233,23 @@ class McpServer {
           dynamic result;
           if (taskSupport == 'required') {
             if (!isTaskRequest) {
-              throw McpError(
-                ErrorCode.methodNotFound.value,
-                "Tool '$toolName' requires task augmentation (taskSupport: 'required')",
-              );
+              if (isStatelessRequest) {
+                result = await _handleAutomaticTaskPolling(
+                  registeredTool,
+                  toolArgs,
+                  extra,
+                );
+              } else {
+                throw McpError(
+                  ErrorCode.methodNotFound.value,
+                  "Tool '$toolName' requires task augmentation (taskSupport: 'required')",
+                );
+              }
+            } else {
+              final InterfaceToolCallback taskHandler =
+                  registeredTool.callback as InterfaceToolCallback;
+              result = await taskHandler.handler.createTask(toolArgs, extra);
             }
-            final InterfaceToolCallback taskHandler =
-                registeredTool.callback as InterfaceToolCallback;
-            result = await taskHandler.handler.createTask(toolArgs, extra);
           } else if (taskSupport == 'optional') {
             if (!isTaskRequest) {
               // Ensure we have a task handler for automatic polling (checked above, but safe cast)

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -184,33 +184,30 @@ class Server extends Protocol {
     return null;
   }
 
-  McpError? _validateTaskSubscriptionCapabilities(JsonRpcRequest request) {
-    if (request is! JsonRpcSubscriptionsListenRequest ||
-        request.listenParams.notifications.taskIds == null) {
-      return null;
-    }
-
+  ({ClientCapabilities? capabilities, McpError? error})
+      _clientCapabilitiesForRequest(JsonRpcRequest request) {
     final clientCapabilitiesValue =
         request.meta?[McpMetaKey.clientCapabilities];
-    final ClientCapabilities? clientCapabilities;
     try {
-      clientCapabilities = clientCapabilitiesValue is Map
+      final clientCapabilities = clientCapabilitiesValue is Map
           ? ClientCapabilities.fromJson(
               clientCapabilitiesValue.cast<String, dynamic>(),
             )
           : _clientCapabilities;
+      return (capabilities: clientCapabilities, error: null);
     } catch (error) {
-      return McpError(
-        ErrorCode.invalidRequest.value,
-        'Invalid request client capabilities metadata.',
-        error.toString(),
+      return (
+        capabilities: null,
+        error: McpError(
+          ErrorCode.invalidRequest.value,
+          'Invalid request client capabilities metadata.',
+          error.toString(),
+        ),
       );
     }
+  }
 
-    if (clientCapabilities?.supportsTasksExtension ?? false) {
-      return null;
-    }
-
+  McpError _missingTasksExtensionCapabilityError() {
     return McpError(
       ErrorCode.missingRequiredClientCapability.value,
       'Missing required client capability',
@@ -220,6 +217,101 @@ class Server extends Protocol {
         },
       },
     );
+  }
+
+  bool _isStatelessRequest(JsonRpcRequest request) {
+    final requestedProtocolVersion = request.meta?[McpMetaKey.protocolVersion];
+    return requestedProtocolVersion is String &&
+        isStatelessProtocolVersion(requestedProtocolVersion);
+  }
+
+  McpError? _validateDraftTaskMethods(JsonRpcRequest request) {
+    if (!_isStatelessRequest(request)) {
+      return null;
+    }
+
+    switch (request.method) {
+      case Method.tasksList:
+      case Method.tasksResult:
+        return McpError(
+          ErrorCode.methodNotFound.value,
+          '${request.method} is not part of the MCP Tasks extension.',
+        );
+    }
+
+    return null;
+  }
+
+  McpError? _validateTasksExtensionCapabilities(JsonRpcRequest request) {
+    final requiresTasksExtension =
+        (request is JsonRpcSubscriptionsListenRequest &&
+                request.listenParams.notifications.taskIds != null) ||
+            (_isStatelessRequest(request) &&
+                (request.method == Method.tasksGet ||
+                    request.method == Method.tasksCancel ||
+                    request.method == Method.tasksUpdate));
+
+    if (!requiresTasksExtension) {
+      return null;
+    }
+
+    final parsed = _clientCapabilitiesForRequest(request);
+    if (parsed.error != null) {
+      return parsed.error;
+    }
+
+    if (parsed.capabilities?.supportsTasksExtension ?? false) {
+      return null;
+    }
+
+    return _missingTasksExtensionCapabilityError();
+  }
+
+  void _assertTasksExtensionClientCapability(JsonRpcRequest request) {
+    final parsed = _clientCapabilitiesForRequest(request);
+    if (parsed.error != null) {
+      throw parsed.error!;
+    }
+    if (!(parsed.capabilities?.supportsTasksExtension ?? false)) {
+      throw _missingTasksExtensionCapabilityError();
+    }
+  }
+
+  McpError? _validateRequestTaskSemantics(JsonRpcRequest request) {
+    final removedMethodError = _validateDraftTaskMethods(request);
+    if (removedMethodError != null) {
+      return removedMethodError;
+    }
+
+    final extensionCapabilityError =
+        _validateTasksExtensionCapabilities(request);
+    if (extensionCapabilityError != null) {
+      return extensionCapabilityError;
+    }
+
+    return null;
+  }
+
+  bool _allowsToolCallResult(BaseResultData result, JsonRpcRequest request) {
+    if (result is CallToolResult) {
+      return true;
+    }
+    if (result is InputRequiredResult && _isStatelessRequest(request)) {
+      return true;
+    }
+    if (result is CreateTaskExtensionResult && _isStatelessRequest(request)) {
+      _assertTasksExtensionClientCapability(request);
+      return true;
+    }
+
+    return false;
+  }
+
+  bool _isLegacyTaskAugmentedRequest(JsonRpcCallToolRequest request) {
+    if (_isStatelessRequest(request)) {
+      return false;
+    }
+    return request.isTaskAugmented;
   }
 
   @override
@@ -244,7 +336,7 @@ class Server extends Protocol {
       if (metadataError != null) {
         return metadataError;
       }
-      return _validateTaskSubscriptionCapabilities(request);
+      return _validateRequestTaskSemantics(request);
     }
 
     if (request.method == Method.initialize) {
@@ -275,7 +367,7 @@ class Server extends Protocol {
       );
     }
 
-    return _validateTaskSubscriptionCapabilities(request);
+    return _validateRequestTaskSemantics(request);
   }
 
   @override
@@ -393,8 +485,10 @@ class Server extends Protocol {
         // Run the original handler
         final result = await handler(request, extra);
 
-        // Validate the result based on whether it's a task-augmented request
-        if (request is JsonRpcCallToolRequest && request.isTaskAugmented) {
+        // Validate the result based on whether it's a legacy task-augmented
+        // request. The stateless task extension ignores the old `task` hint.
+        if (request is JsonRpcCallToolRequest &&
+            _isLegacyTaskAugmentedRequest(request)) {
           if (result is! CreateTaskResult) {
             throw McpError(
               ErrorCode.invalidParams.value,
@@ -402,7 +496,7 @@ class Server extends Protocol {
             );
           }
         } else {
-          if (result is! CallToolResult) {
+          if (!_allowsToolCallResult(result, request)) {
             throw McpError(
               ErrorCode.invalidParams.value,
               "Invalid tools/call result: Expected CallToolResult",
@@ -437,11 +531,17 @@ class Server extends Protocol {
     );
   }
 
+  ServerCapabilities _discoveryCapabilities() {
+    final json = getCapabilities().toJson();
+    json.remove('tasks');
+    return ServerCapabilities.fromJson(json);
+  }
+
   /// Handles the client's `server/discover` request.
   Future<DiscoverResult> _onDiscover() async {
     return DiscoverResult(
       supportedVersions: supportedProtocolVersionsWithDraft,
-      capabilities: getCapabilities(),
+      capabilities: _discoveryCapabilities(),
       serverInfo: _serverInfo,
       instructions: _instructions,
     );
@@ -654,11 +754,18 @@ class Server extends Protocol {
 
       case Method.tasksCancel:
       case Method.tasksGet:
-      case Method.tasksUpdate:
         if (!(_capabilities.tasks != null ||
             _capabilities.supportsTasksExtension)) {
           throw StateError(
             "Server setup error: Cannot handle '$method' without 'tasks' capability or '$mcpTasksExtensionId' extension",
+          );
+        }
+        break;
+
+      case Method.tasksUpdate:
+        if (!_capabilities.supportsTasksExtension) {
+          throw StateError(
+            "Server setup error: Cannot handle '$method' without '$mcpTasksExtensionId' extension",
           );
         }
         break;

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
 
 import 'package:mcp_dart/src/client/client.dart';
+import 'package:mcp_dart/src/server/mcp_server.dart';
 import 'package:mcp_dart/src/server/server.dart';
+import 'package:mcp_dart/src/server/tasks/handler.dart';
+import 'package:mcp_dart/src/shared/protocol.dart';
 import 'package:mcp_dart/src/shared/transport.dart';
 import 'package:mcp_dart/src/types.dart';
 import 'package:test/test.dart';
@@ -139,6 +142,48 @@ class LegacyFallbackTransport extends Transport
 
   @override
   Future<void> start() async {}
+}
+
+class CompletedTaskHandler extends CancelTaskResultHandler {
+  @override
+  Future<CreateTaskResult> createTask(
+    Map<String, dynamic>? args,
+    RequestHandlerExtra? extra,
+  ) async =>
+      const CreateTaskResult(
+        task: Task(
+          taskId: 'task-1',
+          status: TaskStatus.completed,
+          ttl: null,
+          createdAt: '2026-07-28T00:00:00Z',
+          lastUpdatedAt: '2026-07-28T00:01:00Z',
+        ),
+      );
+
+  @override
+  Future<Task> getTask(String taskId, RequestHandlerExtra? extra) async => Task(
+        taskId: taskId,
+        status: TaskStatus.completed,
+        ttl: null,
+        createdAt: '2026-07-28T00:00:00Z',
+        lastUpdatedAt: '2026-07-28T00:01:00Z',
+      );
+
+  @override
+  Future<Task> cancelTaskWithResult(
+    String taskId,
+    RequestHandlerExtra? extra,
+  ) =>
+      getTask(taskId, extra);
+
+  @override
+  Future<CallToolResult> getTaskResult(
+    String taskId,
+    RequestHandlerExtra? extra,
+  ) async =>
+      const CallToolResult(
+        content: [TextContent(text: 'task complete')],
+      );
 }
 
 Map<String, dynamic> _clientMeta({
@@ -501,6 +546,363 @@ void main() {
         response.error.data['requiredCapabilities']['extensions']
             [mcpTasksExtensionId],
         isEmpty,
+      );
+    });
+
+    test('server rejects task extension methods without client capability',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            extensions: {mcpTasksExtensionId: {}},
+          ),
+        ),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport
+        ..receive(
+          JsonRpcGetTaskRequest(
+            id: 'get-task',
+            getParams: const GetTaskRequest(taskId: 'task-1'),
+            meta: _clientMeta(),
+          ),
+        )
+        ..receive(
+          JsonRpcCancelTaskRequest(
+            id: 'cancel-task',
+            cancelParams: const CancelTaskRequest(taskId: 'task-1'),
+            meta: _clientMeta(),
+          ),
+        )
+        ..receive(
+          JsonRpcUpdateTaskRequest(
+            id: 'update-task',
+            updateParams: const UpdateTaskRequest(
+              taskId: 'task-1',
+              inputResponses: {},
+            ),
+            meta: _clientMeta(),
+          ),
+        );
+      await _pump();
+
+      final errors = transport.sentMessages.cast<JsonRpcError>();
+      expect(
+        errors.map((response) => response.error.code),
+        everyElement(ErrorCode.missingRequiredClientCapability.value),
+      );
+      expect(
+        errors.first.error.data['requiredCapabilities']['extensions']
+            [mcpTasksExtensionId],
+        isEmpty,
+      );
+    });
+
+    test('server rejects removed legacy task methods in stateless protocol',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            tasks: ServerCapabilitiesTasks(list: true),
+            extensions: {mcpTasksExtensionId: {}},
+          ),
+        ),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+      final taskExtensionMeta = _clientMeta(
+        clientCapabilities: const ClientCapabilities(
+          extensions: {mcpTasksExtensionId: {}},
+        ),
+      );
+
+      transport
+        ..receive(
+          JsonRpcListTasksRequest(id: 'list-tasks', meta: taskExtensionMeta),
+        )
+        ..receive(
+          JsonRpcTaskResultRequest(
+            id: 'task-result',
+            resultParams: const TaskResultRequest(taskId: 'task-1'),
+            meta: taskExtensionMeta,
+          ),
+        );
+      await _pump();
+
+      final errors = transport.sentMessages.cast<JsonRpcError>();
+      expect(
+        errors.map((response) => response.error.code),
+        everyElement(ErrorCode.methodNotFound.value),
+      );
+      expect(errors.first.error.message, contains('MCP Tasks extension'));
+    });
+
+    test('server/discover omits legacy task capabilities', () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            tasks: ServerCapabilitiesTasks(
+              list: true,
+              requests: ServerCapabilitiesTasksRequests(
+                tools: ServerCapabilitiesTasksTools(
+                  call: ServerCapabilitiesTasksToolsCall(),
+                ),
+              ),
+            ),
+            extensions: {mcpTasksExtensionId: {}},
+          ),
+        ),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcServerDiscoverRequest(id: 'discover-1', meta: _clientMeta()),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      final capabilities = response.result['capabilities'] as Map;
+      expect(capabilities, isNot(contains('tasks')));
+      expect(
+        (capabilities['extensions'] as Map)[mcpTasksExtensionId],
+        isEmpty,
+      );
+    });
+
+    test('stateless tools/call ignores legacy task parameter', () async {
+      final server = McpServer(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+      server.registerTool(
+        'echo',
+        callback: (args, extra) => const CallToolResult(
+          content: [TextContent(text: 'ok')],
+        ),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcCallToolRequest(
+          id: 'call-1',
+          params: {
+            ...const CallToolRequest(name: 'echo').toJson(),
+            'task': {'ttl': 1000},
+          },
+          meta: _clientMeta(),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      expect(response.result['content'][0]['text'], 'ok');
+    });
+
+    test('stateless tools/call permits extension task creation results',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            tools: ServerCapabilitiesTools(),
+            extensions: {mcpTasksExtensionId: {}},
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcCallToolRequest>(
+        Method.toolsCall,
+        (request, extra) async => const CreateTaskExtensionResult(
+          task: TaskExtensionTask(
+            taskId: 'task-1',
+            status: TaskStatus.working,
+            createdAt: '2026-07-28T00:00:00Z',
+            lastUpdatedAt: '2026-07-28T00:00:00Z',
+            ttlMs: null,
+          ),
+        ),
+        (id, params, meta) => JsonRpcCallToolRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcCallToolRequest(
+          id: 'call-1',
+          params: const CallToolRequest(name: 'long').toJson(),
+          meta: _clientMeta(
+            clientCapabilities: const ClientCapabilities(
+              extensions: {mcpTasksExtensionId: {}},
+            ),
+          ),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      expect(response.result['resultType'], resultTypeTask);
+      expect(response.result['taskId'], 'task-1');
+    });
+
+    test(
+        'stateless tools/call rejects task extension result without capability',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            tools: ServerCapabilitiesTools(),
+            extensions: {mcpTasksExtensionId: {}},
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcCallToolRequest>(
+        Method.toolsCall,
+        (request, extra) async => const CreateTaskExtensionResult(
+          task: TaskExtensionTask(
+            taskId: 'task-1',
+            status: TaskStatus.working,
+            createdAt: '2026-07-28T00:00:00Z',
+            lastUpdatedAt: '2026-07-28T00:00:00Z',
+            ttlMs: null,
+          ),
+        ),
+        (id, params, meta) => JsonRpcCallToolRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcCallToolRequest(
+          id: 'call-1',
+          params: const CallToolRequest(name: 'long').toJson(),
+          meta: _clientMeta(),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcError;
+      expect(
+        response.error.code,
+        ErrorCode.missingRequiredClientCapability.value,
+      );
+    });
+
+    test('stateless tools/call permits input required results', () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(tools: ServerCapabilitiesTools()),
+        ),
+      );
+      server.setRequestHandler<JsonRpcCallToolRequest>(
+        Method.toolsCall,
+        (request, extra) async =>
+            const InputRequiredResult(requestState: 'retry-state'),
+        (id, params, meta) => JsonRpcCallToolRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcCallToolRequest(
+          id: 'call-1',
+          params: const CallToolRequest(name: 'needs-input').toJson(),
+          meta: _clientMeta(),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      expect(response.result['resultType'], resultTypeInputRequired);
+      expect(response.result['requestState'], 'retry-state');
+    });
+
+    test('stateless required legacy task tool resolves to final result',
+        () async {
+      final server = McpServer(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+      server.experimental.registerToolTask(
+        'long',
+        handler: CompletedTaskHandler(),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcCallToolRequest(
+          id: 'call-1',
+          params: const CallToolRequest(name: 'long').toJson(),
+          meta: _clientMeta(),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      expect(response.result['content'][0]['text'], 'task complete');
+    });
+
+    test('stateless tools/list omits legacy task execution metadata', () async {
+      final server = McpServer(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+      server.registerTool(
+        'echo',
+        callback: (args, extra) => const CallToolResult(
+          content: [TextContent(text: 'ok')],
+        ),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport
+          .receive(JsonRpcListToolsRequest(id: 'tools', meta: _clientMeta()));
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      final tool = (response.result['tools'] as List).single as Map;
+      expect(tool, isNot(contains('execution')));
+    });
+
+    test('tasks/update handler requires task extension capability', () {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            tasks: ServerCapabilitiesTasks(),
+          ),
+        ),
+      );
+
+      expect(
+        () => server.setRequestHandler<JsonRpcUpdateTaskRequest>(
+          Method.tasksUpdate,
+          (request, extra) async => const TaskExtensionAcknowledgementResult(),
+          (id, params, meta) => JsonRpcUpdateTaskRequest.fromJson({
+            'id': id,
+            'params': params,
+            if (meta != null) '_meta': meta,
+          }),
+        ),
+        throwsStateError,
       );
     });
 


### PR DESCRIPTION
## Summary
- enforce task extension capability checks for stateless tasks/get, tasks/update, tasks/cancel, and task subscriptions
- reject removed legacy tasks/list and tasks/result methods under stateless MCP 2026 metadata
- keep legacy task execution metadata and task request hints out of stateless tool flows

## Spec context
- SEP-2663 Tasks Extension: https://modelcontextprotocol.io/seps/2663-tasks-extension
- Tasks extension overview: https://modelcontextprotocol.io/extensions/tasks/overview
- MCP 2025-11-25 tasks: https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks

## Validation
- dart format .
- dart analyze
- dart test test/mcp_2026_07_28_test.dart
- dart test test/mcp_2025_11_25_test.dart test/server/tasks_test.dart test/client/task_client_test.dart test/types/tasks_extension_test.dart
- dart test -j 1
- git diff --check