### PR TITLE
Reject stateless server requests on response streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
 - Enforced 2026 stateless Streamable HTTP POST-only behavior by skipping
   legacy client GET/DELETE session paths and returning `Allow: POST` for
   stateless non-POST server requests.
+- Rejected server-initiated JSON-RPC requests on 2026 stateless Streamable HTTP
+  response streams so client input is routed through MRTR input-required
+  results instead.
 - Sorted 2026 stateless high-level `tools/list` responses by tool name for
   deterministic list results while preserving legacy registration-order output.
 - Gated 2026 stateless task extension methods on advertised server extension

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -169,6 +169,7 @@ class StreamableHTTPServerTransport
   final Set<StreamId> _ownedStreamIds = {};
   final Map<dynamic, String> _requestToStreamMapping = {};
   final Map<dynamic, JsonRpcMessage> _requestResponseMap = {};
+  final Set<dynamic> _statelessRequestIds = {};
   bool _initialized = false;
   bool _terminated = false;
   final bool _enableJsonResponse;
@@ -1401,6 +1402,9 @@ class StreamableHTTPServerTransport
             _ownedStreamIds.add(streamId);
             _streamMapping[streamId] = req.response;
             _requestToStreamMapping[reqId] = streamId;
+            if (_isStatelessJsonRpcRequest(message)) {
+              _statelessRequestIds.add(reqId);
+            }
           }
         }
 
@@ -1413,6 +1417,7 @@ class StreamableHTTPServerTransport
               final reqId = (message as JsonRpcRequest).id;
               _requestToStreamMapping.remove(reqId);
               _requestResponseMap.remove(reqId);
+              _statelessRequestIds.remove(reqId);
             }
           }
           await _safeClose(req.response);
@@ -1568,6 +1573,7 @@ class StreamableHTTPServerTransport
     // Clear any pending responses
     _requestResponseMap.clear();
     _requestToStreamMapping.clear(); // Also clear this map
+    _statelessRequestIds.clear();
     onclose?.call();
   }
 
@@ -1585,6 +1591,15 @@ class StreamableHTTPServerTransport
     if (_isJsonRpcResponse(message) || _isJsonRpcError(message)) {
       // If the message is a response, use the request ID from the message
       requestId = _getMessageId(message);
+    }
+
+    if (message is JsonRpcRequest &&
+        requestId != null &&
+        _statelessRequestIds.contains(requestId)) {
+      throw StateError(
+        "Cannot send JSON-RPC requests on stateless MCP response streams; "
+        "return an InputRequiredResult for client input instead.",
+      );
     }
 
     // Check if this message should be sent on the standalone SSE stream (no request ID)
@@ -1699,6 +1714,7 @@ class StreamableHTTPServerTransport
         for (final id in relatedIds) {
           _requestResponseMap.remove(id);
           _requestToStreamMapping.remove(id);
+          _statelessRequestIds.remove(id);
         }
       }
     }

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -2027,6 +2027,77 @@ void main() {
       expect(body['result']['content'], isEmpty);
     });
 
+    test('2026 stateless HTTP rejects server requests on response streams',
+        () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => null,
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      final sendError = Completer<Object>();
+      transport.onmessage = (message) {
+        if (message is JsonRpcListToolsRequest) {
+          final requestSend = transport.send(
+            const JsonRpcListRootsRequest(id: 99),
+            relatedRequestId: message.id,
+          );
+          unawaited(
+            requestSend.then(
+              (_) {},
+              onError: (Object error) {
+                if (!sendError.isCompleted) {
+                  sendError.complete(error);
+                }
+              },
+            ),
+          );
+          unawaited(
+            transport.send(
+              JsonRpcResponse(
+                id: message.id,
+                result: const ListToolsResult(tools: []).toJson(),
+              ),
+            ),
+          );
+        }
+      };
+
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+      final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+      request.headers
+        ..contentType = ContentType.json
+        ..set(HttpHeaders.acceptHeader, 'application/json, text/event-stream')
+        ..set('MCP-Protocol-Version', draftProtocolVersion2026_07_28)
+        ..set('Mcp-Method', Method.toolsList);
+      request.write(
+        jsonEncode(
+          JsonRpcListToolsRequest(id: 10, meta: _statelessMeta()).toJson(),
+        ),
+      );
+
+      final response = await request.close();
+      final messages =
+          _decodeSseJsonMessages(await utf8.decodeStream(response));
+      final error = await sendError.future.timeout(
+        const Duration(seconds: 1),
+      );
+
+      expect(response.statusCode, HttpStatus.ok);
+      expect(messages, hasLength(1));
+      expect(messages.single['id'], 10);
+      expect(messages.single['result']['tools'], isEmpty);
+      expect(error, isA<StateError>());
+      expect(
+        error.toString(),
+        contains('stateless MCP response streams'),
+      );
+    });
+
     test('2026 stateless HTTP validates mapped tool parameter headers',
         () async {
       final transport = StreamableHTTPServerTransport(


### PR DESCRIPTION
## Summary
- track 2026 stateless request response streams separately from legacy Streamable HTTP streams
- reject server-initiated JSON-RPC requests on stateless response streams so client input uses MRTR input-required results
- add a transport regression test and changelog entry

## Validation
- dart format .
- dart analyze
- dart test test/server/streamable_https_test.dart
- dart test
- dart pub global run coverage:test_with_coverage
- git diff --check