### PR TITLE
Return 404 for stateless method not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@
   values beginning with `=?base64?` and ending with `?=` round-trip correctly.
 - Synced nested 2026 `x-mcp-header` mappings into Streamable HTTP transports
   using JSON Pointer selectors for nested tool arguments.
+- Returned HTTP 404 with JSON-RPC `Method not found` for unsupported or removed
+  2026 stateless Streamable HTTP request methods before opening response
+  streams.
 - Sorted 2026 stateless high-level `tools/list` responses by tool name for
   deterministic list results while preserving legacy registration-order output.
 - Gated 2026 stateless task extension methods on advertised server extension

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -159,6 +159,7 @@ class StreamableHTTPServerTransport
     implements
         Transport,
         RequestIdAwareTransport,
+        IncomingRequestValidationAwareTransport,
         ToolParameterHeaderAwareTransport {
   // when sessionId is not set (null), it means the transport is in stateless mode
   final String? Function()? _sessionIdGenerator;
@@ -184,6 +185,8 @@ class StreamableHTTPServerTransport
   final bool _rejectBatchJsonRpcPayloads;
   final int _maxReplayedEvents;
   ToolParameterHeaderMappings _toolParameterHeaderMappings = const {};
+  McpError? Function(JsonRpcRequest request)? _incomingRequestValidator;
+  bool Function(String method)? _isRequestMethodSupported;
   static const JsonRpcNotification _ssePrimingMessage =
       JsonRpcNotification(method: 'notifications/experimental/sse/priming');
 
@@ -232,6 +235,18 @@ class StreamableHTTPServerTransport
       for (final entry in mappings.entries)
         entry.key: Map.unmodifiable(Map<String, String>.from(entry.value)),
     };
+  }
+
+  @override
+  void setIncomingRequestValidator(
+    McpError? Function(JsonRpcRequest request) validator,
+  ) {
+    _incomingRequestValidator = validator;
+  }
+
+  @override
+  void setRequestMethodSupported(bool Function(String method) isSupported) {
+    _isRequestMethodSupported = isSupported;
   }
 
   /// Handles an incoming HTTP request, whether GET or POST
@@ -342,6 +357,24 @@ class StreamableHTTPServerTransport
     required String message,
     RequestId? id,
     Object? data,
+  }) {
+    return _writeJsonRpcErrorCodeResponse(
+      response,
+      httpStatus: httpStatus,
+      errorCode: errorCode.value,
+      message: message,
+      id: id,
+      data: data,
+    );
+  }
+
+  Future<void> _writeJsonRpcErrorCodeResponse(
+    HttpResponse response, {
+    required int httpStatus,
+    required int errorCode,
+    required String message,
+    RequestId? id,
+    Object? data,
   }) async {
     response.statusCode = httpStatus;
     response.write(
@@ -349,7 +382,7 @@ class StreamableHTTPServerTransport
         JsonRpcError(
           id: id,
           error: JsonRpcErrorData(
-            code: errorCode.value,
+            code: errorCode,
             message: message,
             data: data,
           ),
@@ -357,6 +390,14 @@ class StreamableHTTPServerTransport
       ),
     );
     await _safeClose(response);
+  }
+
+  int _statelessHttpStatusForErrorCode(int code) {
+    if (code == ErrorCode.methodNotFound.value) {
+      return HttpStatus.notFound;
+    }
+
+    return HttpStatus.badRequest;
   }
 
   Future<void> _writeHeaderMismatchResponse(
@@ -811,7 +852,39 @@ class StreamableHTTPServerTransport
       }
     }
 
