### PR TITLE
Enforce MCP 2026 stateless POST-only transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
   parameters.
 - Removed `Mcp-Session-Id` from 2026 stateless Streamable HTTP requests by
   stripping it from client sends and rejecting it on stateless server POSTs.
+- Enforced 2026 stateless Streamable HTTP POST-only behavior by skipping
+  legacy client GET/DELETE session paths and returning `Allow: POST` for
+  stateless non-POST server requests.
 - Sorted 2026 stateless high-level `tools/list` responses by tool name for
   deterministic list results while preserving legacy registration-order output.
 - Gated 2026 stateless task extension methods on advertised server extension

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -709,6 +709,11 @@ class StreamableHttpClientTransport
   }
 
   Future<void> _startOrAuthSse(StartSseOptions options) async {
+    if (_protocolVersion != null &&
+        isStatelessProtocolVersion(_protocolVersion!)) {
+      return;
+    }
+
     final resumptionToken = options.resumptionToken;
     try {
       // Try to open an initial SSE stream with GET to listen for server messages
@@ -1324,6 +1329,13 @@ class StreamableHttpClientTransport
   /// The server MAY respond with HTTP 405 Method Not Allowed, indicating that
   /// the server does not allow clients to terminate sessions.
   Future<void> terminateSession() async {
+    if (_protocolVersion != null &&
+        isStatelessProtocolVersion(_protocolVersion!)) {
+      _sessionId = null;
+      _staleSessionDetected = false;
+      return;
+    }
+
     if (_sessionId == null) {
       return; // No session to terminate
     }

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -255,8 +255,7 @@ class StreamableHTTPServerTransport
 
     if (req.method == "POST") {
       await _handlePostRequest(req, parsedBody);
-    } else if (_isStatelessProtocolVersionRequest(req) &&
-        (req.method == "GET" || req.method == "DELETE")) {
+    } else if (_isStatelessProtocolVersionRequest(req)) {
       await _handleStatelessUnsupportedRequest(req.response);
     } else if (req.method == "GET") {
       await _handleGetRequest(req);

--- a/lib/src/server/streamable_mcp_server.dart
+++ b/lib/src/server/streamable_mcp_server.dart
@@ -419,6 +419,8 @@ class StreamableMcpServer {
     try {
       if (request.method == 'POST') {
         await _handlePostRequest(request);
+      } else if (_isStatelessProtocolVersionRequest(request)) {
+        await _createStatelessTransport().handleRequest(request);
       } else if (request.method == 'GET') {
         await _handleGetRequest(request);
       } else if (request.method == 'DELETE') {

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -2009,6 +2009,72 @@ void main() {
         expect(true, isTrue);
       });
 
+      test('stateless protocol does not send DELETE for session termination',
+          () async {
+        var deleteRequests = 0;
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() => server.close(force: true));
+        server.listen((request) async {
+          if (request.method == 'DELETE') {
+            deleteRequests += 1;
+          }
+          request.response.statusCode = HttpStatus.ok;
+          await request.response.close();
+        });
+
+        transport = StreamableHttpClientTransport(
+          Uri.parse('http://localhost:${server.port}/mcp'),
+          opts: const StreamableHttpClientTransportOptions(
+            sessionId: 'legacy-session',
+          ),
+        );
+        transport.protocolVersion = draftProtocolVersion2026_07_28;
+        await transport.start();
+
+        await transport.terminateSession();
+
+        expect(deleteRequests, 0);
+        expect(transport.sessionId, isNull);
+      });
+
+      test('stateless protocol does not open legacy GET SSE after initialized',
+          () async {
+        var getRequests = 0;
+        var postRequests = 0;
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() => server.close(force: true));
+        server.listen((request) async {
+          if (request.method == 'GET') {
+            getRequests += 1;
+            request.response.statusCode = HttpStatus.methodNotAllowed;
+            await request.response.close();
+            return;
+          }
+
+          if (request.method == 'POST') {
+            postRequests += 1;
+            request.response.statusCode = HttpStatus.accepted;
+            await request.response.close();
+            return;
+          }
+
+          request.response.statusCode = HttpStatus.methodNotAllowed;
+          await request.response.close();
+        });
+
+        transport = StreamableHttpClientTransport(
+          Uri.parse('http://localhost:${server.port}/mcp'),
+        );
+        transport.protocolVersion = draftProtocolVersion2026_07_28;
+        await transport.start();
+
+        await transport.send(const JsonRpcInitializedNotification());
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        expect(postRequests, 1);
+        expect(getRequests, 0);
+      });
+
       test('handles error callback configuration', () async {
         transport = StreamableHttpClientTransport(serverUrl);
 

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -2437,7 +2437,8 @@ void main() {
       expect(transport.sessionId, isNull);
     });
 
-    test('2026 stateless GET requests return method not allowed', () async {
+    test('2026 stateless non-POST requests return method not allowed',
+        () async {
       final transport = StreamableHTTPServerTransport(
         options: StreamableHTTPServerTransportOptions(
           sessionIdGenerator: () => null,
@@ -2464,6 +2465,28 @@ void main() {
       expect(body['error']['code'], ErrorCode.connectionClosed.value);
       expect(
         body['error']['message'],
+        'Method not allowed for stateless MCP requests.',
+      );
+
+      final patchRequest = await client.openUrl(
+        'PATCH',
+        Uri.parse('$serverUrlBase/mcp'),
+      );
+      patchRequest.headers.set(
+        'MCP-Protocol-Version',
+        draftProtocolVersion2026_07_28,
+      );
+
+      final patchResponse = await patchRequest.close();
+      final patchBody = jsonDecode(
+        await utf8.decodeStream(patchResponse),
+      ) as Map<String, dynamic>;
+
+      expect(patchResponse.statusCode, HttpStatus.methodNotAllowed);
+      expect(patchResponse.headers.value(HttpHeaders.allowHeader), 'POST');
+      expect(patchBody['error']['code'], ErrorCode.connectionClosed.value);
+      expect(
+        patchBody['error']['message'],
         'Method not allowed for stateless MCP requests.',
       );
     });

--- a/test/server/streamable_mcp_server_test.dart
+++ b/test/server/streamable_mcp_server_test.dart
@@ -361,7 +361,8 @@ void main() {
       );
     });
 
-    test('routes 2026 stateless GET and DELETE without a session ID', () async {
+    test('routes 2026 stateless non-POST methods without a session ID',
+        () async {
       final client = HttpClient();
       addTearDown(() => client.close(force: true));
 
@@ -384,6 +385,16 @@ void main() {
       expect(deleteResponse.statusCode, HttpStatus.methodNotAllowed);
       expect(deleteResponse.headers.value(HttpHeaders.allowHeader), 'POST');
       await deleteResponse.drain<void>();
+
+      final patchRequest = await client.openUrl('PATCH', Uri.parse(baseUrl));
+      patchRequest.headers.set(
+        'MCP-Protocol-Version',
+        draftProtocolVersion2026_07_28,
+      );
+      final patchResponse = await patchRequest.close();
+      expect(patchResponse.statusCode, HttpStatus.methodNotAllowed);
+      expect(patchResponse.headers.value(HttpHeaders.allowHeader), 'POST');
+      await patchResponse.drain<void>();
     });
 
     test('rejects unsupported MCP-Protocol-Version header by default',


### PR DESCRIPTION
## Summary
- skip legacy Streamable HTTP GET SSE setup and DELETE session termination when the client transport is using an MCP 2026 stateless protocol version
- route every stateless non-POST server request through the POST-only rejection path with Allow: POST
- cover low-level and high-level Streamable HTTP behavior while preserving 2025 session semantics

## Validation
- dart format .
- dart analyze
- dart test test/client/streamable_https_test.dart
- dart test test/server/streamable_https_test.dart
- dart test test/server/streamable_mcp_server_test.dart
- dart test
- dart pub global run coverage:test_with_coverage