### PR TITLE
Retry MCP 2026 discovery with advertised versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@
   `input_required` results instead.
 - Enforced `subscriptions/listen` stream ordering and filters for 2026
   subscription notifications.
+- Retried `server/discover` with an advertised compatible stateless protocol
+  version after `UnsupportedProtocolVersionError` instead of falling back to
+  legacy initialization.
 
 ## 2.2.0
 

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -296,19 +296,56 @@ class McpClient extends Protocol {
     );
   }
 
-  Future<DiscoverResult> discoverServer() async {
+  String? _retryableDiscoveryProtocolVersion(
+    McpError error,
+    String attemptedVersion,
+  ) {
+    if (error.code != ErrorCode.unsupportedProtocolVersion.value) {
+      return null;
+    }
+
+    final data = error.data;
+    if (data is! Map) {
+      return null;
+    }
+
+    final supported = data['supported'];
+    if (supported is! Iterable) {
+      return null;
+    }
+
+    final advertisedVersions = <String>[];
+    for (final version in supported) {
+      if (version is String) {
+        advertisedVersions.add(version);
+      }
+    }
+
+    final retryVersion = negotiateProtocolVersion(
+      advertisedVersions,
+      localSupportedVersions: statelessProtocolVersions,
+    );
+    if (retryVersion == null || retryVersion == attemptedVersion) {
+      return null;
+    }
+    return retryVersion;
+  }
+
+  Future<DiscoverResult> _discoverServerWithVersion(
+    String protocolVersion,
+  ) async {
     final activeTransport = transport;
     final ProtocolVersionAwareTransport? versionedTransport =
         activeTransport is ProtocolVersionAwareTransport
             ? activeTransport as ProtocolVersionAwareTransport
             : null;
-    versionedTransport?.protocolVersion = _preferredProtocolVersion;
+    versionedTransport?.protocolVersion = protocolVersion;
 
     final result = await super.request<DiscoverResult>(
       JsonRpcServerDiscoverRequest(
         id: -1,
         meta: buildProtocolRequestMeta(
-          protocolVersion: _preferredProtocolVersion,
+          protocolVersion: protocolVersion,
           clientInfo: _clientInfo,
           clientCapabilities: _capabilities,
         ),
@@ -316,17 +353,17 @@ class McpClient extends Protocol {
       (json) => DiscoverResult.fromJson(json),
     );
 
-    final protocolVersion = negotiateProtocolVersion(
+    final negotiatedProtocolVersion = negotiateProtocolVersion(
       result.supportedVersions,
       localSupportedVersions: supportedProtocolVersionsWithDraft,
     );
-    if (protocolVersion == null) {
+    if (negotiatedProtocolVersion == null) {
       throw McpError(
         ErrorCode.unsupportedProtocolVersion.value,
         "Server does not support a compatible MCP protocol version.",
         {
           'supported': result.supportedVersions,
-          'requested': _preferredProtocolVersion,
+          'requested': protocolVersion,
         },
       );
     }
@@ -334,17 +371,43 @@ class McpClient extends Protocol {
     _serverCapabilities = result.capabilities;
     _serverVersion = result.serverInfo;
     _instructions = result.instructions;
-    _negotiatedProtocolVersion = protocolVersion;
-    _usesStatelessProtocol = isStatelessProtocolVersion(protocolVersion);
+    _negotiatedProtocolVersion = negotiatedProtocolVersion;
+    _usesStatelessProtocol = isStatelessProtocolVersion(
+      negotiatedProtocolVersion,
+    );
     _sentInitialized = true;
 
-    versionedTransport?.protocolVersion = protocolVersion;
+    versionedTransport?.protocolVersion = negotiatedProtocolVersion;
 
     _logger.debug(
-      "MCP Server Discovered. Server: ${result.serverInfo.name} ${result.serverInfo.version}, Protocol: $protocolVersion",
+      "MCP Server Discovered. Server: ${result.serverInfo.name} ${result.serverInfo.version}, Protocol: $negotiatedProtocolVersion",
     );
 
     return result;
+  }
+
+  Future<DiscoverResult> discoverServer() async {
+    try {
+      return await _discoverServerWithVersion(_preferredProtocolVersion);
+    } catch (error) {
+      if (error is! McpError) {
+        rethrow;
+      }
+
+      final retryVersion = _retryableDiscoveryProtocolVersion(
+        error,
+        _preferredProtocolVersion,
+      );
+      if (retryVersion == null) {
+        rethrow;
+      }
+
+      _logger.debug(
+        "server/discover rejected protocol $_preferredProtocolVersion; "
+        "retrying with $retryVersion.",
+      );
+      return await _discoverServerWithVersion(retryVersion);
+    }
   }
 
   /// Connects to the server using the given [transport].

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -42,6 +42,8 @@ class DiscoveringClientTransport extends Transport
     implements ProtocolVersionAwareTransport {
   DiscoveringClientTransport({
     this.discoverVersions = const [draftProtocolVersion2026_07_28],
+    this.unsupportedDiscoverProtocolVersions = const [],
+    this.unsupportedDiscoverData,
     this.capabilities = const ServerCapabilities(
       tools: ServerCapabilitiesTools(),
     ),
@@ -49,6 +51,8 @@ class DiscoveringClientTransport extends Transport
   });
 
   final List<String> discoverVersions;
+  final List<String> unsupportedDiscoverProtocolVersions;
+  final Object? unsupportedDiscoverData;
   final ServerCapabilities capabilities;
   final Map<String, dynamic> toolsListResult;
   final List<JsonRpcMessage> sentMessages = [];
@@ -69,6 +73,28 @@ class DiscoveringClientTransport extends Transport
     sentMessages.add(message);
 
     if (message is JsonRpcRequest && message.method == Method.serverDiscover) {
+      final requestedProtocolVersion =
+          message.meta?[McpMetaKey.protocolVersion];
+      if (unsupportedDiscoverProtocolVersions.contains(
+        requestedProtocolVersion,
+      )) {
+        onmessage?.call(
+          JsonRpcError(
+            id: message.id,
+            error: JsonRpcErrorData(
+              code: ErrorCode.unsupportedProtocolVersion.value,
+              message: 'Unsupported protocol version',
+              data: unsupportedDiscoverData ??
+                  {
+                    'supported': discoverVersions,
+                    'requested': requestedProtocolVersion,
+                  },
+            ),
+          ),
+        );
+        return;
+      }
+
       onmessage?.call(
         JsonRpcResponse(
           id: message.id,
@@ -1959,6 +1985,109 @@ void main() {
         ),
       );
     });
+
+    test(
+        'client retries discovery with advertised compatible stateless version',
+        () async {
+      final transport = DiscoveringClientTransport(
+        unsupportedDiscoverProtocolVersions: const ['1900-01-01'],
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(
+          protocolVersion: '1900-01-01',
+          useServerDiscover: true,
+        ),
+      );
+
+      await client.connect(transport);
+
+      final discoverRequests = transport.sentMessages
+          .whereType<JsonRpcRequest>()
+          .where((message) => message.method == Method.serverDiscover)
+          .toList();
+      expect(discoverRequests, hasLength(2));
+      expect(
+        discoverRequests.map(
+          (request) => request.meta?[McpMetaKey.protocolVersion],
+        ),
+        ['1900-01-01', draftProtocolVersion2026_07_28],
+      );
+      expect(client.getProtocolVersion(), draftProtocolVersion2026_07_28);
+      expect(transport.protocolVersion, draftProtocolVersion2026_07_28);
+      expect(
+        transport.sentMessages.whereType<JsonRpcRequest>().map(
+              (message) => message.method,
+            ),
+        isNot(contains(Method.initialize)),
+      );
+    });
+
+    for (final scenario in [
+      (
+        name: 'malformed error data',
+        requested: '1900-01-01',
+        discoverVersions: const [draftProtocolVersion2026_07_28],
+        data: 'not-an-object',
+      ),
+      (
+        name: 'missing supported versions',
+        requested: '1900-01-01',
+        discoverVersions: const [draftProtocolVersion2026_07_28],
+        data: const {'requested': '1900-01-01'},
+      ),
+      (
+        name: 'no compatible stateless version',
+        requested: '1900-01-01',
+        discoverVersions: const ['1900-01-01'],
+        data: null,
+      ),
+      (
+        name: 'advertised version matches rejected request',
+        requested: draftProtocolVersion2026_07_28,
+        discoverVersions: const [draftProtocolVersion2026_07_28],
+        data: const {
+          'supported': [draftProtocolVersion2026_07_28],
+          'requested': draftProtocolVersion2026_07_28,
+        },
+      ),
+    ]) {
+      test(
+        'client does not fall back to initialize after unsupported discovery '
+        '${scenario.name}',
+        () async {
+          final transport = DiscoveringClientTransport(
+            discoverVersions: scenario.discoverVersions,
+            unsupportedDiscoverProtocolVersions: [scenario.requested],
+            unsupportedDiscoverData: scenario.data,
+          );
+          final client = McpClient(
+            const Implementation(name: 'client', version: '1.0.0'),
+            options: McpClientOptions(
+              protocolVersion: scenario.requested,
+              useServerDiscover: true,
+            ),
+          );
+
+          await expectLater(
+            client.connect(transport),
+            throwsA(
+              isA<McpError>().having(
+                (error) => error.code,
+                'code',
+                ErrorCode.unsupportedProtocolVersion.value,
+              ),
+            ),
+          );
+          expect(
+            transport.sentMessages.whereType<JsonRpcRequest>().map(
+                  (message) => message.method,
+                ),
+            isNot(contains(Method.initialize)),
+          );
+        },
+      );
+    }
 
     test('client falls back to initialize when discovery is unavailable',
         () async {


### PR DESCRIPTION
## Summary
- retry server/discover once with an advertised compatible stateless version after UnsupportedProtocolVersionError
- keep Method not found as the only legacy initialize fallback path
- add regression coverage for malformed unsupported-version data and no-retry cases

## Validation
- dart format lib/src/client/client.dart test/mcp_2026_07_28_test.dart
- dart analyze
- dart test test/mcp_2026_07_28_test.dart --name "discovery|server/discover|protocol version"
- dart test
- dart pub global run coverage:test_with_coverage
- dart run bin/mcp_dart.dart conformance --suite all --json
- git diff --check