### PR TITLE
Escape MCP parameter header sentinels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 - Rejected server-initiated JSON-RPC requests on 2026 stateless Streamable HTTP
   response streams so client input is routed through MRTR input-required
   results instead.
+- Escaped sentinel-shaped `Mcp-Param-*` values with Base64 encoding so literal
+  values beginning with `=?base64?` and ending with `?=` round-trip correctly.
 - Sorted 2026 stateless high-level `tools/list` responses by tool name for
   deterministic list results while preserving legacy registration-order output.
 - Gated 2026 stateless task extension methods on advertised server extension

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -634,10 +634,15 @@ class StreamableHttpClientTransport
   }
 
   bool _isPlainToolParameterHeaderValue(String value) {
-    return value.trim() == value &&
+    return !_isBase64ToolParameterHeaderSentinel(value) &&
+        value.trim() == value &&
         value.codeUnits.every(
           (unit) => unit == 0x09 || (unit >= 0x20 && unit <= 0x7E),
         );
+  }
+
+  bool _isBase64ToolParameterHeaderSentinel(String value) {
+    return value.startsWith('=?base64?') && value.endsWith('?=');
   }
 
   String? _methodFrom(JsonRpcMessage message) {

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -1263,6 +1263,8 @@ void main() {
         capturedHeaders['dryRun'] = request.headers.value('mcp-param-dry-run');
         capturedHeaders['text'] = request.headers.value('mcp-param-text');
         capturedHeaders['payload'] = request.headers.value('mcp-param-payload');
+        capturedHeaders['sentinel'] =
+            request.headers.value('mcp-param-sentinel');
         await request.drain<void>();
         request.response
           ..statusCode = HttpStatus.ok
@@ -1294,6 +1296,7 @@ void main() {
               'dryRun': 'Dry-Run',
               'text': 'Text',
               'payload': 'Payload',
+              'sentinel': 'Sentinel',
             },
           },
         );
@@ -1317,6 +1320,7 @@ void main() {
               'dryRun': false,
               'text': ' padded ',
               'payload': {'nested': true},
+              'sentinel': '=?base64?YWJj?=',
             },
           },
           meta: _statelessMeta(),
@@ -1336,6 +1340,10 @@ void main() {
       expect(capturedHeaders['dryRun'], 'false');
       expect(capturedHeaders['text'], '=?base64?IHBhZGRlZCA=?=');
       expect(capturedHeaders['payload'], isNull);
+      expect(
+        capturedHeaders['sentinel'],
+        '=?base64?${base64Encode(utf8.encode('=?base64?YWJj?='))}?=',
+      );
     });
 
     test('send with initialized notification triggers SSE establishment',

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -2113,6 +2113,7 @@ void main() {
             'rounded': 'Rounded',
             'ratio': 'Ratio',
             'region': 'Region',
+            'sentinel': 'Sentinel',
           },
         },
       );
@@ -2252,6 +2253,24 @@ void main() {
       );
       expect(statusCode, HttpStatus.ok);
       expect(body['id'], 35);
+      expect(body['result']['content'], isEmpty);
+
+      (statusCode, body) = await postToolCall(
+        id: 36,
+        arguments: const {
+          'dryRun': false,
+          'region': 'us-east1',
+          'sentinel': '=?base64?YWJj?=',
+        },
+        headers: {
+          'Mcp-Param-Dry-Run': 'false',
+          'Mcp-Param-Region': 'us-east1',
+          'Mcp-Param-Sentinel':
+              '=?base64?${base64Encode(utf8.encode('=?base64?YWJj?='))}?=',
+        },
+      );
+      expect(statusCode, HttpStatus.ok);
+      expect(body['id'], 36);
       expect(body['result']['content'], isEmpty);
 
       (statusCode, body) = await postToolCall(


### PR DESCRIPTION
## Summary
- base64-escape literal `Mcp-Param-*` values that match the `=?base64?...?=` sentinel pattern
- add client coverage for encoded sentinel-shaped tool arguments
- add server validation coverage for decoded sentinel literals and document the RC behavior

## Validation
- dart format .
- dart analyze
- dart test test/client/streamable_https_test.dart
- dart test test/server/streamable_https_test.dart
- dart test
- dart pub global run coverage:test_with_coverage
- git diff --check