### PR TITLE
Sanitize invalid MCP header metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@
   JSON-RPC error bodies with `Content-Type: application/json`.
 - Tightened `x-mcp-header` and `Mcp-Param-*` suffix validation to RFC 9110
   HTTP field-name token syntax.
+- Removed invalid `x-mcp-header` annotations from 2026 stateless `tools/list`
+  responses when the server has already rejected those header mappings.
 
 ## 2.2.0
 

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -593,12 +593,16 @@ class _RegisteredToolImpl implements RegisteredTool {
     _server._registeredTools[name] = this;
   }
 
-  Tool toTool({bool includeExecution = true}) {
+  Tool toTool({
+    bool includeExecution = true,
+    ToolInputSchema? inputSchemaOverride,
+  }) {
     return Tool(
       name: name,
       title: title,
       description: description,
-      inputSchema: inputSchema ?? const ToolInputSchema(),
+      inputSchema:
+          inputSchemaOverride ?? inputSchema ?? const ToolInputSchema(),
       outputSchema: outputSchema,
       annotations: annotations,
       icon: icon,
@@ -1072,6 +1076,95 @@ class McpServer {
     return mappings;
   }
 
+  ToolInputSchema _toolInputSchemaForStatelessList(
+    _RegisteredToolImpl tool,
+  ) {
+    final inputSchema = tool.inputSchema ?? const ToolInputSchema();
+    final properties = inputSchema.properties;
+    if (properties == null || properties.isEmpty) {
+      return inputSchema;
+    }
+
+    final ignoredReason = _collectToolParameterHeaderMappings(
+      toolName: tool.name,
+      properties: properties,
+      path: const [],
+      mappings: <String, String>{},
+      seenHeaders: <String>{},
+    );
+    if (ignoredReason == null) {
+      return inputSchema;
+    }
+
+    return _stripToolParameterHeaderMetadata(inputSchema);
+  }
+
+  ToolInputSchema _stripToolParameterHeaderMetadata(ToolInputSchema schema) {
+    return JsonSchema.fromJson(
+      _stripToolParameterHeaderMetadataFromJson(schema.toJson()),
+    ) as ToolInputSchema;
+  }
+
+  Map<String, dynamic> _stripToolParameterHeaderMetadataFromJson(
+    Map<String, dynamic> json,
+  ) {
+    final stripped = Map<String, dynamic>.from(json)..remove('x-mcp-header');
+
+    final properties = stripped['properties'];
+    if (properties is Map) {
+      final strippedProperties = <String, dynamic>{};
+      for (final entry in properties.entries) {
+        final propertyName = entry.key as String;
+        final propertyValue = entry.value;
+        strippedProperties[propertyName] = propertyValue is Map
+            ? _stripToolParameterHeaderMetadataFromJson(
+                Map<String, dynamic>.from(propertyValue),
+              )
+            : propertyValue;
+      }
+      stripped['properties'] = strippedProperties;
+    }
+
+    final items = stripped['items'];
+    if (items is Map) {
+      stripped['items'] = _stripToolParameterHeaderMetadataFromJson(
+        Map<String, dynamic>.from(items),
+      );
+    }
+
+    final additionalProperties = stripped['additionalProperties'];
+    if (additionalProperties is Map) {
+      stripped['additionalProperties'] =
+          _stripToolParameterHeaderMetadataFromJson(
+        Map<String, dynamic>.from(additionalProperties),
+      );
+    }
+
+    for (final keyword in const ['allOf', 'anyOf', 'oneOf']) {
+      final schemas = stripped[keyword];
+      if (schemas is List) {
+        stripped[keyword] = [
+          for (final schema in schemas)
+            if (schema is Map)
+              _stripToolParameterHeaderMetadataFromJson(
+                Map<String, dynamic>.from(schema),
+              )
+            else
+              schema,
+        ];
+      }
+    }
+
+    final notSchema = stripped['not'];
+    if (notSchema is Map) {
+      stripped['not'] = _stripToolParameterHeaderMetadataFromJson(
+        Map<String, dynamic>.from(notSchema),
+      );
+    }
+
+    return stripped;
+  }
+
   Map<String, String> _toolParameterHeaderMappingsFor(
     _RegisteredToolImpl tool,
   ) {
@@ -1328,6 +1421,9 @@ class McpServer {
               .map(
                 (tool) => tool.toTool(
                   includeExecution: includeLegacyTaskExecution,
+                  inputSchemaOverride: isStatelessRequest
+                      ? _toolInputSchemaForStatelessList(tool)
+                      : null,
                 ),
               )
               .toList(),

--- a/test/server/mcp_server_test.dart
+++ b/test/server/mcp_server_test.dart
@@ -66,6 +66,23 @@ class McpServerTestTransport
   }
 }
 
+Map<String, dynamic> _statelessMeta() => buildProtocolRequestMeta(
+      protocolVersion: draftProtocolVersion2026_07_28,
+      clientInfo: const Implementation(name: 'test-client', version: '1.0.0'),
+      clientCapabilities: const ClientCapabilities(),
+    );
+
+bool _containsMcpHeader(Object? value) {
+  if (value is Map) {
+    return value.containsKey('x-mcp-header') ||
+        value.values.any(_containsMcpHeader);
+  }
+  if (value is Iterable) {
+    return value.any(_containsMcpHeader);
+  }
+  return false;
+}
+
 void main() {
   group('McpServer Tool Registration', () {
     late McpServer server;
@@ -147,6 +164,20 @@ void main() {
           },
         ),
       );
+
+      transport.receiveMessage(
+        JsonRpcListToolsRequest(id: 1, meta: _statelessMeta()),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final response = transport.sentMessages.last as JsonRpcResponse;
+      final tools = response.result['tools'] as List;
+      final tool = tools.single as Map;
+      final inputSchema = tool['inputSchema'] as Map;
+      final properties = inputSchema['properties'] as Map;
+      final authProperties = (properties['auth'] as Map)['properties'] as Map;
+      expect((properties['region'] as Map)['x-mcp-header'], 'Region');
+      expect((authProperties['tenant'] as Map)['x-mcp-header'], 'Tenant');
     });
 
     test('tool updates refresh parameter header mappings on transports',
@@ -246,6 +277,122 @@ void main() {
 
       expect(transport.toolParameterHeaderMappings, isNotEmpty);
       expect(transport.toolParameterHeaderMappings.last, isEmpty);
+
+      transport.receiveMessage(
+        JsonRpcListToolsRequest(id: 1, meta: _statelessMeta()),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final response = transport.sentMessages.last as JsonRpcResponse;
+      final tools = response.result['tools'] as List;
+      expect(tools, hasLength(6));
+      for (final tool in tools.cast<Map>()) {
+        expect(_containsMcpHeader(tool['inputSchema']), isFalse);
+      }
+    });
+
+    test('invalid stateless header metadata is stripped from nested schemas',
+        () async {
+      server.registerTool(
+        'nested-header-tool',
+        inputSchema: ToolInputSchema.fromJson({
+          'type': 'object',
+          'properties': {
+            'invalidArray': {
+              'type': 'array',
+              'x-mcp-header': 'Invalid',
+              'items': {
+                'type': 'string',
+                'x-mcp-header': 'Item',
+              },
+            },
+            'objectMap': {
+              'type': 'object',
+              'additionalProperties': {
+                'type': 'string',
+                'x-mcp-header': 'Additional',
+              },
+            },
+            'combined': {
+              'allOf': [
+                true,
+                {
+                  'type': 'string',
+                  'x-mcp-header': 'All',
+                },
+              ],
+              'anyOf': [
+                false,
+                {
+                  'type': 'integer',
+                  'x-mcp-header': 'Any',
+                },
+              ],
+              'oneOf': [
+                {
+                  'type': 'boolean',
+                  'x-mcp-header': 'One',
+                },
+              ],
+              'not': {
+                'type': 'string',
+                'x-mcp-header': 'Not',
+              },
+            },
+            'literalData': {
+              'default': {
+                'x-mcp-header': 'not schema metadata',
+              },
+            },
+            'preservedAny': {
+              'properties': {
+                'flag': true,
+              },
+            },
+          },
+        }),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+
+      await server.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcListToolsRequest(id: 1, meta: _statelessMeta()),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final response = transport.sentMessages.last as JsonRpcResponse;
+      final tools = response.result['tools'] as List;
+      final tool = tools.single as Map;
+      final inputSchema = tool['inputSchema'] as Map;
+      final properties = inputSchema['properties'] as Map;
+      final invalidArray = properties['invalidArray'] as Map;
+      final objectMap = properties['objectMap'] as Map;
+      final combined = properties['combined'] as Map;
+      final allOf = combined['allOf'] as List;
+      final anyOf = combined['anyOf'] as List;
+      final oneOf = combined['oneOf'] as List;
+      final literalData = properties['literalData'] as Map;
+      final preservedAny = properties['preservedAny'] as Map;
+
+      expect(invalidArray.containsKey('x-mcp-header'), isFalse);
+      expect(
+        (invalidArray['items'] as Map).containsKey('x-mcp-header'),
+        isFalse,
+      );
+      expect(
+        (objectMap['additionalProperties'] as Map).containsKey('x-mcp-header'),
+        isFalse,
+      );
+      expect((allOf[1] as Map).containsKey('x-mcp-header'), isFalse);
+      expect((anyOf[1] as Map).containsKey('x-mcp-header'), isFalse);
+      expect((oneOf.single as Map).containsKey('x-mcp-header'), isFalse);
+      expect((combined['not'] as Map).containsKey('x-mcp-header'), isFalse);
+      expect(
+        (literalData['default'] as Map)['x-mcp-header'],
+        'not schema metadata',
+      );
+      expect(((preservedAny['properties'] as Map)['flag'] as bool), isTrue);
     });
 
     test('registerTool can be updated', () async {


### PR DESCRIPTION
## Summary
- strip rejected x-mcp-header annotations from 2026 stateless tools/list responses
- preserve valid x-mcp-header annotations when mappings remain valid
- cover the invalid-metadata sanitization and valid-metadata preservation paths

## Spec refs
- https://modelcontextprotocol.io/specification/draft/server/tools#x-mcp-header
- https://modelcontextprotocol.io/specification/draft/basic/transports#custom-headers-from-tool-parameters

## Validation
- dart format lib/src/server/mcp_server.dart test/server/mcp_server_test.dart
- dart analyze
- dart test test/server/mcp_server_test.dart --name "connect syncs tool parameter header mappings to transports|invalid tool parameter header metadata is not synced"
- dart test test/mcp_2026_07_28_test.dart test/server/mcp_server_test.dart
- dart run bin/mcp_dart.dart conformance --suite all --json (from packages/mcp_dart_cli)
- git diff --check
- dart format . && dart analyze && dart test
- dart pub global run coverage:test_with_coverage