### PR TITLE
Support nested MCP parameter headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
   results instead.
 - Escaped sentinel-shaped `Mcp-Param-*` values with Base64 encoding so literal
   values beginning with `=?base64?` and ending with `?=` round-trip correctly.
+- Synced nested 2026 `x-mcp-header` mappings into Streamable HTTP transports
+  using JSON Pointer selectors for nested tool arguments.
 - Sorted 2026 stateless high-level `tools/list` responses by tool name for
   deterministic list results while preserving legacy registration-order output.
 - Gated 2026 stateless task extension methods on advertised server extension

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -879,50 +879,96 @@ class McpClient extends Protocol {
 
     final mappings = <String, String>{};
     final seenHeaders = <String>{};
+    final rejectionReason = _collectToolParameterHeaderMappings(
+      properties: properties,
+      path: const [],
+      mappings: mappings,
+      seenHeaders: seenHeaders,
+    );
+
+    if (rejectionReason != null) {
+      return _ToolParameterHeaderValidation.invalid(rejectionReason);
+    }
+
+    return _ToolParameterHeaderValidation.valid(mappings);
+  }
+
+  String? _collectToolParameterHeaderMappings({
+    required Map<String, JsonSchema> properties,
+    required List<String> path,
+    required Map<String, String> mappings,
+    required Set<String> seenHeaders,
+  }) {
     for (final entry in properties.entries) {
+      final parameterPath = [...path, entry.key];
+      final parameterName = _toolParameterHeaderParameterName(parameterPath);
       final propertyJson = entry.value.toJson();
       if (!propertyJson.containsKey('x-mcp-header')) {
+        if (entry.value is JsonObject) {
+          final childProperties = (entry.value as JsonObject).properties;
+          if (childProperties != null && childProperties.isNotEmpty) {
+            final rejectionReason = _collectToolParameterHeaderMappings(
+              properties: childProperties,
+              path: parameterPath,
+              mappings: mappings,
+              seenHeaders: seenHeaders,
+            );
+            if (rejectionReason != null) {
+              return rejectionReason;
+            }
+          }
+        }
         continue;
       }
 
       final rawHeader = propertyJson['x-mcp-header'];
       if (rawHeader is! String) {
-        return _ToolParameterHeaderValidation.invalid(
-          'parameter "${entry.key}" has a non-string x-mcp-header value',
-        );
+        return 'parameter "$parameterName" has a non-string x-mcp-header value';
       }
 
       if (rawHeader.isEmpty) {
-        return _ToolParameterHeaderValidation.invalid(
-          'parameter "${entry.key}" has an empty x-mcp-header value',
-        );
+        return 'parameter "$parameterName" has an empty x-mcp-header value';
       }
 
       if (!_isValidMcpHeaderNameSuffix(rawHeader)) {
-        return _ToolParameterHeaderValidation.invalid(
-          'parameter "${entry.key}" has invalid x-mcp-header value '
-          '"$rawHeader"',
-        );
+        return 'parameter "$parameterName" has invalid x-mcp-header value '
+            '"$rawHeader"';
       }
 
       final normalizedHeader = rawHeader.toLowerCase();
       if (!seenHeaders.add(normalizedHeader)) {
-        return _ToolParameterHeaderValidation.invalid(
-          'x-mcp-header value "$rawHeader" is not unique',
-        );
+        return 'x-mcp-header value "$rawHeader" is not unique';
       }
 
       if (!_isToolParameterHeaderPrimitive(entry.value)) {
-        return _ToolParameterHeaderValidation.invalid(
-          'parameter "${entry.key}" uses x-mcp-header on a schema that is not '
-          'string, integer, or boolean',
-        );
+        return 'parameter "$parameterName" uses x-mcp-header on a schema that '
+            'is not string, integer, or boolean';
       }
 
-      mappings[entry.key] = rawHeader;
+      mappings[_toolParameterHeaderSelector(parameterPath)] = rawHeader;
     }
 
-    return _ToolParameterHeaderValidation.valid(mappings);
+    return null;
+  }
+
+  String _toolParameterHeaderSelector(List<String> path) {
+    if (path.length == 1) {
+      return path.single;
+    }
+
+    return '/${path.map(_escapeJsonPointerSegment).join('/')}';
+  }
+
+  String _toolParameterHeaderParameterName(List<String> path) {
+    if (path.length == 1) {
+      return path.single;
+    }
+
+    return _toolParameterHeaderSelector(path);
+  }
+
+  String _escapeJsonPointerSegment(String segment) {
+    return segment.replaceAll('~', '~0').replaceAll('/', '~1');
   }
 
   bool _isValidMcpHeaderNameSuffix(String value) {

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -578,11 +578,12 @@ class StreamableHttpClientTransport
     final argumentMap = arguments.cast<String, dynamic>();
     final headers = <String, String>{};
     for (final entry in mappings.entries) {
-      if (!argumentMap.containsKey(entry.key)) {
+      final argument = _toolParameterHeaderArgument(argumentMap, entry.key);
+      if (!argument.exists) {
         continue;
       }
 
-      final value = _toolParameterHeaderString(argumentMap[entry.key]);
+      final value = _toolParameterHeaderString(argument.value);
       if (value == null) {
         continue;
       }
@@ -591,6 +592,37 @@ class StreamableHttpClientTransport
           _encodeToolParameterHeaderValue(value);
     }
     return headers;
+  }
+
+  ({bool exists, Object? value}) _toolParameterHeaderArgument(
+    Map<String, dynamic> arguments,
+    String selector,
+  ) {
+    if (!selector.startsWith('/')) {
+      return (
+        exists: arguments.containsKey(selector),
+        value: arguments[selector],
+      );
+    }
+
+    Object? current = arguments;
+    for (final segment in _jsonPointerSegments(selector)) {
+      if (current is! Map || !current.containsKey(segment)) {
+        return (exists: false, value: null);
+      }
+      current = current[segment];
+    }
+    return (exists: true, value: current);
+  }
+
+  Iterable<String> _jsonPointerSegments(String selector) {
+    if (selector == '/') {
+      return const [''];
+    }
+    return selector
+        .substring(1)
+        .split('/')
+        .map((segment) => segment.replaceAll('~1', '/').replaceAll('~0', '~'));
   }
 
   String? _toolParameterHeaderString(Object? value) {

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -1081,51 +1081,99 @@ class McpServer {
 
     final mappings = <String, String>{};
     final seenHeaders = <String>{};
+    final ignoredReason = _collectToolParameterHeaderMappings(
+      toolName: tool.name,
+      properties: properties,
+      path: const [],
+      mappings: mappings,
+      seenHeaders: seenHeaders,
+    );
+
+    if (ignoredReason != null) {
+      _logger.warn(ignoredReason);
+      return const {};
+    }
+
+    return mappings;
+  }
+
+  String? _collectToolParameterHeaderMappings({
+    required String toolName,
+    required Map<String, JsonSchema> properties,
+    required List<String> path,
+    required Map<String, String> mappings,
+    required Set<String> seenHeaders,
+  }) {
     for (final entry in properties.entries) {
+      final parameterPath = [...path, entry.key];
+      final parameterName = _toolParameterHeaderParameterName(parameterPath);
       final propertyJson = entry.value.toJson();
       if (!propertyJson.containsKey('x-mcp-header')) {
+        if (entry.value is JsonObject) {
+          final childProperties = (entry.value as JsonObject).properties;
+          if (childProperties != null && childProperties.isNotEmpty) {
+            final ignoredReason = _collectToolParameterHeaderMappings(
+              toolName: toolName,
+              properties: childProperties,
+              path: parameterPath,
+              mappings: mappings,
+              seenHeaders: seenHeaders,
+            );
+            if (ignoredReason != null) {
+              return ignoredReason;
+            }
+          }
+        }
         continue;
       }
 
       final rawHeader = propertyJson['x-mcp-header'];
       if (rawHeader is! String || rawHeader.isEmpty) {
-        _logger.warn(
-          'Ignoring x-mcp-header mapping for tool "${tool.name}" parameter '
-          '"${entry.key}": value must be a non-empty string.',
-        );
-        return const {};
+        return 'Ignoring x-mcp-header mapping for tool "$toolName" parameter '
+            '"$parameterName": value must be a non-empty string.';
       }
 
       if (!_isValidMcpHeaderNameSuffix(rawHeader)) {
-        _logger.warn(
-          'Ignoring x-mcp-header mapping for tool "${tool.name}" parameter '
-          '"${entry.key}": "$rawHeader" is not a valid Mcp-Param suffix.',
-        );
-        return const {};
+        return 'Ignoring x-mcp-header mapping for tool "$toolName" parameter '
+            '"$parameterName": "$rawHeader" is not a valid Mcp-Param suffix.';
       }
 
       final normalizedHeader = rawHeader.toLowerCase();
       if (!seenHeaders.add(normalizedHeader)) {
-        _logger.warn(
-          'Ignoring x-mcp-header mappings for tool "${tool.name}": '
-          '"$rawHeader" is not unique.',
-        );
-        return const {};
+        return 'Ignoring x-mcp-header mappings for tool "$toolName": '
+            '"$rawHeader" is not unique.';
       }
 
       if (!_isToolParameterHeaderPrimitive(entry.value)) {
-        _logger.warn(
-          'Ignoring x-mcp-header mapping for tool "${tool.name}" parameter '
-          '"${entry.key}": only string, integer, and boolean schemas can be '
-          'mirrored.',
-        );
-        return const {};
+        return 'Ignoring x-mcp-header mapping for tool "$toolName" parameter '
+            '"$parameterName": only string, integer, and boolean schemas can '
+            'be mirrored.';
       }
 
-      mappings[entry.key] = rawHeader;
+      mappings[_toolParameterHeaderSelector(parameterPath)] = rawHeader;
     }
 
-    return mappings;
+    return null;
+  }
+
+  String _toolParameterHeaderSelector(List<String> path) {
+    if (path.length == 1) {
+      return path.single;
+    }
+
+    return '/${path.map(_escapeJsonPointerSegment).join('/')}';
+  }
+
+  String _toolParameterHeaderParameterName(List<String> path) {
+    if (path.length == 1) {
+      return path.single;
+    }
+
+    return _toolParameterHeaderSelector(path);
+  }
+
+  String _escapeJsonPointerSegment(String segment) {
+    return segment.replaceAll('~', '~0').replaceAll('/', '~1');
   }
 
   bool _isValidMcpHeaderNameSuffix(String value) {

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -590,8 +590,9 @@ class StreamableHTTPServerTransport
         final argumentName = entry.key;
         final headerSuffix = entry.value;
         final header = headers[headerSuffix.toLowerCase()];
-        final hasArgument = argumentMap.containsKey(argumentName);
-        final bodyArgument = hasArgument ? argumentMap[argumentName] : null;
+        final argument = _toolParameterHeaderArgument(argumentMap, entry.key);
+        final hasArgument = argument.exists;
+        final bodyArgument = argument.value;
         final bodyValue =
             hasArgument ? _primitiveHeaderString(bodyArgument) : null;
 
@@ -668,6 +669,37 @@ class StreamableHTTPServerTransport
     }
 
     return true;
+  }
+
+  ({bool exists, Object? value}) _toolParameterHeaderArgument(
+    Map<String, dynamic> arguments,
+    String selector,
+  ) {
+    if (!selector.startsWith('/')) {
+      return (
+        exists: arguments.containsKey(selector),
+        value: arguments[selector],
+      );
+    }
+
+    Object? current = arguments;
+    for (final segment in _jsonPointerSegments(selector)) {
+      if (current is! Map || !current.containsKey(segment)) {
+        return (exists: false, value: null);
+      }
+      current = current[segment];
+    }
+    return (exists: true, value: current);
+  }
+
+  Iterable<String> _jsonPointerSegments(String selector) {
+    if (selector == '/') {
+      return const [''];
+    }
+    return selector
+        .substring(1)
+        .split('/')
+        .map((segment) => segment.replaceAll('~1', '/').replaceAll('~0', '~'));
   }
 
   Future<bool> _validateStatelessHttpHeaders(

--- a/lib/src/shared/transport.dart
+++ b/lib/src/shared/transport.dart
@@ -93,7 +93,10 @@ abstract class ProtocolVersionAwareTransport {
   set protocolVersion(String? value);
 }
 
-/// Maps tool names to argument names and their `Mcp-Param-*` header suffixes.
+/// Maps tool names to argument selectors and their `Mcp-Param-*` header suffixes.
+///
+/// Top-level arguments use their argument name as the selector. Nested
+/// arguments use JSON Pointer selectors such as `/auth/tenant`.
 typedef ToolParameterHeaderMappings = Map<String, Map<String, String>>;
 
 /// Optional capability for transports that can mirror tool arguments into

--- a/test/client/client_tool_validation_test.dart
+++ b/test/client/client_tool_validation_test.dart
@@ -153,6 +153,11 @@ void main() {
                 'limit': JsonSchema.integer(mcpHeader: 'Limit'),
                 'dryRun': JsonSchema.boolean(mcpHeader: 'Dry-Run'),
                 'count': JsonSchema.integer(mcpHeader: 'Count'),
+                'auth': JsonSchema.object(
+                  properties: {
+                    'tenant': JsonSchema.string(mcpHeader: 'Tenant'),
+                  },
+                ),
               },
             ),
           ),
