### PR TITLE
Reject MCP 2026 stateless session headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Synced registered tool `x-mcp-header` metadata into Streamable HTTP server
   transports so 2026 stateless `tools/call` requests reject missing or
   mismatched `Mcp-Param-*` argument headers.
+- Removed `Mcp-Session-Id` from 2026 stateless Streamable HTTP requests by
+  stripping it from client sends and rejecting it on stateless server POSTs.
 - Gated 2026 stateless task extension methods on advertised server extension
   support and rejected legacy task result shapes on extension `tasks/get`,
   `tasks/update`, and `tasks/cancel` handlers.

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -1117,6 +1117,12 @@ class StreamableHttpClientTransport
 
       final headers = await _commonHeaders();
       headers.addAll(_headersForMessage(message));
+      final protocolVersion = _protocolVersion ?? _protocolVersionFrom(message);
+      final isStatelessRequest = protocolVersion != null &&
+          isStatelessProtocolVersion(protocolVersion);
+      if (isStatelessRequest) {
+        headers.remove('mcp-session-id');
+      }
       final requestSessionId = headers['mcp-session-id'];
       headers['content-type'] = 'application/json';
       headers['accept'] = 'application/json, text/event-stream';
@@ -1174,7 +1180,7 @@ class StreamableHttpClientTransport
 
       // Handle session ID received from successful stateful responses.
       final sessionId = response.headers['mcp-session-id'];
-      if (sessionId != null) {
+      if (sessionId != null && !isStatelessRequest) {
         _sessionId = sessionId;
         _staleSessionDetected = false;
       }

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -688,6 +688,15 @@ class StreamableHTTPServerTransport
       );
       return false;
     }
+    if (isStatelessProtocolVersion(protocolHeader) &&
+        req.headers.value('mcp-session-id') != null) {
+      await _writeHeaderMismatchResponse(
+        req.response,
+        message,
+        'Mcp-Session-Id header is not part of MCP stateless protocol versions',
+      );
+      return false;
+    }
 
     final method = _messageMethod(message);
     if (method == null) {

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -1069,9 +1069,11 @@ void main() {
             request.headers.value('mcp-protocol-version');
         capturedHeaders['method'] = request.headers.value('mcp-method');
         capturedHeaders['name'] = request.headers.value('mcp-name');
+        capturedHeaders['session'] = request.headers.value('mcp-session-id');
         await request.drain<void>();
         request.response
           ..statusCode = HttpStatus.ok
+          ..headers.set('mcp-session-id', 'ignored-stateless-session')
           ..headers.contentType = ContentType.json
           ..write(
             jsonEncode(
@@ -1086,6 +1088,9 @@ void main() {
 
       transport = StreamableHttpClientTransport(
         Uri.parse('http://localhost:${server.port}/mcp'),
+        opts: const StreamableHttpClientTransportOptions(
+          sessionId: 'legacy-session',
+        ),
       )..protocolVersion = draftProtocolVersion2026_07_28;
       await transport.start();
 
@@ -1110,6 +1115,8 @@ void main() {
       );
       expect(capturedHeaders['method'], Method.toolsCall);
       expect(capturedHeaders['name'], 'echo');
+      expect(capturedHeaders['session'], isNull);
+      expect(transport.sessionId, 'legacy-session');
     });
 
     test('send maps 2026 stateless headers for standard request types',

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -1931,6 +1931,40 @@ void main() {
       expect(body['error']['message'], contains('Mcp-Name header is required'));
     });
 
+    test('2026 stateless HTTP rejects session header', () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => "unused-session-id",
+          enableJsonResponse: true,
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+      final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+      request.headers
+        ..contentType = ContentType.json
+        ..set(HttpHeaders.acceptHeader, 'application/json, text/event-stream')
+        ..set('MCP-Protocol-Version', draftProtocolVersion2026_07_28)
+        ..set('Mcp-Method', Method.toolsList)
+        ..set('Mcp-Session-Id', 'legacy-session');
+      request.write(
+        jsonEncode(JsonRpcListToolsRequest(id: 6, meta: _statelessMeta())),
+      );
+
+      final response = await request.close();
+
+      expect(response.statusCode, HttpStatus.badRequest);
+      final body =
+          jsonDecode(await utf8.decodeStream(response)) as Map<String, dynamic>;
+      expect(body['id'], 6);
+      expect(body['error']['code'], ErrorCode.headerMismatch.value);
+      expect(body['error']['message'], contains('Mcp-Session-Id header'));
+    });
+
     test('2026 stateless HTTP accepts matching standard and parameter headers',
         () async {
       final transport = StreamableHTTPServerTransport(


### PR DESCRIPTION
Stacked on #189 (`spec/2026-task-extension-handler-gating`).

## Summary
- strip `Mcp-Session-Id` from 2026 stateless Streamable HTTP client sends, even when a legacy session id is preconfigured
- ignore response session IDs for stateless requests so legacy state does not leak into 2026 flows
- reject incoming 2026 stateless server POSTs that include `Mcp-Session-Id` with `headerMismatch`

## Validation
- `dart format lib/src/client/streamable_https.dart lib/src/server/streamable_https.dart test/client/streamable_https_test.dart test/server/streamable_https_test.dart`
- `dart analyze`
- `dart test test/client/streamable_https_test.dart`
- `dart test test/server/streamable_https_test.dart`
- `dart test`
- `dart pub global run coverage:test_with_coverage`
- `git diff --check`