### PR TITLE
Reject MCP header mappings on number schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 - Synced registered tool `x-mcp-header` metadata into Streamable HTTP server
   transports so 2026 stateless `tools/call` requests reject missing or
   mismatched `Mcp-Param-*` argument headers.
+- Rejected `x-mcp-header` usage on JSON Schema `number` parameters, keeping
+  mirrored tool headers limited to string, JavaScript-safe integer, and boolean
+  parameters.
 - Removed `Mcp-Session-Id` from 2026 stateless Streamable HTTP requests by
   stripping it from client sends and rejecting it on stateless server POSTs.
 - Sorted 2026 stateless high-level `tools/list` responses by tool name for

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -914,7 +914,8 @@ class McpClient extends Protocol {
 
       if (!_isToolParameterHeaderPrimitive(entry.value)) {
         return _ToolParameterHeaderValidation.invalid(
-          'parameter "${entry.key}" uses x-mcp-header on a non-primitive type',
+          'parameter "${entry.key}" uses x-mcp-header on a schema that is not '
+          'string, integer, or boolean',
         );
       }
 
@@ -932,7 +933,6 @@ class McpClient extends Protocol {
 
   bool _isToolParameterHeaderPrimitive(JsonSchema schema) {
     return schema is JsonString ||
-        schema is JsonNumber ||
         schema is JsonInteger ||
         schema is JsonBoolean;
   }

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -16,6 +16,9 @@ const _defaultStreamableHttpReconnectionOptions =
   maxRetries: 2,
 );
 
+const int _maxSafeHeaderInteger = 9007199254740991;
+const int _minSafeHeaderInteger = -9007199254740991;
+
 /// Error thrown for Streamable HTTP issues
 class StreamableHttpError extends Error {
   /// HTTP status code if applicable
@@ -591,12 +594,35 @@ class StreamableHttpClientTransport
   }
 
   String? _toolParameterHeaderString(Object? value) {
+    final integer = _safeHeaderInteger(value);
+    if (integer != null) {
+      return integer.toString();
+    }
+
     return switch (value) {
       String() => value,
-      num() => value.toString(),
       bool() => value.toString(),
       _ => null,
     };
+  }
+
+  int? _safeHeaderInteger(Object? value) {
+    if (value is int) {
+      if (value < _minSafeHeaderInteger || value > _maxSafeHeaderInteger) {
+        return null;
+      }
+      return value;
+    }
+
+    if (value is double &&
+        value.isFinite &&
+        value.truncateToDouble() == value &&
+        value >= _minSafeHeaderInteger &&
+        value <= _maxSafeHeaderInteger) {
+      return value.toInt();
+    }
+
+    return null;
   }
 
   String _encodeToolParameterHeaderValue(String value) {

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -1116,7 +1116,8 @@ class McpServer {
       if (!_isToolParameterHeaderPrimitive(entry.value)) {
         _logger.warn(
           'Ignoring x-mcp-header mapping for tool "${tool.name}" parameter '
-          '"${entry.key}": only primitive schemas can be mirrored.',
+          '"${entry.key}": only string, integer, and boolean schemas can be '
+          'mirrored.',
         );
         return const {};
       }
@@ -1135,7 +1136,6 @@ class McpServer {
 
   bool _isToolParameterHeaderPrimitive(JsonSchema schema) {
     return schema is JsonString ||
-        schema is JsonNumber ||
         schema is JsonInteger ||
         schema is JsonBoolean;
   }

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -9,6 +9,9 @@ import '../shared/transport.dart';
 import '../types.dart';
 import 'dns_rebinding_protection.dart';
 
+const int _maxSafeHeaderInteger = 9007199254740991;
+const int _minSafeHeaderInteger = -9007199254740991;
+
 /// ID for SSE streams
 typedef StreamId = String;
 
@@ -451,13 +454,47 @@ class StreamableHTTPServerTransport
   }
 
   String? _primitiveHeaderString(Object? value) {
+    final integer = _safeHeaderInteger(value);
+    if (integer != null) {
+      return integer.toString();
+    }
+
     return switch (value) {
       null => null,
       String() => value,
-      num() => value.toString(),
       bool() => value.toString(),
       _ => null,
     };
+  }
+
+  int? _safeHeaderInteger(Object? value) {
+    if (value is int) {
+      if (value < _minSafeHeaderInteger || value > _maxSafeHeaderInteger) {
+        return null;
+      }
+      return value;
+    }
+
+    if (value is double &&
+        value.isFinite &&
+        value.truncateToDouble() == value &&
+        value >= _minSafeHeaderInteger &&
+        value <= _maxSafeHeaderInteger) {
+      return value.toInt();
+    }
+
+    return null;
+  }
+
+  bool _headerValueMatchesPrimitive(Object? bodyValue, String headerValue) {
+    final integer = _safeHeaderInteger(bodyValue);
+    if (integer != null) {
+      final headerInteger = _safeHeaderInteger(num.tryParse(headerValue));
+      return headerInteger != null && headerInteger == integer;
+    }
+
+    final value = _primitiveHeaderString(bodyValue);
+    return value != null && headerValue == value;
   }
 
   String? _toolName(JsonRpcMessage message) {
@@ -554,9 +591,9 @@ class StreamableHTTPServerTransport
         final headerSuffix = entry.value;
         final header = headers[headerSuffix.toLowerCase()];
         final hasArgument = argumentMap.containsKey(argumentName);
-        final bodyValue = hasArgument
-            ? _primitiveHeaderString(argumentMap[argumentName])
-            : null;
+        final bodyArgument = hasArgument ? argumentMap[argumentName] : null;
+        final bodyValue =
+            hasArgument ? _primitiveHeaderString(bodyArgument) : null;
 
         if (!hasArgument || bodyValue == null) {
           if (header != null) {
@@ -582,7 +619,7 @@ class StreamableHTTPServerTransport
         }
 
         consumedHeaders.add(header.suffix.toLowerCase());
-        if (header.value != bodyValue) {
+        if (!_headerValueMatchesPrimitive(bodyArgument, header.value!)) {
           await _writeHeaderMismatchResponse(
             res,
             message,
@@ -619,8 +656,8 @@ class StreamableHTTPServerTransport
         return false;
       }
 
-      final bodyValue = _primitiveHeaderString(argumentMap[argumentName]);
-      if (bodyValue == null || header.value != bodyValue) {
+      final bodyArgument = argumentMap[argumentName];
+      if (!_headerValueMatchesPrimitive(bodyArgument, header.value!)) {
         await _writeHeaderMismatchResponse(
           res,
           message,

--- a/test/client/client_tool_validation_test.dart
+++ b/test/client/client_tool_validation_test.dart
@@ -150,9 +150,17 @@ void main() {
             inputSchema: JsonSchema.object(
               properties: {
                 'region': JsonSchema.string(mcpHeader: 'Region'),
-                'limit': JsonSchema.number(mcpHeader: 'Limit'),
+                'limit': JsonSchema.integer(mcpHeader: 'Limit'),
                 'dryRun': JsonSchema.boolean(mcpHeader: 'Dry-Run'),
                 'count': JsonSchema.integer(mcpHeader: 'Count'),
+              },
+            ),
+          ),
+          Tool(
+            name: 'number_header',
+            inputSchema: JsonSchema.object(
+              properties: {
+                'ratio': JsonSchema.number(mcpHeader: 'Ratio'),
               },
             ),
           ),
@@ -214,7 +222,7 @@ void main() {
       });
       expect(
         warnings.where((message) => message.contains('Rejecting tool')),
-        hasLength(4),
+        hasLength(5),
       );
     });
 

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -1257,6 +1257,9 @@ void main() {
         capturedHeaders['greeting'] =
             request.headers.value('mcp-param-greeting');
         capturedHeaders['limit'] = request.headers.value('mcp-param-limit');
+        capturedHeaders['rounded'] = request.headers.value('mcp-param-rounded');
+        capturedHeaders['unsafe'] = request.headers.value('mcp-param-unsafe');
+        capturedHeaders['ratio'] = request.headers.value('mcp-param-ratio');
         capturedHeaders['dryRun'] = request.headers.value('mcp-param-dry-run');
         capturedHeaders['text'] = request.headers.value('mcp-param-text');
         capturedHeaders['payload'] = request.headers.value('mcp-param-payload');
@@ -1285,6 +1288,9 @@ void main() {
               'region': 'Region',
               'greeting': 'Greeting',
               'limit': 'Limit',
+              'rounded': 'Rounded',
+              'unsafe': 'Unsafe',
+              'ratio': 'Ratio',
               'dryRun': 'Dry-Run',
               'text': 'Text',
               'payload': 'Payload',
@@ -1305,6 +1311,9 @@ void main() {
               'region': 'us-west1',
               'greeting': 'Hello, 世界',
               'limit': 42,
+              'rounded': 42.0,
+              'unsafe': 9007199254740992,
+              'ratio': 1.5,
               'dryRun': false,
               'text': ' padded ',
               'payload': {'nested': true},
@@ -1321,6 +1330,9 @@ void main() {
         '=?base64?${base64Encode(utf8.encode('Hello, 世界'))}?=',
       );
       expect(capturedHeaders['limit'], '42');
+      expect(capturedHeaders['rounded'], '42');
+      expect(capturedHeaders['unsafe'], isNull);
+      expect(capturedHeaders['ratio'], isNull);
       expect(capturedHeaders['dryRun'], 'false');
       expect(capturedHeaders['text'], '=?base64?IHBhZGRlZCA=?=');
       expect(capturedHeaders['payload'], isNull);

--- a/test/server/mcp_server_test.dart
+++ b/test/server/mcp_server_test.dart
@@ -197,6 +197,15 @@ void main() {
         callback: (args, extra) async => const CallToolResult(content: []),
       );
       server.registerTool(
+        'number-header-tool',
+        inputSchema: const ToolInputSchema(
+          properties: {
+            'value': JsonNumber(mcpHeader: 'Value'),
+          },
+        ),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+      server.registerTool(
         'duplicate-header-tool',
         inputSchema: const ToolInputSchema(
           properties: {

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -2039,6 +2039,8 @@ void main() {
         const {
           'execute': {
             'dryRun': 'Dry-Run',
+            'rounded': 'Rounded',
+            'ratio': 'Ratio',
             'region': 'Region',
           },
         },
@@ -2143,6 +2145,43 @@ void main() {
         body['error']['message'],
         contains('no matching primitive body argument'),
       );
+
+      (statusCode, body) = await postToolCall(
+        id: 34,
+        arguments: const {
+          'dryRun': false,
+          'ratio': 1.5,
+          'region': 'us-east1',
+        },
+        headers: const {
+          'Mcp-Param-Dry-Run': 'false',
+          'Mcp-Param-Ratio': '1.5',
+          'Mcp-Param-Region': 'us-east1',
+        },
+      );
+      expect(statusCode, HttpStatus.badRequest);
+      expect(body['id'], 34);
+      expect(
+        body['error']['message'],
+        contains('no matching primitive body argument'),
+      );
+
+      (statusCode, body) = await postToolCall(
+        id: 35,
+        arguments: const {
+          'dryRun': false,
+          'rounded': 42.0,
+          'region': 'us-east1',
+        },
+        headers: const {
+          'Mcp-Param-Dry-Run': 'false',
+          'Mcp-Param-Rounded': '42.0',
+          'Mcp-Param-Region': 'us-east1',
+        },
+      );
+      expect(statusCode, HttpStatus.ok);
+      expect(body['id'], 35);
+      expect(body['result']['content'], isEmpty);
 
       (statusCode, body) = await postToolCall(
         id: 33,


### PR DESCRIPTION
Stacked on #191 (`spec/2026-deterministic-tools-list`).

## Summary
- reject `x-mcp-header` mappings on JSON Schema `number` parameters in client `tools/list` filtering
- stop syncing high-level server `x-mcp-header` mappings for `number` schemas
- restrict Streamable HTTP `Mcp-Param-*` value mirroring/validation to string, integer, and boolean values

## Spec
- Draft Streamable HTTP requires `x-mcp-header` only on primitive string, integer, and boolean parameters; `number` is not permitted.

## Validation
- `dart format lib/src/client/client.dart lib/src/client/streamable_https.dart lib/src/server/mcp_server.dart lib/src/server/streamable_https.dart test/client/client_tool_validation_test.dart test/client/streamable_https_test.dart test/server/mcp_server_test.dart test/server/streamable_https_test.dart`
- `dart test test/client/client_tool_validation_test.dart`
- `dart test test/client/streamable_https_test.dart`
- `dart test test/server/mcp_server_test.dart`
- `dart test test/server/streamable_https_test.dart`
- `dart test test/mcp_2026_07_28_test.dart`
- `dart analyze`
- `dart test`
- `dart pub global run coverage:test_with_coverage`
- `git diff --check`