### PR TITLE
Ignore stateless session headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
   mirrored tool headers limited to string, JavaScript-safe integer, and boolean
   parameters.
 - Removed `Mcp-Session-Id` from 2026 stateless Streamable HTTP requests by
-  stripping it from client sends and rejecting it on stateless server POSTs.
+  stripping it from client sends and ignoring it on stateless server POSTs.
 - Enforced 2026 stateless Streamable HTTP POST-only behavior by skipping
   legacy client GET/DELETE session paths and returning `Allow: POST` for
   stateless non-POST server requests.

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -798,16 +798,6 @@ class StreamableHTTPServerTransport
       );
       return false;
     }
-    if (isStatelessProtocolVersion(protocolHeader) &&
-        req.headers.value('mcp-session-id') != null) {
-      await _writeHeaderMismatchResponse(
-        req.response,
-        message,
-        'Mcp-Session-Id header is not part of MCP stateless protocol versions',
-      );
-      return false;
-    }
-
     final method = _messageMethod(message);
     if (method == null) {
       return true;

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -1932,7 +1932,7 @@ void main() {
       expect(body['error']['message'], contains('Mcp-Name header is required'));
     });
 
-    test('2026 stateless HTTP rejects session header', () async {
+    test('2026 stateless HTTP ignores session header', () async {
       final transport = StreamableHTTPServerTransport(
         options: StreamableHTTPServerTransportOptions(
           sessionIdGenerator: () => "unused-session-id",
@@ -1942,6 +1942,19 @@ void main() {
       addTearDown(transport.close);
       await transport.start();
       transports['/mcp'] = transport;
+
+      transport.onmessage = (message) {
+        if (message is JsonRpcListToolsRequest) {
+          unawaited(
+            transport.send(
+              JsonRpcResponse(
+                id: message.id,
+                result: const ListToolsResult(tools: []).toJson(),
+              ),
+            ),
+          );
+        }
+      };
 
       final client = HttpClient();
       addTearDown(() => client.close(force: true));
@@ -1958,12 +1971,12 @@ void main() {
 
       final response = await request.close();
 
-      expect(response.statusCode, HttpStatus.badRequest);
+      expect(response.statusCode, HttpStatus.ok);
+      expect(response.headers.value('mcp-session-id'), isNull);
       final body =
           jsonDecode(await utf8.decodeStream(response)) as Map<String, dynamic>;
       expect(body['id'], 6);
-      expect(body['error']['code'], ErrorCode.headerMismatch.value);
-      expect(body['error']['message'], contains('Mcp-Session-Id header'));
+      expect(body['result']['tools'], isEmpty);
     });
 
     test('2026 stateless HTTP accepts matching standard and parameter headers',


### PR DESCRIPTION
## Summary
- align 2026 stateless Streamable HTTP with the current draft by ignoring incoming Mcp-Session-Id headers instead of rejecting them
- keep the client-side behavior that strips Mcp-Session-Id from 2026 stateless requests
- update the HTTP regression to prove the server accepts the request and does not echo a session id

## Spec
- Draft Streamable HTTP earlier-revision compatibility says a 2026-only server receiving an Mcp-Session-Id header should ignore it and not mint or echo session IDs: https://modelcontextprotocol.io/specification/draft/basic/transports#earlier-streamable-http-revisions

## Validation
- dart format .
- dart analyze
- dart test test/server/streamable_https_test.dart --name "2026 stateless HTTP ignores session header"
- dart test test/server/streamable_https_test.dart --name "2026 stateless HTTP"
- dart test
- dart pub global run coverage:test_with_coverage
- git diff --check