@@ -218,6 +223,7 @@ void main() {
           'limit': 'Limit',
           'dryRun': 'Dry-Run',
           'count': 'Count',
+          '/auth/tenant': 'Tenant',
         },
       });
       expect(

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -1265,6 +1265,7 @@ void main() {
         capturedHeaders['payload'] = request.headers.value('mcp-param-payload');
         capturedHeaders['sentinel'] =
             request.headers.value('mcp-param-sentinel');
+        capturedHeaders['tenant'] = request.headers.value('mcp-param-tenant');
         await request.drain<void>();
         request.response
           ..statusCode = HttpStatus.ok
@@ -1297,6 +1298,7 @@ void main() {
               'text': 'Text',
               'payload': 'Payload',
               'sentinel': 'Sentinel',
+              '/auth/tenant': 'Tenant',
             },
           },
         );
@@ -1321,6 +1323,7 @@ void main() {
               'text': ' padded ',
               'payload': {'nested': true},
               'sentinel': '=?base64?YWJj?=',
+              'auth': {'tenant': 'acme'},
             },
           },
           meta: _statelessMeta(),
@@ -1344,6 +1347,7 @@ void main() {
         capturedHeaders['sentinel'],
         '=?base64?${base64Encode(utf8.encode('=?base64?YWJj?='))}?=',
       );