-    return _validateMcpParamHeaders(req, req.response, message);
+    if (!await _validateMcpParamHeaders(req, req.response, message)) {
+      return false;
+    }
+
+    if (message is JsonRpcRequest) {
+      final validationError = _incomingRequestValidator?.call(message);
+      if (validationError != null) {
+        await _writeJsonRpcErrorCodeResponse(
+          req.response,
+          httpStatus: _statelessHttpStatusForErrorCode(validationError.code),
+          errorCode: validationError.code,
+          id: message.id,
+          message: validationError.message,
+          data: validationError.data,
+        );
+        return false;
+      }
+
+      final isRequestMethodSupported = _isRequestMethodSupported;
+      if (isRequestMethodSupported != null &&
+          !isRequestMethodSupported(message.method)) {
+        await _writeJsonRpcErrorResponse(
+          req.response,
+          httpStatus: HttpStatus.notFound,
+          errorCode: ErrorCode.methodNotFound,
+          id: message.id,
+          message: 'Method not found: ${message.method}',
+        );
+        return false;
+      }
+    }
+
+    return true;
   }
 
   bool _isStandaloneSseStreamId(StreamId streamId) {

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -506,6 +506,15 @@ abstract class Protocol {
       throw StateError("Protocol already connected to a transport.");
     }
     _transport = transport;
+    if (transport is IncomingRequestValidationAwareTransport) {
+      final validationAwareTransport =
+          transport as IncomingRequestValidationAwareTransport;
+      validationAwareTransport.setIncomingRequestValidator(
+        validateIncomingRequest,
+      );
+      validationAwareTransport
+          .setRequestMethodSupported(_supportsRequestMethod);
+    }
     _transport!.onclose = _onclose;
     _transport!.onerror = _onerror;
     _transport!.onmessage = (message) {
@@ -541,6 +550,9 @@ abstract class Protocol {
       rethrow;
     }
   }
+
+  bool _supportsRequestMethod(String method) =>
+      _requestHandlers.containsKey(method) || fallbackRequestHandler != null;
 
   /// Gets the currently attached transport, or null if not connected.
   Transport? get transport => _transport;

--- a/lib/src/shared/transport.dart
+++ b/lib/src/shared/transport.dart
@@ -107,3 +107,15 @@ abstract class ToolParameterHeaderAwareTransport {
     ToolParameterHeaderMappings mappings,
   );
 }
+
+/// Optional capability for transports that can validate incoming requests
+/// before committing transport-level response details.
+abstract class IncomingRequestValidationAwareTransport {
+  /// Supplies the protocol-level request validator.
+  void setIncomingRequestValidator(
+    McpError? Function(JsonRpcRequest request) validator,
+  );
+
+  /// Supplies a live request-method support predicate.
+  void setRequestMethodSupported(bool Function(String method) isSupported);
+}

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:mcp_dart/src/server/server.dart';
 import 'package:mcp_dart/src/server/streamable_https.dart';
 import 'package:mcp_dart/src/shared/uuid.dart';
 import 'package:mcp_dart/src/types.dart';
@@ -2483,6 +2484,66 @@ void main() {
         },
       );
       expect(body['error']['message'], contains('must contain one'));
+    });
+
+    test('2026 stateless HTTP returns 404 for method not found', () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => "unused-session-id",
+        ),
+      );
+      final server = Server(
+        const Implementation(name: 'StatelessServer', version: '1.0.0'),
+      );
+      addTearDown(server.close);
+      await server.connect(transport);
+      transports['/mcp'] = transport;
+
+      Future<Map<String, dynamic>> postStatelessRequest(
+        JsonRpcRequest message,
+      ) async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers
+          ..contentType = ContentType.json
+          ..set(
+            HttpHeaders.acceptHeader,
+            'application/json, text/event-stream',
+          )
+          ..set('MCP-Protocol-Version', draftProtocolVersion2026_07_28)
+          ..set('Mcp-Method', message.method);
+        request.write(jsonEncode(message.toJson()));
+
+        final response = await request.close();
+        expect(response.statusCode, HttpStatus.notFound);
+        final body = jsonDecode(await utf8.decodeStream(response))
+            as Map<String, dynamic>;
+        expect(body['id'], message.id);
+        expect(body['error']['code'], ErrorCode.methodNotFound.value);
+        return body;
+      }
+
+      var body = await postStatelessRequest(
+        JsonRpcRequest(
+          id: 20,
+          method: 'experimental/unknown',
+          meta: _statelessMeta(),
+        ),
+      );
+      expect(body['error']['message'], contains('experimental/unknown'));
+
+      body = await postStatelessRequest(
+        JsonRpcRequest(
+          id: 21,
+          method: Method.ping,
+          meta: _statelessMeta(),
+        ),
+      );
+      expect(
+        body['error']['message'],
+        contains('not part of MCP stateless protocol versions'),
+      );
     });
 
     test('stateless mode allows initialization with session header', () async {


### PR DESCRIPTION
## Summary
- add a transport/protocol hook so Streamable HTTP can reject unsupported stateless request methods before opening a response stream
- map stateless protocol validation errors with JSON-RPC method-not-found codes to HTTP 404
- cover unknown and removed stateless methods with an HTTP-level regression test

## Spec
- Draft Streamable HTTP says unimplemented requested RPC methods must return HTTP 404 with JSON-RPC -32601: https://modelcontextprotocol.io/specification/draft/basic/transports#protocol-version-header

## Validation
- dart format .
- dart analyze
- dart test test/server/streamable_https_test.dart --name "2026 stateless HTTP returns 404 for method not found"
- dart test test/server/streamable_https_test.dart
- dart test test/mcp_2026_07_28_test.dart
- dart test test/shared/protocol_test.dart
- dart test
- dart pub global run coverage:test_with_coverage
- git diff --check