### PR TITLE
Add MCP 2026 cacheable result hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Added opt-in client discovery via `McpClientOptions(useServerDiscover: true)`
   while keeping the stable `initialize` flow as the default until the 2026
   stateless transport and MRTR implementation is complete.
+- Added 2026 cacheable result support for `tools/list`, `prompts/list`,
+  `resources/list`, `resources/templates/list`, and `resources/read`, including
+  stateless server defaults for `resultType`, `ttlMs`, and `cacheScope` while
+  keeping legacy result serialization unchanged unless cache hints are set.
 
 ## 2.2.0
 

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -436,6 +436,45 @@ class Server extends Protocol {
     }
   }
 
+  bool _requiresCacheableResult(String method) {
+    return switch (method) {
+      Method.toolsList ||
+      Method.promptsList ||
+      Method.resourcesList ||
+      Method.resourcesTemplatesList ||
+      Method.resourcesRead =>
+        true,
+      _ => false,
+    };
+  }
+
+  @override
+  Map<String, dynamic> serializeIncomingResult(
+    JsonRpcRequest request,
+    BaseResultData result,
+  ) {
+    final json = super.serializeIncomingResult(request, result);
+    if (!_isStatelessRequest(request)) {
+      return json;
+    }
+
+    json.putIfAbsent('resultType', () => resultTypeComplete);
+    if (_requiresCacheableResult(request.method)) {
+      json.putIfAbsent(
+        'ttlMs',
+        () => result is CacheableResultData ? result.ttlMs ?? 0 : 0,
+      );
+      json.putIfAbsent(
+        'cacheScope',
+        () => result is CacheableResultData
+            ? result.cacheScope ?? CacheScope.private
+            : CacheScope.private,
+      );
+    }
+
+    return json;
+  }
+
   @override
   void onConnectionClosed() {
     _resetSessionState();

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -899,6 +899,14 @@ abstract class Protocol {
   @protected
   void onIncomingRequestFailed(JsonRpcRequest request, Object error) {}
 
+  /// Converts a handler result into the JSON object sent on the wire.
+  @protected
+  Map<String, dynamic> serializeIncomingResult(
+    JsonRpcRequest request,
+    BaseResultData result,
+  ) =>
+      result.toJson();
+
   /// Subclass hook called after protocol-owned state has been cleared for a
   /// closed transport.
   @protected
@@ -1159,7 +1167,7 @@ abstract class Protocol {
 
         final response = JsonRpcResponse(
           id: request.id,
-          result: result.toJson(),
+          result: serializeIncomingResult(request, result),
           meta: _mergeRelatedTaskMeta(result.meta, relatedTaskJson),
         );
 

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -540,6 +540,23 @@ abstract class BaseResultData {
   Map<String, dynamic> toJson();
 }
 
+/// Result data that carries MCP cache freshness hints.
+abstract class CacheableResultData implements BaseResultData {
+  /// How long, in milliseconds, the client may consider this result fresh.
+  int? get ttlMs;
+
+  /// Intended cache visibility: [CacheScope.public] or [CacheScope.private].
+  String? get cacheScope;
+}
+
+/// Allowed cache scopes for MCP cacheable results.
+class CacheScope {
+  static const public = 'public';
+  static const private = 'private';
+
+  const CacheScope._();
+}
+
 /// Result type for completed MCP requests.
 const resultTypeComplete = 'complete';
 

--- a/lib/src/types/prompts.dart
+++ b/lib/src/types/prompts.dart
@@ -143,18 +143,32 @@ class JsonRpcListPromptsRequest extends JsonRpcRequest {
 }
 
 /// Result data for a successful `prompts/list` request.
-class ListPromptsResult implements BaseResultData {
+class ListPromptsResult implements CacheableResultData {
   /// The list of prompts/templates found.
   final List<Prompt> prompts;
 
   /// Opaque token for pagination.
   final Cursor? nextCursor;
 
+  /// How long, in milliseconds, the client may consider this result fresh.
+  @override
+  final int? ttlMs;
+
+  /// Intended cache visibility: `public` or `private`.
+  @override
+  final String? cacheScope;
+
   /// Optional metadata.
   @override
   final Map<String, dynamic>? meta;
 
-  const ListPromptsResult({required this.prompts, this.nextCursor, this.meta});
+  const ListPromptsResult({
+    required this.prompts,
+    this.nextCursor,
+    this.ttlMs,
+    this.cacheScope,
+    this.meta,
+  });
 
   factory ListPromptsResult.fromJson(Map<String, dynamic> json) {
     final meta = json['_meta'] as Map<String, dynamic>?;
@@ -167,16 +181,27 @@ class ListPromptsResult implements BaseResultData {
           .map((p) => Prompt.fromJson(p as Map<String, dynamic>))
           .toList(),
       nextCursor: json['nextCursor'] as String?,
+      ttlMs: readOptionalTtlMs(json['ttlMs'], 'ListPromptsResult.ttlMs'),
+      cacheScope: readOptionalCacheScope(
+        json['cacheScope'],
+        'ListPromptsResult.cacheScope',
+      ),
       meta: meta,
     );
   }
 
   @override
-  Map<String, dynamic> toJson() => {
-        'prompts': prompts.map((p) => p.toJson()).toList(),
-        if (nextCursor != null) 'nextCursor': nextCursor,
-        if (meta != null) '_meta': meta,
-      };
+  Map<String, dynamic> toJson() {
+    validateTtlMs(ttlMs, 'ListPromptsResult.ttlMs');
+    validateCacheScope(cacheScope, 'ListPromptsResult.cacheScope');
+    return {
+      'prompts': prompts.map((p) => p.toJson()).toList(),
+      if (nextCursor != null) 'nextCursor': nextCursor,
+      if (ttlMs != null) 'ttlMs': ttlMs,
+      if (cacheScope != null) 'cacheScope': cacheScope,
+      if (meta != null) '_meta': meta,
+    };
+  }
 }
 
 /// Parameters for the `prompts/get` request.

--- a/lib/src/types/resources.dart
+++ b/lib/src/types/resources.dart
@@ -261,12 +261,20 @@ class JsonRpcListResourcesRequest extends JsonRpcRequest {
 }
 
 /// Result data for a successful `resources/list` request.
-class ListResourcesResult implements BaseResultData {
+class ListResourcesResult implements CacheableResultData {
   /// The list of resources found.
   final List<Resource> resources;
 
   /// Opaque token for pagination, indicating more results might be available.
   final Cursor? nextCursor;
+
+  /// How long, in milliseconds, the client may consider this result fresh.
+  @override
+  final int? ttlMs;
+
+  /// Intended cache visibility: `public` or `private`.
+  @override
+  final String? cacheScope;
 
   /// Optional metadata.
   @override
@@ -276,6 +284,8 @@ class ListResourcesResult implements BaseResultData {
   const ListResourcesResult({
     required this.resources,
     this.nextCursor,
+    this.ttlMs,
+    this.cacheScope,
     this.meta,
   });
 
@@ -291,17 +301,28 @@ class ListResourcesResult implements BaseResultData {
           .map((e) => Resource.fromJson(e as Map<String, dynamic>))
           .toList(),
       nextCursor: json['nextCursor'] as String?,
+      ttlMs: readOptionalTtlMs(json['ttlMs'], 'ListResourcesResult.ttlMs'),
+      cacheScope: readOptionalCacheScope(
+        json['cacheScope'],
+        'ListResourcesResult.cacheScope',
+      ),
       meta: meta,
     );
   }
 
   /// Converts to JSON (excluding meta).
   @override
-  Map<String, dynamic> toJson() => {
-        'resources': resources.map((r) => r.toJson()).toList(),
-        if (nextCursor != null) 'nextCursor': nextCursor,
-        if (meta != null) '_meta': meta,
-      };
+  Map<String, dynamic> toJson() {
+    validateTtlMs(ttlMs, 'ListResourcesResult.ttlMs');
+    validateCacheScope(cacheScope, 'ListResourcesResult.cacheScope');
+    return {
+      'resources': resources.map((r) => r.toJson()).toList(),
+      if (nextCursor != null) 'nextCursor': nextCursor,
+      if (ttlMs != null) 'ttlMs': ttlMs,
+      if (cacheScope != null) 'cacheScope': cacheScope,
+      if (meta != null) '_meta': meta,
+    };
+  }
 }
 
 /// Parameters for the `resources/templates/list` request. Includes pagination.
@@ -347,12 +368,20 @@ class JsonRpcListResourceTemplatesRequest extends JsonRpcRequest {
 }
 
 /// Result data for a successful `resources/templates/list` request.
-class ListResourceTemplatesResult implements BaseResultData {
+class ListResourceTemplatesResult implements CacheableResultData {
   /// The list of resource templates found.
   final List<ResourceTemplate> resourceTemplates;
 
   /// Opaque token for pagination.
   final Cursor? nextCursor;
+
+  /// How long, in milliseconds, the client may consider this result fresh.
+  @override
+  final int? ttlMs;
+
+  /// Intended cache visibility: `public` or `private`.
+  @override
+  final String? cacheScope;
 
   @override
   final Map<String, dynamic>? meta;
@@ -360,6 +389,8 @@ class ListResourceTemplatesResult implements BaseResultData {
   const ListResourceTemplatesResult({
     required this.resourceTemplates,
     this.nextCursor,
+    this.ttlMs,
+    this.cacheScope,
     this.meta,
   });
 
@@ -376,16 +407,30 @@ class ListResourceTemplatesResult implements BaseResultData {
           .map((e) => ResourceTemplate.fromJson(e as Map<String, dynamic>))
           .toList(),
       nextCursor: json['nextCursor'] as String?,
+      ttlMs: readOptionalTtlMs(
+        json['ttlMs'],
+        'ListResourceTemplatesResult.ttlMs',
+      ),
+      cacheScope: readOptionalCacheScope(
+        json['cacheScope'],
+        'ListResourceTemplatesResult.cacheScope',
+      ),
       meta: meta,
     );
   }
 
   @override
-  Map<String, dynamic> toJson() => {
-        'resourceTemplates': resourceTemplates.map((t) => t.toJson()).toList(),
-        if (nextCursor != null) 'nextCursor': nextCursor,
-        if (meta != null) '_meta': meta,
-      };
+  Map<String, dynamic> toJson() {
+    validateTtlMs(ttlMs, 'ListResourceTemplatesResult.ttlMs');
+    validateCacheScope(cacheScope, 'ListResourceTemplatesResult.cacheScope');
+    return {
+      'resourceTemplates': resourceTemplates.map((t) => t.toJson()).toList(),
+      if (nextCursor != null) 'nextCursor': nextCursor,
+      if (ttlMs != null) 'ttlMs': ttlMs,
+      if (cacheScope != null) 'cacheScope': cacheScope,
+      if (meta != null) '_meta': meta,
+    };
+  }
 }
 
 /// Parameters for the `resources/read` request.
@@ -452,14 +497,27 @@ class JsonRpcReadResourceRequest extends JsonRpcRequest {
 }
 
 /// Result data for a successful `resources/read` request.
-class ReadResourceResult implements BaseResultData {
+class ReadResourceResult implements CacheableResultData {
   /// The contents of the resource (can be multiple parts).
   final List<ResourceContents> contents;
+
+  /// How long, in milliseconds, the client may consider this result fresh.
+  @override
+  final int? ttlMs;
+
+  /// Intended cache visibility: `public` or `private`.
+  @override
+  final String? cacheScope;
 
   @override
   final Map<String, dynamic>? meta;
 
-  const ReadResourceResult({required this.contents, this.meta});
+  const ReadResourceResult({
+    required this.contents,
+    this.ttlMs,
+    this.cacheScope,
+    this.meta,
+  });
 
   factory ReadResourceResult.fromJson(Map<String, dynamic> json) {
     final meta = json['_meta'] as Map<String, dynamic>?;
@@ -471,15 +529,26 @@ class ReadResourceResult implements BaseResultData {
       contents: contents
           .map((e) => ResourceContents.fromJson(e as Map<String, dynamic>))
           .toList(),
+      ttlMs: readOptionalTtlMs(json['ttlMs'], 'ReadResourceResult.ttlMs'),
+      cacheScope: readOptionalCacheScope(
+        json['cacheScope'],
+        'ReadResourceResult.cacheScope',
+      ),
       meta: meta,
     );
   }
 
   @override
-  Map<String, dynamic> toJson() => {
-        'contents': contents.map((c) => c.toJson()).toList(),
-        if (meta != null) '_meta': meta,
-      };
+  Map<String, dynamic> toJson() {
+    validateTtlMs(ttlMs, 'ReadResourceResult.ttlMs');
+    validateCacheScope(cacheScope, 'ReadResourceResult.cacheScope');
+    return {
+      'contents': contents.map((c) => c.toJson()).toList(),
+      if (ttlMs != null) 'ttlMs': ttlMs,
+      if (cacheScope != null) 'cacheScope': cacheScope,
+      if (meta != null) '_meta': meta,
+    };
+  }
 }
 
 /// Notification from server indicating the list of available resources has changed.

--- a/lib/src/types/tools.dart
+++ b/lib/src/types/tools.dart
@@ -271,12 +271,20 @@ class ListToolsRequest {
 typedef ListToolsRequestParams = ListToolsRequest;
 
 /// The server's response to a [ListToolsRequest].
-class ListToolsResult implements BaseResultData {
+class ListToolsResult implements CacheableResultData {
   /// A list of tools.
   final List<Tool> tools;
 
   /// An opaque token for pagination.
   final String? nextCursor;
+
+  /// How long, in milliseconds, the client may consider this result fresh.
+  @override
+  final int? ttlMs;
+
+  /// Intended cache visibility: `public` or `private`.
+  @override
+  final String? cacheScope;
 
   /// Optional metadata.
   @override
@@ -285,6 +293,8 @@ class ListToolsResult implements BaseResultData {
   const ListToolsResult({
     required this.tools,
     this.nextCursor,
+    this.ttlMs,
+    this.cacheScope,
     this.meta,
   });
 
@@ -297,16 +307,27 @@ class ListToolsResult implements BaseResultData {
       tools:
           tools.map((e) => Tool.fromJson(e as Map<String, dynamic>)).toList(),
       nextCursor: json['nextCursor'] as String?,
+      ttlMs: readOptionalTtlMs(json['ttlMs'], 'ListToolsResult.ttlMs'),
+      cacheScope: readOptionalCacheScope(
+        json['cacheScope'],
+        'ListToolsResult.cacheScope',
+      ),
       meta: json['_meta'] as Map<String, dynamic>?,
     );
   }
 
   @override
-  Map<String, dynamic> toJson() => {
-        'tools': tools.map((e) => e.toJson()).toList(),
-        if (nextCursor != null) 'nextCursor': nextCursor,
-        if (meta != null) '_meta': meta,
-      };
+  Map<String, dynamic> toJson() {
+    validateTtlMs(ttlMs, 'ListToolsResult.ttlMs');
+    validateCacheScope(cacheScope, 'ListToolsResult.cacheScope');
+    return {
+      'tools': tools.map((e) => e.toJson()).toList(),
+      if (nextCursor != null) 'nextCursor': nextCursor,
+      if (ttlMs != null) 'ttlMs': ttlMs,
+      if (cacheScope != null) 'cacheScope': cacheScope,
+      if (meta != null) '_meta': meta,
+    };
+  }
 }
 
 @Deprecated('Use [CallToolRequest] instead.')

--- a/lib/src/types/validation.dart
+++ b/lib/src/types/validation.dart
@@ -43,3 +43,48 @@ String? readOptionalString(Object? value, String field) {
   }
   throw FormatException('$field must be a string');
 }
+
+int? readOptionalTtlMs(Object? value, String field) {
+  final ttlMs = readOptionalInteger(value, field);
+  if (ttlMs == null) {
+    return null;
+  }
+  return ttlMs < 0 ? 0 : ttlMs;
+}
+
+void validateTtlMs(int? value, String field) {
+  if (value == null) {
+    return;
+  }
+  if (value < 0) {
+    throw ArgumentError.value(
+      value,
+      field,
+      'must be greater than or equal to 0',
+    );
+  }
+}
+
+String? readOptionalCacheScope(Object? value, String field) {
+  final scope = readOptionalString(value, field);
+  if (scope == null) {
+    return null;
+  }
+  if (scope == 'public' || scope == 'private') {
+    return scope;
+  }
+  throw FormatException('$field must be either "public" or "private"');
+}
+
+void validateCacheScope(String? value, String field) {
+  if (value == null) {
+    return;
+  }
+  if (value != 'public' && value != 'private') {
+    throw ArgumentError.value(
+      value,
+      field,
+      'must be either "public" or "private"',
+    );
+  }
+}

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -268,6 +268,91 @@ void main() {
       );
     });
 
+    test('serializes cacheable result hints without changing legacy defaults',
+        () {
+      final toolsJson = const ListToolsResult(
+        tools: [],
+        ttlMs: 300000,
+        cacheScope: CacheScope.public,
+      ).toJson();
+      expect(toolsJson['ttlMs'], 300000);
+      expect(toolsJson['cacheScope'], CacheScope.public);
+      expect(toolsJson, isNot(contains('resultType')));
+      final parsedTools = ListToolsResult.fromJson(toolsJson);
+      expect(parsedTools.ttlMs, 300000);
+      expect(parsedTools.cacheScope, CacheScope.public);
+
+      final promptsJson = const ListPromptsResult(
+        prompts: [],
+        ttlMs: 600000,
+        cacheScope: CacheScope.private,
+      ).toJson();
+      expect(ListPromptsResult.fromJson(promptsJson).ttlMs, 600000);
+      expect(
+        ListPromptsResult.fromJson(promptsJson).cacheScope,
+        CacheScope.private,
+      );
+
+      final resourcesJson = const ListResourcesResult(
+        resources: [],
+        ttlMs: 120000,
+        cacheScope: CacheScope.public,
+      ).toJson();
+      expect(ListResourcesResult.fromJson(resourcesJson).ttlMs, 120000);
+      expect(
+        ListResourcesResult.fromJson(resourcesJson).cacheScope,
+        CacheScope.public,
+      );
+
+      final templatesJson = const ListResourceTemplatesResult(
+        resourceTemplates: [],
+        ttlMs: 30000,
+        cacheScope: CacheScope.public,
+      ).toJson();
+      expect(
+        ListResourceTemplatesResult.fromJson(templatesJson).ttlMs,
+        30000,
+      );
+      expect(
+        ListResourceTemplatesResult.fromJson(templatesJson).cacheScope,
+        CacheScope.public,
+      );
+
+      final readJson = const ReadResourceResult(
+        contents: [TextResourceContents(uri: 'file:///a.txt', text: 'a')],
+        ttlMs: 60000,
+        cacheScope: CacheScope.private,
+      ).toJson();
+      expect(ReadResourceResult.fromJson(readJson).ttlMs, 60000);
+      expect(
+        ReadResourceResult.fromJson(readJson).cacheScope,
+        CacheScope.private,
+      );
+
+      expect(const ListToolsResult(tools: []).toJson(), {'tools': []});
+      expect(
+        ListToolsResult.fromJson(const {'tools': [], 'ttlMs': -1}).ttlMs,
+        0,
+      );
+      expect(
+        () => ListToolsResult.fromJson(
+          const {'tools': [], 'cacheScope': 'shared'},
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => const ListToolsResult(tools: [], ttlMs: -1).toJson(),
+        throwsArgumentError,
+      );
+      expect(
+        () => const ListToolsResult(
+          tools: [],
+          cacheScope: 'shared',
+        ).toJson(),
+        throwsArgumentError,
+      );
+    });
+
     test('serializes MRTR input required results', () {
       final result = InputRequiredResult(
         inputRequests: {
@@ -502,6 +587,105 @@ void main() {
         },
       );
       expect(transport.sentMessages.last, isA<JsonRpcResponse>());
+    });
+
+    test('stateless server responses add complete result and cache defaults',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            prompts: ServerCapabilitiesPrompts(),
+            resources: ServerCapabilitiesResources(),
+            tools: ServerCapabilitiesTools(),
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcListToolsRequest>(
+        Method.toolsList,
+        (request, extra) async => const ListToolsResult(
+          tools: [],
+          ttlMs: 300000,
+          cacheScope: CacheScope.public,
+        ),
+        (id, params, meta) => JsonRpcListToolsRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      server.setRequestHandler<JsonRpcListPromptsRequest>(
+        Method.promptsList,
+        (request, extra) async => const ListPromptsResult(prompts: []),
+        (id, params, meta) => JsonRpcListPromptsRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      server.setRequestHandler<JsonRpcListResourcesRequest>(
+        Method.resourcesList,
+        (request, extra) async => const ListResourcesResult(resources: []),
+        (id, params, meta) => JsonRpcListResourcesRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      server.setRequestHandler<JsonRpcListResourceTemplatesRequest>(
+        Method.resourcesTemplatesList,
+        (request, extra) async =>
+            const ListResourceTemplatesResult(resourceTemplates: []),
+        (id, params, meta) => JsonRpcListResourceTemplatesRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      server.setRequestHandler<JsonRpcReadResourceRequest>(
+        Method.resourcesRead,
+        (request, extra) async => const ReadResourceResult(
+          contents: [TextResourceContents(uri: 'file:///a.txt', text: 'a')],
+        ),
+        (id, params, meta) => JsonRpcReadResourceRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      final requests = [
+        JsonRpcListToolsRequest(id: 'tools', meta: _clientMeta()),
+        JsonRpcListPromptsRequest(id: 'prompts', meta: _clientMeta()),
+        JsonRpcListResourcesRequest(id: 'resources', meta: _clientMeta()),
+        JsonRpcListResourceTemplatesRequest(
+          id: 'templates',
+          meta: _clientMeta(),
+        ),
+        JsonRpcReadResourceRequest(
+          id: 'read',
+          readParams: const ReadResourceRequest(uri: 'file:///a.txt'),
+          meta: _clientMeta(),
+        ),
+      ];
+      for (final request in requests) {
+        transport.receive(request);
+        await _pump();
+      }
+
+      final responses = transport.sentMessages.cast<JsonRpcResponse>().toList();
+      final tools = responses[0].result;
+      expect(tools['resultType'], resultTypeComplete);
+      expect(tools['ttlMs'], 300000);
+      expect(tools['cacheScope'], CacheScope.public);
+
+      for (final response in responses.skip(1)) {
+        expect(response.result['resultType'], resultTypeComplete);
+        expect(response.result['ttlMs'], 0);
+        expect(response.result['cacheScope'], CacheScope.private);
+      }
     });
 
     test('server rejects task subscriptions without task extension capability',


### PR DESCRIPTION
## Summary
- add optional cacheable result fields (ttlMs/cacheScope) to tools, prompts, resources, resource templates, and resource reads
- inject 2026 stateless server defaults for resultType, ttlMs, and cacheScope on cacheable operations while preserving legacy result JSON when hints are unset
- cover explicit hints, legacy default serialization, negative/invalid cache metadata handling, and stateless server wire defaults

## Spec context
- MCP draft caching requires cache hints on tools/list, prompts/list, resources/list, resources/templates/list, and resources/read
- 2026 stateless result examples use resultType: complete for completed results

## Validation
- dart format .
- dart analyze
- dart test test/mcp_2026_07_28_test.dart
- dart test test/mcp_2026_07_28_test.dart test/mcp_2025_11_25_test.dart test/types/resources_test.dart test/types_test.dart test/tool_schema_test.dart test/client/client_test.dart
- dart test -j 1
- git diff --check