### PR TITLE
Validate MCP 2026 tool parameter headers on servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
   (`initialize`, `ping`, `logging/setLevel`, `resources/subscribe`,
   `resources/unsubscribe`, `notifications/initialized`, and
   `notifications/roots/list_changed`) while preserving legacy session behavior.
+- Synced registered tool `x-mcp-header` metadata into Streamable HTTP server
+  transports so 2026 stateless `tools/call` requests reject missing or
+  mismatched `Mcp-Param-*` argument headers.
 - Added request-scoped stateless logging gating via
   `io.modelcontextprotocol/logLevel` metadata so 2026 log notifications are
   emitted only when the current request opts in.

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -972,6 +972,7 @@ class McpServer {
 
   /// Connects the server to a communication [transport].
   Future<void> connect(Transport transport) async {
+    _syncToolParameterHeaderMappings(transport);
     return await server.connect(transport);
   }
 
@@ -1035,8 +1036,108 @@ class McpServer {
   /// Notifies clients that the list of available tools has changed.
   void sendToolListChanged() {
     if (server.transport != null) {
+      _syncToolParameterHeaderMappings();
       server.sendToolListChanged();
     }
+  }
+
+  void _syncToolParameterHeaderMappings([Transport? target]) {
+    final activeTransport = target ?? server.transport;
+    final headerAwareTransport =
+        activeTransport is ToolParameterHeaderAwareTransport
+            ? activeTransport as ToolParameterHeaderAwareTransport
+            : null;
+    if (headerAwareTransport != null) {
+      headerAwareTransport.setToolParameterHeaderMappings(
+        _buildToolParameterHeaderMappings(),
+      );
+    }
+  }
+
+  ToolParameterHeaderMappings _buildToolParameterHeaderMappings() {
+    final mappings = <String, Map<String, String>>{};
+
+    for (final tool in _registeredTools.values) {
+      if (!tool.enabled) {
+        continue;
+      }
+
+      final toolMappings = _toolParameterHeaderMappingsFor(tool);
+      if (toolMappings.isNotEmpty) {
+        mappings[tool.name] = toolMappings;
+      }
+    }
+
+    return mappings;
+  }
+
+  Map<String, String> _toolParameterHeaderMappingsFor(
+    _RegisteredToolImpl tool,
+  ) {
+    final properties = tool.inputSchema?.properties;
+    if (properties == null || properties.isEmpty) {
+      return const {};
+    }
+
+    final mappings = <String, String>{};
+    final seenHeaders = <String>{};
+    for (final entry in properties.entries) {
+      final propertyJson = entry.value.toJson();
+      if (!propertyJson.containsKey('x-mcp-header')) {
+        continue;
+      }
+
+      final rawHeader = propertyJson['x-mcp-header'];
+      if (rawHeader is! String || rawHeader.isEmpty) {
+        _logger.warn(
+          'Ignoring x-mcp-header mapping for tool "${tool.name}" parameter '
+          '"${entry.key}": value must be a non-empty string.',
+        );
+        return const {};
+      }
+
+      if (!_isValidMcpHeaderNameSuffix(rawHeader)) {
+        _logger.warn(
+          'Ignoring x-mcp-header mapping for tool "${tool.name}" parameter '
+          '"${entry.key}": "$rawHeader" is not a valid Mcp-Param suffix.',
+        );
+        return const {};
+      }
+
+      final normalizedHeader = rawHeader.toLowerCase();
+      if (!seenHeaders.add(normalizedHeader)) {
+        _logger.warn(
+          'Ignoring x-mcp-header mappings for tool "${tool.name}": '
+          '"$rawHeader" is not unique.',
+        );
+        return const {};
+      }
+
+      if (!_isToolParameterHeaderPrimitive(entry.value)) {
+        _logger.warn(
+          'Ignoring x-mcp-header mapping for tool "${tool.name}" parameter '
+          '"${entry.key}": only primitive schemas can be mirrored.',
+        );
+        return const {};
+      }
+
+      mappings[entry.key] = rawHeader;
+    }
+
+    return mappings;
+  }
+
+  bool _isValidMcpHeaderNameSuffix(String value) {
+    return value.codeUnits.every(
+      (unit) => unit >= 0x21 && unit <= 0x7E && unit != 0x3A,
+    );
+  }
+
+  bool _isToolParameterHeaderPrimitive(JsonSchema schema) {
+    return schema is JsonString ||
+        schema is JsonNumber ||
+        schema is JsonInteger ||
+        schema is JsonBoolean;
   }
 
   /// Notifies clients that the list of available prompts has changed.

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -153,7 +153,10 @@ class StreamableHTTPServerTransportOptions {
 /// - Session ID is only included in initialization responses
 /// - No session validation is performed
 class StreamableHTTPServerTransport
-    implements Transport, RequestIdAwareTransport {
+    implements
+        Transport,
+        RequestIdAwareTransport,
+        ToolParameterHeaderAwareTransport {
   // when sessionId is not set (null), it means the transport is in stateless mode
   final String? Function()? _sessionIdGenerator;
   bool _started = false;
@@ -176,6 +179,7 @@ class StreamableHTTPServerTransport
   final bool _strictProtocolVersionHeaderValidation;
   final bool _rejectBatchJsonRpcPayloads;
   final int _maxReplayedEvents;
+  ToolParameterHeaderMappings _toolParameterHeaderMappings = const {};
   static const JsonRpcNotification _ssePrimingMessage =
       JsonRpcNotification(method: 'notifications/experimental/sse/priming');
 
@@ -214,6 +218,16 @@ class StreamableHTTPServerTransport
       throw StateError("Transport already started");
     }
     _started = true;
+  }
+
+  @override
+  void setToolParameterHeaderMappings(
+    ToolParameterHeaderMappings mappings,
+  ) {
+    _toolParameterHeaderMappings = {
+      for (final entry in mappings.entries)
+        entry.key: Map.unmodifiable(Map<String, String>.from(entry.value)),
+    };
   }
 
   /// Handles an incoming HTTP request, whether GET or POST
@@ -446,55 +460,171 @@ class StreamableHTTPServerTransport
     };
   }
 
+  String? _toolName(JsonRpcMessage message) {
+    if (_messageMethod(message) != Method.toolsCall) {
+      return null;
+    }
+
+    final name = _messageParams(message)?['name'];
+    return name is String ? name : null;
+  }
+
   Future<bool> _validateMcpParamHeaders(
     HttpRequest req,
     HttpResponse res,
     JsonRpcMessage message,
   ) async {
-    final params = _messageParams(message);
-    final arguments = params?['arguments'];
-    if (arguments is! Map) {
-      return true;
-    }
-    final argumentMap = arguments.cast<String, dynamic>();
-
-    final headerNames = <String>[];
+    final headers = <String, _McpParamHeader>{};
     req.headers.forEach((name, values) {
-      headerNames.add(name);
-    });
-
-    for (final headerName in headerNames) {
       const prefix = 'mcp-param-';
-      if (!headerName.toLowerCase().startsWith(prefix)) {
-        continue;
+      final lowerName = name.toLowerCase();
+      if (!lowerName.startsWith(prefix)) {
+        return;
       }
 
-      final headerSuffix = headerName.substring(prefix.length);
+      final headerSuffix = name.substring(prefix.length);
       if (headerSuffix.isEmpty ||
           !headerSuffix.codeUnits.every(
             (unit) => unit >= 0x21 && unit <= 0x7E && unit != 0x3A,
           )) {
+        headers[lowerName] = _McpParamHeader.invalidName(
+          name: name,
+          suffix: headerSuffix,
+        );
+        return;
+      }
+
+      final headerValue = req.headers.value(name);
+      final decodedValue =
+          headerValue == null ? null : _decodeMcpParamHeaderValue(headerValue);
+      if (decodedValue == null) {
+        headers[lowerName] = _McpParamHeader.invalidValue(
+          name: name,
+          suffix: headerSuffix,
+        );
+        return;
+      }
+
+      headers[headerSuffix.toLowerCase()] = _McpParamHeader(
+        name: name,
+        suffix: headerSuffix,
+        value: decodedValue,
+      );
+    });
+
+    _McpParamHeader? invalidHeader;
+    for (final header in headers.values) {
+      if (header.validationError != null) {
+        invalidHeader = header;
+        break;
+      }
+    }
+    if (invalidHeader != null) {
+      final messageText =
+          invalidHeader.validationError == _McpParamHeaderValidationError.name
+              ? '${invalidHeader.name} header name is malformed'
+              : '${invalidHeader.name} header value is malformed';
+      await _writeHeaderMismatchResponse(res, message, messageText);
+      return false;
+    }
+
+    final params = _messageParams(message);
+    final arguments = params?['arguments'];
+    if (arguments is! Map) {
+      if (headers.isEmpty) {
+        return true;
+      }
+      await _writeHeaderMismatchResponse(
+        res,
+        message,
+        '${headers.values.first.name} header has no matching body arguments',
+      );
+      return false;
+    }
+
+    final argumentMap = arguments.cast<String, dynamic>();
+    final consumedHeaders = <String>{};
+    final toolName = _toolName(message);
+    final headerMappings =
+        toolName == null ? null : _toolParameterHeaderMappings[toolName];
+
+    if (headerMappings != null) {
+      for (final entry in headerMappings.entries) {
+        final argumentName = entry.key;
+        final headerSuffix = entry.value;
+        final header = headers[headerSuffix.toLowerCase()];
+        final hasArgument = argumentMap.containsKey(argumentName);
+        final bodyValue = hasArgument
+            ? _primitiveHeaderString(argumentMap[argumentName])
+            : null;
+
+        if (!hasArgument || bodyValue == null) {
+          if (header != null) {
+            await _writeHeaderMismatchResponse(
+              res,
+              message,
+              '${header.name} header has no matching primitive body argument '
+              "'$argumentName'",
+            );
+            return false;
+          }
+          continue;
+        }
+
+        if (header == null) {
+          await _writeHeaderMismatchResponse(
+            res,
+            message,
+            'Mcp-Param-$headerSuffix header is required for body argument '
+            "'$argumentName'",
+          );
+          return false;
+        }
+
+        consumedHeaders.add(header.suffix.toLowerCase());
+        if (header.value != bodyValue) {
+          await _writeHeaderMismatchResponse(
+            res,
+            message,
+            '${header.name} header value does not match body argument '
+            "'$argumentName'",
+          );
+          return false;
+        }
+      }
+    }
+
+    final argumentNamesByLowercase = <String, String>{};
+    for (final argumentName in argumentMap.keys) {
+      argumentNamesByLowercase.putIfAbsent(
+        argumentName.toLowerCase(),
+        () => argumentName,
+      );
+    }
+
+    for (final header in headers.values) {
+      if (consumedHeaders.contains(header.suffix.toLowerCase())) {
+        continue;
+      }
+
+      final argumentName = argumentMap.containsKey(header.suffix)
+          ? header.suffix
+          : argumentNamesByLowercase[header.suffix.toLowerCase()];
+      if (argumentName == null) {
         await _writeHeaderMismatchResponse(
           res,
           message,
-          "$headerName header name is malformed",
+          '${header.name} header has no matching body argument',
         );
         return false;
       }
 
-      if (!argumentMap.containsKey(headerSuffix)) {
-        continue;
-      }
-
-      final headerValue = req.headers.value(headerName);
-      final decodedValue =
-          headerValue == null ? null : _decodeMcpParamHeaderValue(headerValue);
-      final bodyValue = _primitiveHeaderString(argumentMap[headerSuffix]);
-      if (decodedValue == null || decodedValue != bodyValue) {
+      final bodyValue = _primitiveHeaderString(argumentMap[argumentName]);
+      if (bodyValue == null || header.value != bodyValue) {
         await _writeHeaderMismatchResponse(
           res,
           message,
-          "$headerName header value does not match body argument '$headerSuffix'",
+          "${header.name} header value does not match body argument '$argumentName'",
         );
         return false;
       }
@@ -1570,4 +1700,31 @@ class StreamableHTTPServerTransport
     }
     return null;
   }
+}
+
+enum _McpParamHeaderValidationError { name, value }
+
+class _McpParamHeader {
+  final String name;
+  final String suffix;
+  final String? value;
+  final _McpParamHeaderValidationError? validationError;
+
+  const _McpParamHeader({
+    required this.name,
+    required this.suffix,
+    required String this.value,
+  }) : validationError = null;
+
+  const _McpParamHeader.invalidName({
+    required this.name,
+    required this.suffix,
+  })  : value = null,
+        validationError = _McpParamHeaderValidationError.name;
+
+  const _McpParamHeader.invalidValue({
+    required this.name,
+    required this.suffix,
+  })  : value = null,
+        validationError = _McpParamHeaderValidationError.value;
 }

--- a/test/server/mcp_server_test.dart
+++ b/test/server/mcp_server_test.dart
@@ -6,8 +6,10 @@ import 'package:mcp_dart/src/types.dart';
 import 'package:test/test.dart';
 
 /// Mock transport for McpServer tests
-class McpServerTestTransport implements Transport {
+class McpServerTestTransport
+    implements Transport, ToolParameterHeaderAwareTransport {
   final List<JsonRpcMessage> sentMessages = [];
+  final List<ToolParameterHeaderMappings> toolParameterHeaderMappings = [];
   bool _closed = false;
 
   @override
@@ -36,6 +38,13 @@ class McpServerTestTransport implements Transport {
   Future<void> send(JsonRpcMessage message, {int? relatedRequestId}) async {
     if (_closed) throw StateError('Transport is closed');
     sentMessages.add(message);
+  }
+
+  @override
+  void setToolParameterHeaderMappings(
+    ToolParameterHeaderMappings mappings,
+  ) {
+    toolParameterHeaderMappings.add(mappings);
   }
 
   @override
@@ -103,6 +112,116 @@ void main() {
       final tools = response.result['tools'] as List;
       expect(tools.length, equals(1));
       expect(tools.first['name'], equals('test-tool'));
+    });
+
+    test('connect syncs tool parameter header mappings to transports',
+        () async {
+      server.registerTool(
+        'header-tool',
+        inputSchema: const ToolInputSchema(
+          properties: {
+            'dryRun': JsonBoolean(mcpHeader: 'Dry-Run'),
+            'region': JsonString(mcpHeader: 'Region'),
+          },
+        ),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+
+      await server.connect(transport);
+
+      expect(transport.toolParameterHeaderMappings, isNotEmpty);
+      expect(
+        transport.toolParameterHeaderMappings.last,
+        equals(
+          const {
+            'header-tool': {
+              'dryRun': 'Dry-Run',
+              'region': 'Region',
+            },
+          },
+        ),
+      );
+    });
+
+    test('tool updates refresh parameter header mappings on transports',
+        () async {
+      final registeredTool = server.registerTool(
+        'header-tool',
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+      await server.connect(transport);
+      transport.toolParameterHeaderMappings.clear();
+
+      registeredTool.update(
+        inputSchema: const ToolInputSchema(
+          properties: {
+            'dryRun': JsonBoolean(mcpHeader: 'Dry-Run'),
+          },
+        ),
+      );
+
+      expect(transport.toolParameterHeaderMappings, isNotEmpty);
+      expect(
+        transport.toolParameterHeaderMappings.last,
+        equals(
+          const {
+            'header-tool': {'dryRun': 'Dry-Run'},
+          },
+        ),
+      );
+
+      registeredTool.disable();
+
+      expect(transport.toolParameterHeaderMappings.last, isEmpty);
+    });
+
+    test('invalid tool parameter header metadata is not synced', () async {
+      server.registerTool(
+        'non-string-header-tool',
+        inputSchema: ToolInputSchema(
+          properties: {
+            'value': JsonSchema.fromJson(
+              {'type': 'string', 'x-mcp-header': 1},
+            ),
+          },
+        ),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+      server.registerTool(
+        'invalid-header-tool',
+        inputSchema: const ToolInputSchema(
+          properties: {
+            'value': JsonString(mcpHeader: 'Bad:Header'),
+          },
+        ),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+      server.registerTool(
+        'duplicate-header-tool',
+        inputSchema: const ToolInputSchema(
+          properties: {
+            'primary': JsonString(mcpHeader: 'Region'),
+            'secondary': JsonString(mcpHeader: 'region'),
+          },
+        ),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+      server.registerTool(
+        'non-primitive-header-tool',
+        inputSchema: ToolInputSchema(
+          properties: {
+            'value': JsonSchema.fromJson(
+              {'type': 'object', 'x-mcp-header': 'Value'},
+            ),
+          },
+        ),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+
+      await server.connect(transport);
+
+      expect(transport.toolParameterHeaderMappings, isNotEmpty);
+      expect(transport.toolParameterHeaderMappings.last, isEmpty);
     });
 
     test('registerTool can be updated', () async {

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -1965,14 +1965,18 @@ void main() {
         ..set('MCP-Protocol-Version', draftProtocolVersion2026_07_28)
         ..set('Mcp-Method', Method.toolsCall)
         ..set('Mcp-Name', 'execute')
-        ..set('Mcp-Param-region', 'us-east1');
+        ..set('Mcp-Param-region', 'us-east1')
+        ..set('Mcp-Param-dryRun', 'false');
       request.write(
         jsonEncode(
           JsonRpcCallToolRequest(
             id: 3,
             params: const {
               'name': 'execute',
-              'arguments': {'region': 'us-east1'},
+              'arguments': {
+                'region': 'us-east1',
+                'dryRun': false,
+              },
             },
             meta: _statelessMeta(),
           ),
@@ -1986,6 +1990,135 @@ void main() {
       final body =
           jsonDecode(await utf8.decodeStream(response)) as Map<String, dynamic>;
       expect(body['id'], 3);
+      expect(body['result']['content'], isEmpty);
+    });
+
+    test('2026 stateless HTTP validates mapped tool parameter headers',
+        () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => "unused-session-id",
+          enableJsonResponse: true,
+        ),
+      );
+      transport.setToolParameterHeaderMappings(
+        const {
+          'execute': {
+            'dryRun': 'Dry-Run',
+            'region': 'Region',
+          },
+        },
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      transport.onmessage = (message) {
+        if (message is JsonRpcCallToolRequest) {
+          unawaited(
+            transport.send(
+              JsonRpcResponse(
+                id: message.id,
+                result: const CallToolResult(content: []).toJson(),
+              ),
+            ),
+          );
+        }
+      };
+
+      Future<(int, Map<String, dynamic>)> postToolCall({
+        required int id,
+        required Map<String, Object> headers,
+        Map<String, Object?> arguments = const {
+          'dryRun': false,
+          'region': 'us-east1',
+        },
+      }) async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers
+          ..contentType = ContentType.json
+          ..set(HttpHeaders.acceptHeader, 'application/json, text/event-stream')
+          ..set('MCP-Protocol-Version', draftProtocolVersion2026_07_28)
+          ..set('Mcp-Method', Method.toolsCall)
+          ..set('Mcp-Name', 'execute');
+        headers.forEach(request.headers.set);
+        request.write(
+          jsonEncode(
+            JsonRpcCallToolRequest(
+              id: id,
+              params: {
+                'name': 'execute',
+                'arguments': arguments,
+              },
+              meta: _statelessMeta(),
+            ),
+          ),
+        );
+
+        final response = await request.close();
+        return (
+          response.statusCode,
+          jsonDecode(await utf8.decodeStream(response)) as Map<String, dynamic>,
+        );
+      }
+
+      var (statusCode, body) = await postToolCall(
+        id: 30,
+        headers: const {
+          'Mcp-Param-Region': 'us-east1',
+        },
+      );
+      expect(statusCode, HttpStatus.badRequest);
+      expect(body['id'], 30);
+      expect(body['error']['code'], ErrorCode.headerMismatch.value);
+      expect(
+        body['error']['message'],
+        contains('Mcp-Param-Dry-Run header is required'),
+      );
+
+      (statusCode, body) = await postToolCall(
+        id: 31,
+        headers: const {
+          'Mcp-Param-Dry-Run': 'true',
+          'Mcp-Param-Region': 'us-east1',
+        },
+      );
+      expect(statusCode, HttpStatus.badRequest);
+      expect(body['id'], 31);
+      expect(
+        body['error']['message'],
+        contains("body argument 'dryRun'"),
+      );
+
+      (statusCode, body) = await postToolCall(
+        id: 32,
+        arguments: const {
+          'dryRun': {'nested': true},
+          'region': 'us-east1',
+        },
+        headers: const {
+          'Mcp-Param-Dry-Run': 'false',
+          'Mcp-Param-Region': 'us-east1',
+        },
+      );
+      expect(statusCode, HttpStatus.badRequest);
+      expect(body['id'], 32);
+      expect(
+        body['error']['message'],
+        contains('no matching primitive body argument'),
+      );
+
+      (statusCode, body) = await postToolCall(
+        id: 33,
+        headers: const {
+          'Mcp-Param-Dry-Run': 'false',
+          'Mcp-Param-Region': 'us-east1',
+        },
+      );
+      expect(statusCode, HttpStatus.ok);
+      expect(body['id'], 33);
       expect(body['result']['content'], isEmpty);
     });
 
@@ -2062,6 +2195,85 @@ void main() {
       );
       expect(body['id'], 6);
       expect(body['error']['message'], contains('mcp-param-enabled'));
+
+      body = await postJson(
+        JsonRpcCallToolRequest(
+          id: 16,
+          params: const {
+            'name': 'execute',
+            'arguments': {'region': 'us-east1'},
+          },
+          meta: _statelessMeta(),
+        ).toJson(),
+        headers: {
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+          'Mcp-Method': Method.toolsCall,
+          'Mcp-Name': 'execute',
+          'Mcp-Param-': 'us-east1',
+        },
+      );
+      expect(body['id'], 16);
+      expect(body['error']['message'], contains('header name is malformed'));
+
+      body = await postJson(
+        JsonRpcCallToolRequest(
+          id: 17,
+          params: const {
+            'name': 'execute',
+            'arguments': {'region': 'us-east1'},
+          },
+          meta: _statelessMeta(),
+        ).toJson(),
+        headers: {
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+          'Mcp-Method': Method.toolsCall,
+          'Mcp-Name': 'execute',
+          'Mcp-Param-region': '=?base64?%%%?=',
+        },
+      );
+      expect(body['id'], 17);
+      expect(body['error']['message'], contains('header value is malformed'));
+
+      body = await postJson(
+        JsonRpcCallToolRequest(
+          id: 18,
+          params: const {'name': 'execute'},
+          meta: _statelessMeta(),
+        ).toJson(),
+        headers: {
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+          'Mcp-Method': Method.toolsCall,
+          'Mcp-Name': 'execute',
+          'Mcp-Param-region': 'us-east1',
+        },
+      );
+      expect(body['id'], 18);
+      expect(
+        body['error']['message'],
+        contains('header has no matching body arguments'),
+      );
+
+      body = await postJson(
+        JsonRpcCallToolRequest(
+          id: 19,
+          params: const {
+            'name': 'execute',
+            'arguments': {'region': 'us-east1'},
+          },
+          meta: _statelessMeta(),
+        ).toJson(),
+        headers: {
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+          'Mcp-Method': Method.toolsCall,
+          'Mcp-Name': 'execute',
+          'Mcp-Param-zone': 'us-east1-b',
+        },
+      );
+      expect(body['id'], 19);
+      expect(
+        body['error']['message'],
+        contains('header has no matching body argument'),
+      );
 
       body = await postJson(
         JsonRpcCallToolRequest(


### PR DESCRIPTION
Summary:
- Sync registered x-mcp-header tool schema metadata into ToolParameterHeaderAware server transports.
- Validate mapped Mcp-Param-* headers in stateless Streamable HTTP tools/call requests, including missing and mismatched values.
- Add MCP server and Streamable HTTP regression coverage.

Validation:
- dart format .
- dart analyze
- dart test test/server/streamable_https_test.dart
- dart test test/server/mcp_server_test.dart
- dart test test/mcp_2026_07_28_test.dart
- dart test test/client/client_tool_validation_test.dart
- dart test test/server/streamable_mcp_server_test.dart
- dart test