### PR TITLE
Gate MCP 2026 task extension handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 - Synced registered tool `x-mcp-header` metadata into Streamable HTTP server
   transports so 2026 stateless `tools/call` requests reject missing or
   mismatched `Mcp-Param-*` argument headers.
+- Gated 2026 stateless task extension methods on advertised server extension
+  support and rejected legacy task result shapes on extension `tasks/get`,
+  `tasks/update`, and `tasks/cancel` handlers.
 - Added request-scoped stateless logging gating via
   `io.modelcontextprotocol/logLevel` metadata so 2026 log notifications are
   emitted only when the current request opts in.

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -339,6 +339,27 @@ class Server extends Protocol {
     return null;
   }
 
+  McpError? _validateServerTasksExtensionSupport(JsonRpcRequest request) {
+    if (!_isStatelessRequest(request)) {
+      return null;
+    }
+
+    switch (request.method) {
+      case Method.tasksGet:
+      case Method.tasksCancel:
+      case Method.tasksUpdate:
+        if (_capabilities.supportsTasksExtension) {
+          return null;
+        }
+        return McpError(
+          ErrorCode.methodNotFound.value,
+          '${request.method} requires server support for $mcpTasksExtensionId.',
+        );
+    }
+
+    return null;
+  }
+
   McpError? _validateTasksExtensionCapabilities(JsonRpcRequest request) {
     final requiresTasksExtension =
         (request is JsonRpcSubscriptionsListenRequest &&
@@ -380,6 +401,11 @@ class Server extends Protocol {
       return removedMethodError;
     }
 
+    final serverExtensionError = _validateServerTasksExtensionSupport(request);
+    if (serverExtensionError != null) {
+      return serverExtensionError;
+    }
+
     final extensionCapabilityError =
         _validateTasksExtensionCapabilities(request);
     if (extensionCapabilityError != null) {
@@ -402,6 +428,33 @@ class Server extends Protocol {
     }
 
     return false;
+  }
+
+  bool _allowsTaskExtensionResult(
+    BaseResultData result,
+    JsonRpcRequest request,
+  ) {
+    if (!_isStatelessRequest(request)) {
+      return true;
+    }
+
+    return switch (request.method) {
+      Method.tasksGet => result is GetTaskExtensionResult,
+      Method.tasksCancel ||
+      Method.tasksUpdate =>
+        result is TaskExtensionAcknowledgementResult || result is EmptyResult,
+      _ => true,
+    };
+  }
+
+  String _expectedTaskExtensionResult(String method) {
+    return switch (method) {
+      Method.tasksGet => 'GetTaskExtensionResult',
+      Method.tasksCancel ||
+      Method.tasksUpdate =>
+        'TaskExtensionAcknowledgementResult or EmptyResult',
+      _ => 'valid MCP Tasks extension result',
+    };
   }
 
   bool _isLegacyTaskAugmentedRequest(JsonRpcCallToolRequest request) {
@@ -650,6 +703,24 @@ class Server extends Protocol {
               "Invalid tools/call result: Expected CallToolResult",
             );
           }
+        }
+        return result;
+      }
+
+      super.setRequestHandler(method, wrappedHandler, requestFactory);
+    } else if (method == Method.tasksGet ||
+        method == Method.tasksCancel ||
+        method == Method.tasksUpdate) {
+      Future<BaseResultData> wrappedHandler(
+        ReqT request,
+        RequestHandlerExtra extra,
+      ) async {
+        final result = await handler(request, extra);
+        if (!_allowsTaskExtensionResult(result, request)) {
+          throw McpError(
+            ErrorCode.invalidParams.value,
+            "Invalid ${request.method} result for MCP Tasks extension: Expected ${_expectedTaskExtensionResult(request.method)}",
+          );
         }
         return result;
       }

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -787,6 +787,185 @@ void main() {
       );
     });
 
