### PR TITLE
Tighten MCP parameter header names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@
   client while keeping absent `resultType` compatible with stable result parsing.
 - Added `X-Accel-Buffering: no` to Streamable HTTP SSE responses and marked
   JSON-RPC error bodies with `Content-Type: application/json`.
+- Tightened `x-mcp-header` and `Mcp-Param-*` suffix validation to RFC 9110
+  HTTP field-name token syntax.
 
 ## 2.2.0
 

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+
 import 'package:mcp_dart/src/shared/json_schema/json_schema_validator.dart';
 import 'package:mcp_dart/src/shared/logging.dart';
+import 'package:mcp_dart/src/shared/mcp_header_validation.dart';
 import 'package:mcp_dart/src/shared/protocol.dart';
 import 'package:mcp_dart/src/shared/transport.dart';
 import 'package:mcp_dart/src/types.dart';
@@ -982,9 +984,7 @@ class McpClient extends Protocol {
   }
 
   bool _isValidMcpHeaderNameSuffix(String value) {
-    return value.codeUnits.every(
-      (unit) => unit >= 0x21 && unit <= 0x7E && unit != 0x3A,
-    );
+    return isValidMcpHeaderNameSuffix(value);
   }
 
   bool _isToolParameterHeaderPrimitive(JsonSchema schema) {

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -1,7 +1,8 @@
 import 'dart:async';
-import 'package:mcp_dart/src/shared/json_schema/json_schema_validator.dart';
 
+import 'package:mcp_dart/src/shared/json_schema/json_schema_validator.dart';
 import 'package:mcp_dart/src/shared/logging.dart';
+import 'package:mcp_dart/src/shared/mcp_header_validation.dart';
 import 'package:mcp_dart/src/shared/protocol.dart';
 import 'package:mcp_dart/src/shared/task_interfaces.dart';
 import 'package:mcp_dart/src/shared/tool_name_validation.dart';
@@ -1177,9 +1178,7 @@ class McpServer {
   }
 
   bool _isValidMcpHeaderNameSuffix(String value) {
-    return value.codeUnits.every(
-      (unit) => unit >= 0x21 && unit <= 0x7E && unit != 0x3A,
-    );
+    return isValidMcpHeaderNameSuffix(value);
   }
 
   bool _isToolParameterHeaderPrimitive(JsonSchema schema) {

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:mcp_dart/src/shared/mcp_header_validation.dart';
 import 'package:mcp_dart/src/shared/uuid.dart';
 
 import '../shared/transport.dart';
@@ -573,10 +574,7 @@ class StreamableHTTPServerTransport
       }
 
       final headerSuffix = name.substring(prefix.length);
-      if (headerSuffix.isEmpty ||
-          !headerSuffix.codeUnits.every(
-            (unit) => unit >= 0x21 && unit <= 0x7E && unit != 0x3A,
-          )) {
+      if (!isValidMcpHeaderNameSuffix(headerSuffix)) {
         headers[lowerName] = _McpParamHeader.invalidName(
           name: name,
           suffix: headerSuffix,

--- a/lib/src/shared/mcp_header_validation.dart
+++ b/lib/src/shared/mcp_header_validation.dart
@@ -1,0 +1,31 @@
+/// Validates an MCP parameter header suffix against RFC 9110 field-name token
+/// syntax.
+bool isValidMcpHeaderNameSuffix(String value) {
+  return value.isNotEmpty && value.codeUnits.every(isHttpFieldNameTokenChar);
+}
+
+/// Returns whether [unit] is an RFC 9110 HTTP field-name token character.
+bool isHttpFieldNameTokenChar(int unit) {
+  return unit >= 0x30 && unit <= 0x39 ||
+      unit >= 0x41 && unit <= 0x5A ||
+      unit >= 0x61 && unit <= 0x7A ||
+      switch (unit) {
+        0x21 ||
+        0x23 ||
+        0x24 ||
+        0x25 ||
+        0x26 ||
+        0x27 ||
+        0x2A ||
+        0x2B ||
+        0x2D ||
+        0x2E ||
+        0x5E ||
+        0x5F ||
+        0x60 ||
+        0x7C ||
+        0x7E =>
+          true,
+        _ => false,
+      };
+}

--- a/test/client/client_tool_validation_test.dart
+++ b/test/client/client_tool_validation_test.dart
@@ -186,6 +186,14 @@ void main() {
               },
             ),
           ),
+          Tool(
+            name: 'separator_header',
+            inputSchema: JsonSchema.object(
+              properties: {
+                'region': JsonSchema.string(mcpHeader: 'Bad/Header'),
+              },
+            ),
+          ),
           Tool.fromJson({
             'name': 'non_string_header',
             'inputSchema': {
@@ -228,7 +236,7 @@ void main() {
       });
       expect(
         warnings.where((message) => message.contains('Rejecting tool')),
-        hasLength(5),
+        hasLength(6),
       );
     });
 

--- a/test/server/mcp_server_test.dart
+++ b/test/server/mcp_server_test.dart
@@ -203,6 +203,15 @@ void main() {
         callback: (args, extra) async => const CallToolResult(content: []),
       );
       server.registerTool(
+        'separator-header-tool',
+        inputSchema: const ToolInputSchema(
+          properties: {
+            'value': JsonString(mcpHeader: 'Bad/Header'),
+          },
+        ),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+      server.registerTool(
         'number-header-tool',
         inputSchema: const ToolInputSchema(
           properties: {

--- a/test/shared/mcp_header_validation_test.dart
+++ b/test/shared/mcp_header_validation_test.dart
@@ -1,0 +1,50 @@
+import 'package:mcp_dart/src/shared/mcp_header_validation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('isValidMcpHeaderNameSuffix', () {
+    test('accepts RFC 9110 field-name token characters', () {
+      expect(
+        isValidMcpHeaderNameSuffix("AZaz09!#\$%&'*+-.^_`|~"),
+        isTrue,
+      );
+    });
+
+    test('rejects empty and separator characters', () {
+      expect(isValidMcpHeaderNameSuffix(''), isFalse);
+
+      for (final separator in [
+        '"',
+        '(',
+        ')',
+        ',',
+        '/',
+        ':',
+        ';',
+        '<',
+        '=',
+        '>',
+        '?',
+        '@',
+        '[',
+        r'\',
+        ']',
+        '{',
+        '}',
+      ]) {
+        expect(
+          isValidMcpHeaderNameSuffix('Bad${separator}Header'),
+          isFalse,
+          reason: 'separator $separator must be rejected',
+        );
+      }
+    });
+
+    test('rejects whitespace, control characters, and non-ASCII characters',
+        () {
+      for (final value in ['Bad Header', 'Bad\tHeader', 'Bad\nHeader', 'Bäd']) {
+        expect(isValidMcpHeaderNameSuffix(value), isFalse);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared RFC 9110 field-name token validator for MCP parameter header suffixes
- use it for `x-mcp-header` filtering, server header mapping sync, and Streamable HTTP `Mcp-Param-*` request validation
- add regression coverage for allowed token characters and rejected separator/control/non-ASCII suffixes

## Spec references
- https://modelcontextprotocol.io/specification/draft/server/tools#x-mcp-header
- https://modelcontextprotocol.io/specification/draft/basic/transports#custom-headers-from-tool-parameters

## Validation
- `dart format .`
- `dart analyze`
- `dart test test/shared/mcp_header_validation_test.dart test/client/client_tool_validation_test.dart test/server/mcp_server_test.dart test/server/streamable_https_test.dart`
- `dart test`
- `dart pub global run coverage:test_with_coverage`
- `git diff --check`
- `git diff --cached --check`
