### PR TITLE
Sort MCP 2026 stateless tools list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   mismatched `Mcp-Param-*` argument headers.
 - Removed `Mcp-Session-Id` from 2026 stateless Streamable HTTP requests by
   stripping it from client sends and rejecting it on stateless server POSTs.
+- Sorted 2026 stateless high-level `tools/list` responses by tool name for
+  deterministic list results while preserving legacy registration-order output.
 - Gated 2026 stateless task extension methods on advertised server extension
   support and rejected legacy task result shapes on extension `tasks/get`,
   `tasks/update`, and `tasks/cancel` handlers.

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -1268,14 +1268,18 @@ class McpServer {
       Method.toolsList,
       (request, extra) async {
         final protocolVersion = request.meta?[McpMetaKey.protocolVersion];
-        final includeLegacyTaskExecution = protocolVersion is! String ||
-            !isStatelessProtocolVersion(protocolVersion);
+        final isStatelessRequest = protocolVersion is String &&
+            isStatelessProtocolVersion(protocolVersion);
+        final includeLegacyTaskExecution = !isStatelessRequest;
+        final tools = _registeredTools.values.where((t) => t.enabled).toList();
+        if (isStatelessRequest) {
+          tools.sort((a, b) => a.name.compareTo(b.name));
+        }
 
         return ListToolsResult(
-          tools: _registeredTools.values
-              .where((t) => t.enabled)
+          tools: tools
               .map(
-                (e) => e.toTool(
+                (tool) => tool.toTool(
                   includeExecution: includeLegacyTaskExecution,
                 ),
               )

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -1247,6 +1247,30 @@ void main() {
       expect(tool, isNot(contains('execution')));
     });
 
+    test('stateless tools/list returns tools sorted by name', () async {
+      final server = McpServer(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+      for (final name in ['zeta', 'alpha', 'middle']) {
+        server.registerTool(
+          name,
+          callback: (args, extra) => const CallToolResult(
+            content: [TextContent(text: 'ok')],
+          ),
+        );
+      }
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport
+          .receive(JsonRpcListToolsRequest(id: 'tools', meta: _clientMeta()));
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      final tools = response.result['tools'] as List;
+      expect(tools.map((tool) => tool['name']), ['alpha', 'middle', 'zeta']);
+    });
+
     test('tasks/update handler requires task extension capability', () {
       final server = Server(
         const Implementation(name: 'server', version: '1.0.0'),


### PR DESCRIPTION
Stacked on #190 (`spec/2026-stateless-session-header-rejection`).

## Summary
- sort high-level 2026 stateless `tools/list` responses by tool name
- keep legacy/non-stateless `tools/list` registration-order output unchanged
- add a 2026 regression test for deterministic tool ordering

## Validation
- `dart format lib/src/server/mcp_server.dart test/mcp_2026_07_28_test.dart`
- `dart test test/mcp_2026_07_28_test.dart`
- `dart analyze`
- `dart test test/server/mcp_server_test.dart`
- `dart test`
- `dart pub global run coverage:test_with_coverage`
- `git diff --check`