+      expect(capturedHeaders['tenant'], 'acme');
     });
 
     test('send with initialized notification triggers SSE establishment',

--- a/test/server/mcp_server_test.dart
+++ b/test/server/mcp_server_test.dart
@@ -122,6 +122,11 @@ void main() {
           properties: {
             'dryRun': JsonBoolean(mcpHeader: 'Dry-Run'),
             'region': JsonString(mcpHeader: 'Region'),
+            'auth': JsonObject(
+              properties: {
+                'tenant': JsonString(mcpHeader: 'Tenant'),
+              },
+            ),
           },
         ),
         callback: (args, extra) async => const CallToolResult(content: []),
@@ -137,6 +142,7 @@ void main() {
             'header-tool': {
               'dryRun': 'Dry-Run',
               'region': 'Region',
+              '/auth/tenant': 'Tenant',
             },
           },
         ),

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -2114,6 +2114,7 @@ void main() {
             'ratio': 'Ratio',
             'region': 'Region',
             'sentinel': 'Sentinel',
+            '/location/zone': 'Zone',
           },
         },
       );
@@ -2271,6 +2272,23 @@ void main() {
       );
       expect(statusCode, HttpStatus.ok);
       expect(body['id'], 36);
+      expect(body['result']['content'], isEmpty);
+
+      (statusCode, body) = await postToolCall(
+        id: 37,
+        arguments: const {
+          'dryRun': false,
+          'region': 'us-east1',
+          'location': {'zone': 'us-east1-b'},
+        },
+        headers: const {
+          'Mcp-Param-Dry-Run': 'false',
+          'Mcp-Param-Region': 'us-east1',
+          'Mcp-Param-Zone': 'us-east1-b',
+        },
+      );
+      expect(statusCode, HttpStatus.ok);
+      expect(body['id'], 37);
       expect(body['result']['content'], isEmpty);
 
       (statusCode, body) = await postToolCall(


### PR DESCRIPTION
## Summary
- discover `x-mcp-header` annotations at nested object-property depths in tool schemas
- sync nested mappings into Streamable HTTP transports using JSON Pointer selectors while preserving top-level selector compatibility
- mirror and validate nested `tools/call` arguments through `Mcp-Param-*` headers

## Validation
- dart format .
- dart analyze
- dart test test/client/client_tool_validation_test.dart
- dart test test/client/streamable_https_test.dart
- dart test test/server/mcp_server_test.dart
- dart test test/server/streamable_https_test.dart
- dart test
- dart pub global run coverage:test_with_coverage
- git diff --check