### PR TITLE
Reject stateless server requests on clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@
   HTTP field-name token syntax.
 - Removed invalid `x-mcp-header` annotations from 2026 stateless `tools/list`
   responses when the server has already rejected those header mappings.
+- Rejected server-initiated JSON-RPC requests received on 2026 stateless
+  Streamable HTTP client response streams; servers must use MRTR
+  `input_required` results instead.
 
 ## 2.2.0
 

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -51,11 +51,15 @@ class StartSseOptions {
   /// Default is true.
   final bool shouldReconnect;
 
+  /// Whether JSON-RPC requests received on this stream should be rejected.
+  final bool rejectServerRequests;
+
   const StartSseOptions({
     this.resumptionToken,
     this.onResumptionToken,
     this.replayMessageId,
     this.shouldReconnect = true,
+    this.rejectServerRequests = false,
   });
 }
 
@@ -942,9 +946,15 @@ class StreamableHttpClientTransport
             result: message.result,
             meta: message.meta,
           );
-          onmessage?.call(newMessage);
+          _dispatchReceivedMessage(
+            newMessage,
+            rejectServerRequests: options.rejectServerRequests,
+          );
         } else {
-          onmessage?.call(message);
+          _dispatchReceivedMessage(
+            message,
+            rejectServerRequests: options.rejectServerRequests,
+          );
         }
       } catch (error) {
         if (error is Error) {
@@ -1065,6 +1075,25 @@ class StreamableHttpClientTransport
     _abortController?.stream.listen((_) {
       subscription.cancel();
     });
+  }
+
+  void _dispatchReceivedMessage(
+    JsonRpcMessage message, {
+    required bool rejectServerRequests,
+  }) {
+    if (rejectServerRequests && message is JsonRpcRequest) {
+      onerror?.call(
+        McpError(
+          ErrorCode.invalidRequest.value,
+          'Server-initiated JSON-RPC requests are not supported on 2026 '
+          'stateless MCP response streams; return input_required with '
+          'inputRequests instead.',
+        ),
+      );
+      return;
+    }
+
+    onmessage?.call(message);
   }
 
   @override
@@ -1300,6 +1329,7 @@ class StreamableHttpClientTransport
             StartSseOptions(
               onResumptionToken: onResumptionToken,
               shouldReconnect: false, // Do not reconnect for POST responses
+              rejectServerRequests: isStatelessRequest,
             ),
           );
         } else if (contentType?.contains('application/json') ?? false) {
@@ -1310,11 +1340,17 @@ class StreamableHttpClientTransport
           if (data is List) {
             for (final item in data) {
               final msg = JsonRpcMessage.fromJson(item);
-              onmessage?.call(msg);
+              _dispatchReceivedMessage(
+                msg,
+                rejectServerRequests: isStatelessRequest,
+              );
             }
           } else {
             final msg = JsonRpcMessage.fromJson(data);
-            onmessage?.call(msg);
+            _dispatchReceivedMessage(
+              msg,
+              rejectServerRequests: isStatelessRequest,
+            );
           }
         } else {
           throw StreamableHttpError(

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -1247,6 +1247,94 @@ void main() {
       expect(capturedHeaders['name'], 'task-1');
     });
 
+    test('stateless SSE responses reject server-initiated requests', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        await request.drain<void>();
+        final serverRequest = const JsonRpcRequest(
+          id: 99,
+          method: Method.rootsList,
+        );
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType('text', 'event-stream')
+          ..write('data: ${jsonEncode(serverRequest.toJson())}\n\n');
+        await request.response.close();
+      });
+
+      transport = StreamableHttpClientTransport(
+        Uri.parse('http://localhost:${server.port}/mcp'),
+      )..protocolVersion = draftProtocolVersion2026_07_28;
+      await transport.start();
+
+      final errorCompleter = Completer<Error>();
+      final messages = <JsonRpcMessage>[];
+      transport
+        ..onmessage = messages.add
+        ..onerror = (error) {
+          if (!errorCompleter.isCompleted) {
+            errorCompleter.complete(error);
+          }
+        };
+
+      await transport.send(
+        JsonRpcListToolsRequest(id: 1, meta: _statelessMeta()),
+      );
+
+      final error = await errorCompleter.future.timeout(
+        const Duration(seconds: 5),
+      );
+      expect(error, isA<McpError>());
+      expect((error as McpError).code, ErrorCode.invalidRequest.value);
+      expect(error.message, contains('input_required'));
+      expect(messages, isEmpty);
+    });
+
+    test('stateless JSON responses reject server-initiated requests', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        await request.drain<void>();
+        final serverRequest = const JsonRpcRequest(
+          id: 99,
+          method: Method.rootsList,
+        );
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(jsonEncode([serverRequest.toJson()]));
+        await request.response.close();
+      });
+
+      transport = StreamableHttpClientTransport(
+        Uri.parse('http://localhost:${server.port}/mcp'),
+      )..protocolVersion = draftProtocolVersion2026_07_28;
+      await transport.start();
+
+      final errorCompleter = Completer<Error>();
+      final messages = <JsonRpcMessage>[];
+      transport
+        ..onmessage = messages.add
+        ..onerror = (error) {
+          if (!errorCompleter.isCompleted) {
+            errorCompleter.complete(error);
+          }
+        };
+
+      await transport.send(
+        JsonRpcListToolsRequest(id: 1, meta: _statelessMeta()),
+      );
+
+      final error = await errorCompleter.future.timeout(
+        const Duration(seconds: 5),
+      );
+      expect(error, isA<McpError>());
+      expect((error as McpError).code, ErrorCode.invalidRequest.value);
+      expect(error.message, contains('inputRequests'));
+      expect(messages, isEmpty);
+    });
+
     test('send mirrors mapped tool parameters into 2026 stateless headers',
         () async {
       final capturedHeaders = <String, String?>{};


### PR DESCRIPTION
## Summary
- reject server-initiated JSON-RPC requests received on 2026 stateless Streamable HTTP SSE response streams
- apply the same guard to non-streaming JSON response bodies
- add regression coverage for SSE and JSON stateless responses

## Validation
- dart format .
- dart analyze
- dart test test/mcp_2026_07_28_test.dart test/client/streamable_https_test.dart
- dart test
- dart pub global run coverage:test_with_coverage
- dart run bin/mcp_dart.dart conformance --suite all --json (from packages/mcp_dart_cli)
- git diff --check

## Notes
- This is stacked on #203 and remains draft-only while the 2026-07-28 spec is still RC.
- Spec context: https://modelcontextprotocol.io/specification/draft/basic/utilities/mrtr