### PR TITLE
Validate stateless response result types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
 - Added request-scoped stateless logging gating via
   `io.modelcontextprotocol/logLevel` metadata so 2026 log notifications are
   emitted only when the current request opts in.
+- Rejected unrecognized 2026 stateless response `resultType` values on the
+  client while keeping absent `resultType` compatible with stable result parsing.
 
 ## 2.2.0
 

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -454,6 +454,16 @@ class McpClient extends Protocol {
   String? getProtocolVersion() => _negotiatedProtocolVersion;
 
   @override
+  bool isRecognizedResultType(String resultType) {
+    if (super.isRecognizedResultType(resultType)) {
+      return true;
+    }
+
+    return resultType == resultTypeTask &&
+        (_serverCapabilities?.supportsTasksExtension ?? false);
+  }
+
+  @override
   McpError? validateIncomingRequest(JsonRpcRequest request) {
     if (_sentInitialized || request.method == Method.ping) {
       return null;

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -399,6 +399,50 @@ abstract class Protocol {
     }
   }
 
+  /// Returns whether [resultType] is recognized for result parsing.
+  @protected
+  bool isRecognizedResultType(String resultType) {
+    return resultType == resultTypeComplete ||
+        resultType == resultTypeInputRequired;
+  }
+
+  bool _usesStatelessResultTypes(JsonRpcRequest request) {
+    final requestProtocolVersion = request.meta?[McpMetaKey.protocolVersion];
+    if (requestProtocolVersion is String &&
+        isStatelessProtocolVersion(requestProtocolVersion)) {
+      return true;
+    }
+
+    final Object? activeTransport = _transport;
+    if (activeTransport is! ProtocolVersionAwareTransport) {
+      return false;
+    }
+
+    final transportProtocolVersion = activeTransport.protocolVersion;
+    return transportProtocolVersion != null &&
+        isStatelessProtocolVersion(transportProtocolVersion);
+  }
+
+  void _validateResponseResultType(
+    JsonRpcRequest request,
+    Map<String, dynamic> resultJson,
+  ) {
+    if (!_usesStatelessResultTypes(request)) {
+      return;
+    }
+
+    final resultType = resultJson['resultType'];
+    if (resultType == null) {
+      return;
+    }
+    if (resultType is! String) {
+      throw const FormatException('MCP resultType must be a string');
+    }
+    if (!isRecognizedResultType(resultType)) {
+      throw FormatException('Unrecognized MCP resultType "$resultType"');
+    }
+  }
+
   void _registerTaskHandlers() {
     setRequestHandler<JsonRpcGetTaskRequest>(
       Method.tasksGet,
@@ -1674,8 +1718,10 @@ abstract class Protocol {
       Object? taskCancellationError;
       late final T result;
       try {
+        final resultJson = response.toJson()['result'] as Map<String, dynamic>;
+        _validateResponseResultType(jsonrpcRequest, resultJson);
         result = resultFactory(
-          response.toJson()['result'] as Map<String, dynamic>,
+          resultJson,
         );
         final state = taskRequestState;
         if (state != null) {

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -42,9 +42,15 @@ class DiscoveringClientTransport extends Transport
     implements ProtocolVersionAwareTransport {
   DiscoveringClientTransport({
     this.discoverVersions = const [draftProtocolVersion2026_07_28],
+    this.capabilities = const ServerCapabilities(
+      tools: ServerCapabilitiesTools(),
+    ),
+    this.toolsListResult = const {'tools': []},
   });
 
   final List<String> discoverVersions;
+  final ServerCapabilities capabilities;
+  final Map<String, dynamic> toolsListResult;
   final List<JsonRpcMessage> sentMessages = [];
 
   @override
@@ -68,9 +74,7 @@ class DiscoveringClientTransport extends Transport
           id: message.id,
           result: DiscoverResult(
             supportedVersions: discoverVersions,
-            capabilities: const ServerCapabilities(
-              tools: ServerCapabilitiesTools(),
-            ),
+            capabilities: capabilities,
             serverInfo: const Implementation(name: 'server', version: '1.0.0'),
           ).toJson(),
         ),
@@ -82,7 +86,7 @@ class DiscoveringClientTransport extends Transport
       onmessage?.call(
         JsonRpcResponse(
           id: message.id,
-          result: const ListToolsResult(tools: []).toJson(),
+          result: toolsListResult,
         ),
       );
     }
@@ -94,6 +98,11 @@ class DiscoveringClientTransport extends Transport
 
 class LegacyFallbackTransport extends Transport
     implements ProtocolVersionAwareTransport {
+  LegacyFallbackTransport({
+    this.toolsListResult = const {'tools': []},
+  });
+
+  final Map<String, dynamic> toolsListResult;
   final List<JsonRpcMessage> sentMessages = [];
 
   @override
@@ -135,6 +144,16 @@ class LegacyFallbackTransport extends Transport
             ),
             serverInfo: Implementation(name: 'server', version: '1.0.0'),
           ).toJson(),
+        ),
+      );
+      return;
+    }
+
+    if (message is JsonRpcRequest && message.method == Method.toolsList) {
+      onmessage?.call(
+        JsonRpcResponse(
+          id: message.id,
+          result: toolsListResult,
         ),
       );
     }
@@ -1694,6 +1713,118 @@ void main() {
         'version': '1.0.0',
       });
       expect(listRequest.meta?[McpMetaKey.clientCapabilities], {});
+    });
+
+    test('client rejects unrecognized stateless resultType values', () async {
+      final transport = DiscoveringClientTransport(
+        toolsListResult: const {
+          'resultType': 'future_extension',
+          'tools': [],
+        },
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+
+      await client.connect(transport);
+
+      await expectLater(
+        client.listTools(),
+        throwsA(
+          isA<McpError>()
+              .having(
+                (error) => error.code,
+                'code',
+                ErrorCode.internalError.value,
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                contains('Failed to parse result for ${Method.toolsList}'),
+              )
+              .having(
+                (error) => error.data.toString(),
+                'data',
+                contains('Unrecognized MCP resultType "future_extension"'),
+              ),
+        ),
+      );
+    });
+
+    test('client rejects non-string stateless resultType values', () async {
+      final transport = DiscoveringClientTransport(
+        toolsListResult: const {
+          'resultType': 42,
+          'tools': [],
+        },
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+
+      await client.connect(transport);
+
+      await expectLater(
+        client.listTools(),
+        throwsA(
+          isA<McpError>()
+              .having(
+                (error) => error.code,
+                'code',
+                ErrorCode.internalError.value,
+              )
+              .having(
+                (error) => error.data.toString(),
+                'data',
+                contains('MCP resultType must be a string'),
+              ),
+        ),
+      );
+    });
+
+    test('client accepts advertised task extension resultType values',
+        () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: ServerCapabilities(
+          tools: const ServerCapabilitiesTools(),
+          extensions: withMcpTasksExtension(null),
+        ),
+        toolsListResult: const {
+          'resultType': resultTypeTask,
+          'tools': [],
+        },
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+
+      await client.connect(transport);
+
+      final result = await client.listTools();
+      expect(result.tools, isEmpty);
+    });
+
+    test('stable client sessions do not validate future resultType values',
+        () async {
+      final transport = LegacyFallbackTransport(
+        toolsListResult: const {
+          'resultType': 'future_extension',
+          'tools': [],
+        },
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+
+      await client.connect(transport);
+
+      final result = await client.listTools();
+      expect(client.getProtocolVersion(), stableProtocolVersion2025_11_25);
+      expect(result.tools, isEmpty);
     });
 
     test('client rejects discovery when no compatible version is offered',


### PR DESCRIPTION
## Summary
- validate present `resultType` values on 2026 stateless client responses before typed result parsing
- accept core result types plus the Tasks extension `task` result type only when the server advertised that extension
- keep absent `resultType` and stable initialized sessions compatible with earlier protocol responses

## Spec
- https://modelcontextprotocol.io/specification/draft/basic

## Validation
- `dart format .`
- `dart analyze`
- `dart test test/mcp_2026_07_28_test.dart --name "resultType"`
- `dart test test/mcp_2026_07_28_test.dart`
- `dart test`
- `dart pub global run coverage:test_with_coverage`
- `git diff --check`