+    test('server handles task extension methods with 2026 result shapes',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            extensions: {mcpTasksExtensionId: {}},
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcGetTaskRequest>(
+        Method.tasksGet,
+        (request, extra) async => const GetTaskExtensionResult(
+          task: TaskExtensionTask(
+            taskId: 'task-1',
+            status: TaskStatus.completed,
+            createdAt: '2026-07-28T00:00:00Z',
+            lastUpdatedAt: '2026-07-28T00:01:00Z',
+            ttlMs: 60000,
+            result: {
+              'content': [
+                {'type': 'text', 'text': 'done'},
+              ],
+            },
+          ),
+        ),
+        (id, params, meta) => JsonRpcGetTaskRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      server.setRequestHandler<JsonRpcCancelTaskRequest>(
+        Method.tasksCancel,
+        (request, extra) async => const TaskExtensionAcknowledgementResult(),
+        (id, params, meta) => JsonRpcCancelTaskRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      server.setRequestHandler<JsonRpcUpdateTaskRequest>(
+        Method.tasksUpdate,
+        (request, extra) async => const EmptyResult(),
+        (id, params, meta) => JsonRpcUpdateTaskRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+      final taskExtensionMeta = _clientMeta(
+        clientCapabilities: const ClientCapabilities(
+          extensions: {mcpTasksExtensionId: {}},
+        ),
+      );
+
+      transport
+        ..receive(
+          JsonRpcGetTaskRequest(
+            id: 'get-task',
+            getParams: const GetTaskRequest(taskId: 'task-1'),
+            meta: taskExtensionMeta,
+          ),
+        )
+        ..receive(
+          JsonRpcCancelTaskRequest(
+            id: 'cancel-task',
+            cancelParams: const CancelTaskRequest(taskId: 'task-1'),
+            meta: taskExtensionMeta,
+          ),
+        )
+        ..receive(
+          JsonRpcUpdateTaskRequest(
+            id: 'update-task',
+            updateParams: const UpdateTaskRequest(
+              taskId: 'task-1',
+              inputResponses: {},
+            ),
+            meta: taskExtensionMeta,
+          ),
+        );
+      await _pump();
+
+      final responses = transport.sentMessages.cast<JsonRpcResponse>().toList();
+      expect(responses, hasLength(3));
+      expect(responses[0].result['resultType'], resultTypeComplete);
+      expect(responses[0].result['taskId'], 'task-1');
+      expect(responses[0].result['ttlMs'], 60000);
+      expect(responses[0].result, isNot(contains('ttl')));
+      expect(responses[1].result, {'resultType': resultTypeComplete});
+      expect(responses[2].result, {'resultType': resultTypeComplete});
+    });
+
+    test('server does not expose legacy task handlers as task extension',
+        () async {
+      final server = McpServer(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+      var handlerCalled = false;
+      server.experimental.onGetTask((taskId, extra) async {
+        handlerCalled = true;
+        return Task(
+          taskId: taskId,
+          status: TaskStatus.completed,
+          ttl: null,
+          createdAt: '2026-07-28T00:00:00Z',
+          lastUpdatedAt: '2026-07-28T00:01:00Z',
+        );
+      });
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcGetTaskRequest(
+          id: 'get-task',
+          getParams: const GetTaskRequest(taskId: 'task-1'),
+          meta: _clientMeta(
+            clientCapabilities: const ClientCapabilities(
+              extensions: {mcpTasksExtensionId: {}},
+            ),
+          ),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcError;
+      expect(response.error.code, ErrorCode.methodNotFound.value);
+      expect(response.error.message, contains(mcpTasksExtensionId));
+      expect(handlerCalled, isFalse);
+    });
+
+    test('stateless task extension handlers reject legacy result shapes',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            extensions: {mcpTasksExtensionId: {}},
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcGetTaskRequest>(
+        Method.tasksGet,
+        (request, extra) async => Task(
+          taskId: request.getParams.taskId,
+          status: TaskStatus.completed,
+          ttl: null,
+          createdAt: '2026-07-28T00:00:00Z',
+          lastUpdatedAt: '2026-07-28T00:01:00Z',
+        ),
+        (id, params, meta) => JsonRpcGetTaskRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcGetTaskRequest(
+          id: 'get-task',
+          getParams: const GetTaskRequest(taskId: 'task-1'),
+          meta: _clientMeta(
+            clientCapabilities: const ClientCapabilities(
+              extensions: {mcpTasksExtensionId: {}},
+            ),
+          ),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcError;
+      expect(response.error.code, ErrorCode.invalidParams.value);
+      expect(response.error.message, contains('GetTaskExtensionResult'));
+    });
+
     test('server rejects removed legacy task methods in stateless protocol',
         () async {
       final server = Server(


### PR DESCRIPTION
## Summary
- require server support for `io.modelcontextprotocol/tasks` before accepting stateless `tasks/get`, `tasks/update`, or `tasks/cancel`
- reject legacy task result shapes from stateless task extension handlers so 2026 responses use `ttlMs`/`resultType` shapes
- add 2026 regression coverage for valid task extension handlers, legacy handler isolation, and legacy result rejection

## Spec context
- Draft changelog moves tasks out of core and removes legacy `tasks/list`/`tasks/result`: https://modelcontextprotocol.io/specification/draft/changelog
- SEP-2663 defines the extension methods and 2026 task result shapes: https://modelcontextprotocol.io/seps/2663-tasks-extension

## Validation
- `dart format lib/src/server/server.dart test/mcp_2026_07_28_test.dart`
- `dart analyze`
- `dart test test/mcp_2026_07_28_test.dart`
- `dart test test/types/tasks_extension_test.dart`
- `dart test test/server/streamable_https_test.dart`
- `dart test`
- `dart pub global run coverage:test_with_coverage`
- `git diff --check`