### PR TITLE
Add client subscription listen support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@
 - Retried `server/discover` with an advertised compatible stateless protocol
   version after `UnsupportedProtocolVersionError` instead of falling back to
   legacy initialization.
+- Added client-side `subscriptions/listen` handles that correlate stream
+  notifications by `io.modelcontextprotocol/subscriptionId`, validate the
+  acknowledgment, and cancel long-lived streams with `notifications/cancelled`.
 
 ## 2.2.0
 

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -40,6 +40,36 @@ class McpClientOptions extends ProtocolOptions {
 @Deprecated('Use McpClientOptions instead')
 typedef ClientOptions = McpClientOptions;
 
+/// Handle for an active `subscriptions/listen` stream opened by [McpClient].
+class McpSubscription {
+  final void Function([Object? reason]) _cancel;
+
+  /// JSON-RPC request ID that identifies this subscription stream.
+  final int id;
+
+  /// Acknowledgment sent as the first message on the subscription stream.
+  final Future<SubscriptionsAcknowledgedNotification> acknowledged;
+
+  /// Notifications delivered on this subscription stream after acknowledgment.
+  final Stream<JsonRpcNotification> notifications;
+
+  /// Completes when the `subscriptions/listen` request ends.
+  final Future<EmptyResult> done;
+
+  McpSubscription._({
+    required this.id,
+    required this.acknowledged,
+    required this.notifications,
+    required this.done,
+    required void Function([Object? reason]) cancel,
+  }) : _cancel = cancel;
+
+  /// Cancels this subscription stream.
+  void cancel([Object? reason]) {
+    _cancel(reason);
+  }
+}
+
 // Recursively applies default values from a JSON Schema to a data object.
 void _applyElicitationDefaults(JsonSchema schema, Map<String, dynamic> data) {
   if (schema is! JsonObject) return;
@@ -99,6 +129,7 @@ class McpClient extends Protocol {
   final Map<String, JsonSchema> _cachedToolOutputSchemas = {};
   final Set<String> _cachedRequiredTaskTools = {};
   final ToolParameterHeaderMappings _cachedToolParameterHeaders = {};
+  final Map<Object, _ClientSubscriptionState> _activeSubscriptions = {};
 
   /// Callback for handling elicitation requests from the server.
   ///
@@ -560,6 +591,31 @@ class McpClient extends Protocol {
   }
 
   @override
+  void onIncomingNotificationAccepted(JsonRpcNotification notification) {
+    final subscriptionId = notification.meta?[McpMetaKey.subscriptionId];
+    if (subscriptionId is! int && subscriptionId is! String) {
+      return;
+    }
+
+    final activeSubscription = _activeSubscriptions[subscriptionId];
+    activeSubscription?.handleNotification(notification);
+  }
+
+  @override
+  void onConnectionClosed() {
+    final subscriptions = List<_ClientSubscriptionState>.from(
+      _activeSubscriptions.values,
+    );
+    _activeSubscriptions.clear();
+    for (final subscription in subscriptions) {
+      subscription.fail(
+        McpError(ErrorCode.connectionClosed.value, 'Connection closed'),
+        StackTrace.current,
+      );
+    }
+  }
+
+  @override
   void assertCapabilityForMethod(String method) {
     final serverCaps = _serverCapabilities;
     if (serverCaps == null) {
@@ -837,6 +893,47 @@ class McpClient extends Protocol {
     return request<EmptyResult>(req, (json) => const EmptyResult(), options);
   }
 
+  /// Opens a `subscriptions/listen` stream and demultiplexes notifications.
+  McpSubscription listenSubscriptions(SubscriptionsListenRequest params) {
+    if (transport == null) {
+      throw StateError('Not connected to a transport.');
+    }
+
+    final requestId = reserveRequestId();
+    final abortController = BasicAbortController();
+    final state = _ClientSubscriptionState(
+      id: requestId,
+      requestedNotifications: params.notifications,
+      abortController: abortController,
+      onClose: () => _activeSubscriptions.remove(requestId),
+    );
+    _activeSubscriptions[requestId] = state;
+
+    final requestData = JsonRpcSubscriptionsListenRequest(
+      id: requestId,
+      listenParams: params,
+      meta: _usesStatelessProtocol ? _statelessRequestMeta(null) : null,
+    );
+    final requestDone = super.requestWithReservedId<EmptyResult>(
+      requestId,
+      requestData,
+      (json) => const EmptyResult(),
+      RequestOptions(
+        signal: abortController.signal,
+        timeoutEnabled: false,
+      ),
+    );
+    state.trackRequest(requestDone);
+
+    return McpSubscription._(
+      id: requestId,
+      acknowledged: state.acknowledged,
+      notifications: state.notifications,
+      done: state.done,
+      cancel: state.cancel,
+    );
+  }
+
   /// Sends a `tools/call` request to invoke a tool on the server.
   Future<CallToolResult> callTool(
     CallToolRequest params, {
@@ -1066,6 +1163,174 @@ class McpClient extends Protocol {
 /// Deprecated alias for [McpClient].
 @Deprecated('Use McpClient instead')
 typedef Client = McpClient;
+
+class _ClientSubscriptionState {
+  final int id;
+  final SubscriptionFilter requestedNotifications;
+  final BasicAbortController abortController;
+  final void Function() onClose;
+  final StreamController<JsonRpcNotification> _notifications =
+      StreamController<JsonRpcNotification>.broadcast();
+  final Completer<SubscriptionsAcknowledgedNotification> _acknowledged =
+      Completer<SubscriptionsAcknowledgedNotification>();
+  final Completer<EmptyResult> _done = Completer<EmptyResult>();
+
+  SubscriptionFilter? _acknowledgedNotifications;
+  bool _closed = false;
+  bool _localCancellation = false;
+
+  _ClientSubscriptionState({
+    required this.id,
+    required this.requestedNotifications,
+    required this.abortController,
+    required this.onClose,
+  });
+
+  Future<SubscriptionsAcknowledgedNotification> get acknowledged =>
+      _acknowledged.future;
+
+  Stream<JsonRpcNotification> get notifications => _notifications.stream;
+
+  Future<EmptyResult> get done => _done.future;
+
+  void handleNotification(JsonRpcNotification notification) {
+    if (_closed) {
+      return;
+    }
+
+    if (_acknowledgedNotifications == null) {
+      if (notification.method !=
+          Method.notificationsSubscriptionsAcknowledged) {
+        fail(
+          McpError(
+            ErrorCode.invalidRequest.value,
+            'Subscription $id received ${notification.method} before '
+            '${Method.notificationsSubscriptionsAcknowledged}.',
+          ),
+          StackTrace.current,
+        );
+        return;
+      }
+
+      final acknowledgedParams =
+          (notification as JsonRpcSubscriptionsAcknowledgedNotification)
+              .acknowledgedParams;
+      final acknowledgedNotifications = acknowledgedParams.notifications;
+      if (!acknowledgedNotifications.isSubsetOf(requestedNotifications)) {
+        fail(
+          McpError(
+            ErrorCode.invalidRequest.value,
+            'Subscription $id acknowledged notifications that were not '
+            'requested.',
+          ),
+          StackTrace.current,
+        );
+        return;
+      }
+
+      _acknowledgedNotifications = acknowledgedNotifications;
+      if (!_acknowledged.isCompleted) {
+        _acknowledged.complete(acknowledgedParams);
+      }
+      return;
+    }
+
+    final acknowledgedNotifications = _acknowledgedNotifications!;
+    if (!acknowledgedNotifications.allowsNotification(notification)) {
+      fail(
+        McpError(
+          ErrorCode.invalidRequest.value,
+          '${notification.method} was not requested or acknowledged for '
+          'subscription $id.',
+        ),
+        StackTrace.current,
+      );
+      return;
+    }
+
+    _notifications.add(notification);
+  }
+
+  void trackRequest(Future<EmptyResult> requestDone) {
+    requestDone.then(
+      complete,
+      onError: (Object error, StackTrace stackTrace) {
+        if (_localCancellation) {
+          complete(const EmptyResult());
+        } else {
+          fail(error, stackTrace, abort: false);
+        }
+      },
+    );
+  }
+
+  void cancel([Object? reason]) {
+    if (_closed) {
+      return;
+    }
+
+    _localCancellation = true;
+    if (!_acknowledged.isCompleted) {
+      _acknowledged.completeError(AbortError(reason), StackTrace.current);
+    }
+    abortController.abort(reason);
+    complete(const EmptyResult());
+  }
+
+  void complete(EmptyResult result) {
+    if (_closed) {
+      return;
+    }
+
+    final missingAcknowledgment = _acknowledgedNotifications == null &&
+        !_localCancellation &&
+        !abortController.signal.aborted;
+    if (missingAcknowledgment) {
+      fail(
+        McpError(
+          ErrorCode.invalidRequest.value,
+          'Subscription $id completed before '
+          '${Method.notificationsSubscriptionsAcknowledged}.',
+        ),
+        StackTrace.current,
+        abort: false,
+      );
+      return;
+    }
+
+    _closed = true;
+    onClose();
+    if (!_done.isCompleted) {
+      _done.complete(result);
+    }
+    _notifications.close();
+  }
+
+  void fail(
+    Object error,
+    StackTrace stackTrace, {
+    bool abort = true,
+  }) {
+    if (_closed) {
+      return;
+    }
+
+    _closed = true;
+    onClose();
+    if (abort && !abortController.signal.aborted) {
+      abortController.abort(error);
+    }
+    if (!_acknowledged.isCompleted) {
+      _acknowledged.completeError(error, stackTrace);
+    }
+    if (!_done.isCompleted) {
+      _done.completeError(error, stackTrace);
+    }
+    _notifications
+      ..addError(error, stackTrace)
+      ..close();
+  }
+}
 
 class _ToolParameterHeaderValidation {
   final Map<String, String> mappings;

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -78,6 +78,12 @@ class RequestOptions {
   /// Maximum total time to wait for a response.
   final Duration? maxTotalTimeout;
 
+  /// Whether this request should use protocol-level timeout handling.
+  ///
+  /// Long-lived requests such as `subscriptions/listen` can disable this and
+  /// rely on explicit cancellation or transport closure instead.
+  final bool timeoutEnabled;
+
   /// Augments the request with task creation parameters.
   final TaskCreation? task;
 
@@ -91,6 +97,7 @@ class RequestOptions {
     this.timeout,
     this.resetTimeoutOnProgress = false,
     this.maxTotalTimeout,
+    this.timeoutEnabled = true,
     this.task,
     this.relatedTask,
   });
@@ -276,10 +283,7 @@ void _recordOrValidateSubscriptionNotification(
     );
   }
 
-  if (!_subscriptionFilterAllowsNotification(
-    state.acknowledgedNotifications,
-    notification,
-  )) {
+  if (!state.acknowledgedNotifications.allowsNotification(notification)) {
     throw McpError(
       ErrorCode.invalidRequest.value,
       '${notification.method} was not requested or acknowledged for this '
@@ -299,29 +303,6 @@ SubscriptionFilter _acknowledgedSubscriptionFilter(
   }
 
   return SubscriptionsAcknowledgedNotification.fromJson(params).notifications;
-}
-
-bool _subscriptionFilterAllowsNotification(
-  SubscriptionFilter filter,
-  JsonRpcNotification notification,
-) {
-  switch (notification.method) {
-    case Method.notificationsToolsListChanged:
-      return filter.toolsListChanged == true;
-    case Method.notificationsPromptsListChanged:
-      return filter.promptsListChanged == true;
-    case Method.notificationsResourcesListChanged:
-      return filter.resourcesListChanged == true;
-    case Method.notificationsResourcesUpdated:
-      final uri = notification.params?['uri'];
-      return uri is String &&
-          (filter.resourceSubscriptions?.contains(uri) ?? false);
-    case Method.notificationsTasks:
-      final taskId = notification.params?['taskId'];
-      return taskId is String && (filter.taskIds?.contains(taskId) ?? false);
-    default:
-      return false;
-  }
 }
 
 /// Internal class holding timeout state for a request.
@@ -1036,6 +1017,10 @@ abstract class Protocol {
   @protected
   void onIncomingRequestAccepted(JsonRpcRequest request) {}
 
+  /// Subclass hook called after an incoming notification has passed validation.
+  @protected
+  void onIncomingNotificationAccepted(JsonRpcNotification notification) {}
+
   /// Subclass hook called after an incoming request handler has completed and
   /// its response has been sent or enqueued.
   @protected
@@ -1069,6 +1054,8 @@ abstract class Protocol {
       _onerror(validationError);
       return;
     }
+
+    onIncomingNotificationAccepted(notification);
 
     if (notification is JsonRpcTaskStatusNotification) {
       _onTaskStatusNotification(notification);
@@ -1278,6 +1265,7 @@ abstract class Protocol {
           timeout: options.timeout,
           resetTimeoutOnProgress: options.resetTimeoutOnProgress,
           maxTotalTimeout: options.maxTotalTimeout,
+          timeoutEnabled: options.timeoutEnabled,
           task: options.task,
           relatedTask: options.relatedTask ??
               (relatedTaskId != null
@@ -1558,11 +1546,35 @@ abstract class Protocol {
     );
   }
 
+  /// Reserves an outgoing integer request ID for APIs that need to correlate
+  /// side-channel data before the response arrives.
+  @protected
+  int reserveRequestId() => _requestMessageId++;
+
+  /// Sends a request using a previously reserved outgoing integer request ID.
+  @protected
+  Future<T> requestWithReservedId<T extends BaseResultData>(
+    int requestId,
+    JsonRpcRequest requestData,
+    T Function(Map<String, dynamic> resultJson) resultFactory, [
+    RequestOptions? options,
+    RequestId? relatedRequestId,
+  ]) {
+    return _requestWithRequestId(
+      requestData,
+      resultFactory,
+      options,
+      relatedRequestId,
+      requestId,
+    );
+  }
+
   Future<T> _requestWithRequestId<T extends BaseResultData>(
     JsonRpcRequest requestData,
     T Function(Map<String, dynamic> resultJson) resultFactory, [
     RequestOptions? options,
     RequestId? relatedRequestId,
+    int? reservedRequestId,
   ]) {
     if (_transport == null) {
       return Future.error(StateError("Not connected to a transport."));
@@ -1585,7 +1597,7 @@ abstract class Protocol {
       return Future.error(e);
     }
 
-    final messageId = _requestMessageId++;
+    final messageId = reservedRequestId ?? _requestMessageId++;
     final completer = Completer<JsonRpcResponse>();
     Error? capturedError;
     Object? progressToken;
@@ -1746,26 +1758,28 @@ abstract class Protocol {
       taskRequestState?.abortSubscription = abortSubscription;
     }
 
-    final timeoutDuration = options?.timeout ?? defaultRequestTimeout;
-    final maxTotalTimeoutDuration = options?.maxTotalTimeout;
-    void timeoutHandler() {
-      cancel(
-        McpError(
-          ErrorCode.requestTimeout.value,
-          "Request $messageId timed out after $timeoutDuration",
-          {'timeout': timeoutDuration.inMilliseconds},
-        ),
-        fromTimeout: true,
+    if (options?.timeoutEnabled ?? true) {
+      final timeoutDuration = options?.timeout ?? defaultRequestTimeout;
+      final maxTotalTimeoutDuration = options?.maxTotalTimeout;
+      void timeoutHandler() {
+        cancel(
+          McpError(
+            ErrorCode.requestTimeout.value,
+            "Request $messageId timed out after $timeoutDuration",
+            {'timeout': timeoutDuration.inMilliseconds},
+          ),
+          fromTimeout: true,
+        );
+      }
+
+      _setupTimeout(
+        messageId,
+        timeoutDuration,
+        maxTotalTimeoutDuration,
+        options?.resetTimeoutOnProgress ?? false,
+        timeoutHandler,
       );
     }
-
-    _setupTimeout(
-      messageId,
-      timeoutDuration,
-      maxTotalTimeoutDuration,
-      options?.resetTimeoutOnProgress ?? false,
-      timeoutHandler,
-    );
 
     // Queue request if related to a task
     if (options?.relatedTask != null) {

--- a/lib/src/types/completion.dart
+++ b/lib/src/types/completion.dart
@@ -260,13 +260,13 @@ class CompleteResult implements BaseResultData {
   'Stable MCP 2025-11-25 does not define completion list-changed notifications.',
 )
 class JsonRpcCompletionListChangedNotification extends JsonRpcNotification {
-  const JsonRpcCompletionListChangedNotification()
+  const JsonRpcCompletionListChangedNotification({super.meta})
       : super(method: Method.notificationsExperimentalCompletionsListChanged);
 
   factory JsonRpcCompletionListChangedNotification.fromJson(
     Map<String, dynamic> json,
   ) =>
-      const JsonRpcCompletionListChangedNotification();
+      JsonRpcCompletionListChangedNotification(meta: extractRequestMeta(json));
 }
 
 /// Deprecated alias for [CompleteRequest].

--- a/lib/src/types/prompts.dart
+++ b/lib/src/types/prompts.dart
@@ -343,13 +343,13 @@ class GetPromptResult implements BaseResultData {
 
 /// Notification from server indicating the list of available prompts has changed.
 class JsonRpcPromptListChangedNotification extends JsonRpcNotification {
-  const JsonRpcPromptListChangedNotification()
+  const JsonRpcPromptListChangedNotification({super.meta})
       : super(method: Method.notificationsPromptsListChanged);
 
   factory JsonRpcPromptListChangedNotification.fromJson(
     Map<String, dynamic> json,
   ) =>
-      const JsonRpcPromptListChangedNotification();
+      JsonRpcPromptListChangedNotification(meta: extractRequestMeta(json));
 }
 
 /// Deprecated alias for [ListPromptsRequest].

--- a/lib/src/types/resources.dart
+++ b/lib/src/types/resources.dart
@@ -553,13 +553,13 @@ class ReadResourceResult implements CacheableResultData {
 
 /// Notification from server indicating the list of available resources has changed.
 class JsonRpcResourceListChangedNotification extends JsonRpcNotification {
-  const JsonRpcResourceListChangedNotification()
+  const JsonRpcResourceListChangedNotification({super.meta})
       : super(method: Method.notificationsResourcesListChanged);
 
   factory JsonRpcResourceListChangedNotification.fromJson(
     Map<String, dynamic> json,
   ) =>
-      const JsonRpcResourceListChangedNotification();
+      JsonRpcResourceListChangedNotification(meta: extractRequestMeta(json));
 }
 
 /// Parameters for the `resources/subscribe` request.

--- a/lib/src/types/subscriptions.dart
+++ b/lib/src/types/subscriptions.dart
@@ -76,6 +76,50 @@ class SubscriptionFilter {
     );
   }
 
+  /// Whether this filter is a subset of [requested].
+  bool isSubsetOf(SubscriptionFilter requested) {
+    if (toolsListChanged == true && requested.toolsListChanged != true) {
+      return false;
+    }
+    if (promptsListChanged == true && requested.promptsListChanged != true) {
+      return false;
+    }
+    if (resourcesListChanged == true &&
+        requested.resourcesListChanged != true) {
+      return false;
+    }
+    if (!_stringListSubsetOf(
+      resourceSubscriptions,
+      requested.resourceSubscriptions,
+    )) {
+      return false;
+    }
+    if (!_stringListSubsetOf(taskIds, requested.taskIds)) {
+      return false;
+    }
+    return true;
+  }
+
+  /// Whether this acknowledged filter allows [notification].
+  bool allowsNotification(JsonRpcNotification notification) {
+    switch (notification.method) {
+      case Method.notificationsToolsListChanged:
+        return toolsListChanged == true;
+      case Method.notificationsPromptsListChanged:
+        return promptsListChanged == true;
+      case Method.notificationsResourcesListChanged:
+        return resourcesListChanged == true;
+      case Method.notificationsResourcesUpdated:
+        final uri = notification.params?['uri'];
+        return uri is String && (resourceSubscriptions?.contains(uri) ?? false);
+      case Method.notificationsTasks:
+        final taskId = notification.params?['taskId'];
+        return taskId is String && (taskIds?.contains(taskId) ?? false);
+      default:
+        return false;
+    }
+  }
+
   Map<String, dynamic> toJson() => {
         if (toolsListChanged != null) 'toolsListChanged': toolsListChanged,
         if (promptsListChanged != null)
@@ -231,6 +275,17 @@ List<String>? _readOptionalStringList(Object? value, String field) {
     throw FormatException('$field must contain only strings');
   }
   return value.cast<String>();
+}
+
+bool _stringListSubsetOf(List<String>? subset, List<String>? superset) {
+  if (subset == null || subset.isEmpty) {
+    return true;
+  }
+  final allowed = superset?.toSet();
+  if (allowed == null) {
+    return false;
+  }
+  return subset.every(allowed.contains);
 }
 
 Map<String, dynamic>? _readOptionalJsonObject(Object? value, String field) {

--- a/lib/src/types/tools.dart
+++ b/lib/src/types/tools.dart
@@ -456,13 +456,13 @@ class CallToolResult implements BaseResultData {
 
 /// Notification from server indicating the list of available tools has changed.
 class JsonRpcToolListChangedNotification extends JsonRpcNotification {
-  const JsonRpcToolListChangedNotification()
+  const JsonRpcToolListChangedNotification({super.meta})
       : super(method: Method.notificationsToolsListChanged);
 
   factory JsonRpcToolListChangedNotification.fromJson(
     Map<String, dynamic> json,
   ) =>
-      const JsonRpcToolListChangedNotification();
+      JsonRpcToolListChangedNotification(meta: extractRequestMeta(json));
 }
 
 void _validateObjectRootSchema(

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -1852,6 +1852,434 @@ void main() {
       expect(listRequest.meta?[McpMetaKey.clientCapabilities], {});
     });
 
+    test('client listenSubscriptions requires a connected transport', () {
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+      );
+
+      expect(
+        () => client.listenSubscriptions(
+          const SubscriptionsListenRequest(
+            notifications: SubscriptionFilter(toolsListChanged: true),
+          ),
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('client listenSubscriptions demultiplexes by subscription id',
+        () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+          resources: ServerCapabilitiesResources(),
+        ),
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+
+      final toolsSubscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+      );
+      final resourcesSubscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(
+            resourceSubscriptions: ['file:///project/config.json'],
+          ),
+        ),
+      );
+      await _pump();
+
+      final listenRequests = transport.sentMessages
+          .whereType<JsonRpcRequest>()
+          .where((message) => message.method == Method.subscriptionsListen)
+          .toList();
+      expect(listenRequests, hasLength(2));
+      expect(listenRequests[0].id, toolsSubscription.id);
+      expect(listenRequests[1].id, resourcesSubscription.id);
+      expect(
+        listenRequests[0].meta?[McpMetaKey.protocolVersion],
+        draftProtocolVersion2026_07_28,
+      );
+      expect(listenRequests[0].params?['notifications'], {
+        'toolsListChanged': true,
+      });
+
+      transport.onmessage?.call(
+        JsonRpcSubscriptionsAcknowledgedNotification(
+          acknowledgedParams: const SubscriptionsAcknowledgedNotification(
+            notifications: SubscriptionFilter(
+              resourceSubscriptions: ['file:///project/config.json'],
+            ),
+          ),
+          meta: {McpMetaKey.subscriptionId: resourcesSubscription.id},
+        ),
+      );
+      transport.onmessage?.call(
+        JsonRpcSubscriptionsAcknowledgedNotification(
+          acknowledgedParams: const SubscriptionsAcknowledgedNotification(
+            notifications: SubscriptionFilter(toolsListChanged: true),
+          ),
+          meta: {McpMetaKey.subscriptionId: toolsSubscription.id},
+        ),
+      );
+
+      final toolsAcknowledged = await toolsSubscription.acknowledged;
+      final resourcesAcknowledged = await resourcesSubscription.acknowledged;
+      expect(toolsAcknowledged.notifications.toolsListChanged, isTrue);
+      expect(
+        resourcesAcknowledged.notifications.resourceSubscriptions,
+        ['file:///project/config.json'],
+      );
+
+      final toolNotification = toolsSubscription.notifications.first;
+      final resourceNotification = resourcesSubscription.notifications.first;
+      transport.onmessage?.call(
+        JsonRpcToolListChangedNotification(
+          meta: {McpMetaKey.subscriptionId: toolsSubscription.id},
+        ),
+      );
+      transport.onmessage?.call(
+        JsonRpcResourceUpdatedNotification(
+          updatedParams: const ResourceUpdatedNotification(
+            uri: 'file:///project/config.json',
+          ),
+          meta: {McpMetaKey.subscriptionId: resourcesSubscription.id},
+        ),
+      );
+
+      expect(
+        (await toolNotification).method,
+        Method.notificationsToolsListChanged,
+      );
+      expect(
+        (await resourceNotification).method,
+        Method.notificationsResourcesUpdated,
+      );
+
+      toolsSubscription.cancel('done');
+      resourcesSubscription.cancel('done');
+      await expectLater(toolsSubscription.done, completes);
+      await expectLater(resourcesSubscription.done, completes);
+      await _pump();
+
+      final cancellations =
+          transport.sentMessages.whereType<JsonRpcCancelledNotification>();
+      expect(
+        cancellations
+            .map((notification) => notification.cancelParams.requestId),
+        containsAll([toolsSubscription.id, resourcesSubscription.id]),
+      );
+    });
+
+    test('client subscription rejects notifications before acknowledgment',
+        () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+        ),
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+
+      final subscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+      );
+      subscription.notifications.listen(null, onError: (_) {});
+      await _pump();
+
+      final acknowledgedExpectation = expectLater(
+        subscription.acknowledged,
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.message,
+            'message',
+            contains(Method.notificationsSubscriptionsAcknowledged),
+          ),
+        ),
+      );
+      final doneExpectation = expectLater(
+        subscription.done,
+        throwsA(isA<McpError>()),
+      );
+
+      transport.onmessage?.call(
+        JsonRpcToolListChangedNotification(
+          meta: {McpMetaKey.subscriptionId: subscription.id},
+        ),
+      );
+
+      await acknowledgedExpectation;
+      await doneExpectation;
+      await _pump();
+
+      final cancellation = transport.sentMessages
+          .whereType<JsonRpcCancelledNotification>()
+          .single;
+      expect(cancellation.cancelParams.requestId, subscription.id);
+    });
+
+    test('client subscription fails when the connection closes', () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+        ),
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+
+      final subscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+      );
+      subscription.notifications.listen(null, onError: (_) {});
+      await _pump();
+
+      final acknowledgedExpectation = expectLater(
+        subscription.acknowledged,
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.code,
+            'code',
+            ErrorCode.connectionClosed.value,
+          ),
+        ),
+      );
+      final doneExpectation = expectLater(
+        subscription.done,
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.message,
+            'message',
+            'Connection closed',
+          ),
+        ),
+      );
+
+      await transport.close();
+
+      await acknowledgedExpectation;
+      await doneExpectation;
+    });
+
+    test('client subscription rejects acknowledgments outside requested filter',
+        () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+          prompts: ServerCapabilitiesPrompts(listChanged: true),
+        ),
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+
+      final subscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+      );
+      subscription.notifications.listen(null, onError: (_) {});
+      await _pump();
+
+      final acknowledgedExpectation = expectLater(
+        subscription.acknowledged,
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.message,
+            'message',
+            contains('not requested'),
+          ),
+        ),
+      );
+      final doneExpectation = expectLater(
+        subscription.done,
+        throwsA(isA<McpError>()),
+      );
+
+      transport.onmessage?.call(
+        JsonRpcNotification(
+          method: Method.notificationsSubscriptionsAcknowledged,
+          params: const {
+            'notifications': {'promptsListChanged': true},
+          },
+          meta: {McpMetaKey.subscriptionId: subscription.id},
+        ),
+      );
+
+      await acknowledgedExpectation;
+      await doneExpectation;
+      await _pump();
+
+      final cancellation = transport.sentMessages
+          .whereType<JsonRpcCancelledNotification>()
+          .single;
+      expect(cancellation.cancelParams.requestId, subscription.id);
+    });
+
+    test('client subscription rejects unacknowledged notification types',
+        () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+          prompts: ServerCapabilitiesPrompts(listChanged: true),
+        ),
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+
+      final subscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+      );
+      subscription.notifications.listen(null, onError: (_) {});
+      await _pump();
+
+      transport.onmessage?.call(
+        JsonRpcSubscriptionsAcknowledgedNotification(
+          acknowledgedParams: const SubscriptionsAcknowledgedNotification(
+            notifications: SubscriptionFilter(toolsListChanged: true),
+          ),
+          meta: {McpMetaKey.subscriptionId: subscription.id},
+        ),
+      );
+      await subscription.acknowledged;
+
+      final doneExpectation = expectLater(
+        subscription.done,
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.message,
+            'message',
+            contains(Method.notificationsPromptsListChanged),
+          ),
+        ),
+      );
+
+      transport.onmessage?.call(
+        JsonRpcPromptListChangedNotification(
+          meta: {McpMetaKey.subscriptionId: subscription.id},
+        ),
+      );
+
+      await doneExpectation;
+      await _pump();
+
+      final cancellation = transport.sentMessages
+          .whereType<JsonRpcCancelledNotification>()
+          .single;
+      expect(cancellation.cancelParams.requestId, subscription.id);
+    });
+
+    test('client subscription cancel before ack completes done', () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+        ),
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+
+      final subscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+      );
+      await _pump();
+
+      final acknowledgedExpectation = expectLater(
+        subscription.acknowledged,
+        throwsA(
+          isA<AbortError>().having(
+            (error) => error.reason,
+            'reason',
+            'user cancelled',
+          ),
+        ),
+      );
+
+      subscription.cancel('user cancelled');
+
+      await acknowledgedExpectation;
+      await expectLater(subscription.done, completes);
+      await _pump();
+
+      final cancellation = transport.sentMessages
+          .whereType<JsonRpcCancelledNotification>()
+          .single;
+      expect(cancellation.cancelParams.requestId, subscription.id);
+    });
+
+    test('client subscription rejects completion before acknowledgment',
+        () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+        ),
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+
+      final subscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+      );
+      subscription.notifications.listen(null, onError: (_) {});
+      await _pump();
+
+      final acknowledgedExpectation = expectLater(
+        subscription.acknowledged,
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.message,
+            'message',
+            contains('completed before'),
+          ),
+        ),
+      );
+      final doneExpectation = expectLater(
+        subscription.done,
+        throwsA(isA<McpError>()),
+      );
+
+      transport.onmessage?.call(
+        JsonRpcResponse(
+          id: subscription.id,
+          result: const EmptyResult().toJson(),
+        ),
+      );
+
+      await acknowledgedExpectation;
+      await doneExpectation;
+    });
+
     test('client rejects unrecognized stateless resultType values', () async {
       final transport = DiscoveringClientTransport(
         toolsListResult: const {

--- a/test/types/subscriptions_test.dart
+++ b/test/types/subscriptions_test.dart
@@ -76,6 +76,73 @@ void main() {
       expect(acknowledged.toJson(), isEmpty);
     });
 
+    test('checks acknowledged subsets and allowed notifications', () {
+      const requested = SubscriptionFilter(
+        toolsListChanged: true,
+        resourceSubscriptions: [
+          'file:///project/config.json',
+          'file:///project/other.json',
+        ],
+      );
+      const acknowledged = SubscriptionFilter(
+        toolsListChanged: true,
+        resourceSubscriptions: ['file:///project/config.json'],
+      );
+
+      expect(acknowledged.isSubsetOf(requested), isTrue);
+      expect(
+        const SubscriptionFilter(promptsListChanged: true).isSubsetOf(
+          requested,
+        ),
+        isFalse,
+      );
+      expect(
+        const SubscriptionFilter(resourcesListChanged: true).isSubsetOf(
+          requested,
+        ),
+        isFalse,
+      );
+      expect(
+        const SubscriptionFilter(
+          resourceSubscriptions: ['file:///project/missing.json'],
+        ).isSubsetOf(requested),
+        isFalse,
+      );
+
+      expect(
+        acknowledged.allowsNotification(
+          const JsonRpcToolListChangedNotification(),
+        ),
+        isTrue,
+      );
+      expect(
+        acknowledged.allowsNotification(
+          JsonRpcResourceUpdatedNotification(
+            updatedParams: const ResourceUpdatedNotification(
+              uri: 'file:///project/config.json',
+            ),
+          ),
+        ),
+        isTrue,
+      );
+      expect(
+        acknowledged.allowsNotification(
+          JsonRpcResourceUpdatedNotification(
+            updatedParams: const ResourceUpdatedNotification(
+              uri: 'file:///project/missing.json',
+            ),
+          ),
+        ),
+        isFalse,
+      );
+      expect(
+        acknowledged.allowsNotification(
+          const JsonRpcPromptListChangedNotification(),
+        ),
+        isFalse,
+      );
+    });
+
     test('rejects malformed filters', () {
       expect(
         () => SubscriptionFilter.fromJson(
@@ -151,6 +218,29 @@ void main() {
   });
 
   group('JsonRpcSubscriptionsAcknowledgedNotification', () {
+    test('preserves subscription metadata on list changed notifications', () {
+      for (final notification in [
+        const JsonRpcToolListChangedNotification(
+          meta: {McpMetaKey.subscriptionId: 'sub-1'},
+        ),
+        const JsonRpcPromptListChangedNotification(
+          meta: {McpMetaKey.subscriptionId: 'sub-1'},
+        ),
+        const JsonRpcResourceListChangedNotification(
+          meta: {McpMetaKey.subscriptionId: 'sub-1'},
+        ),
+        // ignore: deprecated_member_use_from_same_package, deprecated_member_use
+        const JsonRpcCompletionListChangedNotification(
+          meta: {McpMetaKey.subscriptionId: 'sub-1'},
+        ),
+      ]) {
+        final parsed = JsonRpcMessage.fromJson(notification.toJson())
+            as JsonRpcNotification;
+
+        expect(parsed.meta?[McpMetaKey.subscriptionId], 'sub-1');
+      }
+    });
+
     test('serializes and parses subscription acknowledgments', () {
       final notification = JsonRpcSubscriptionsAcknowledgedNotification(
         acknowledgedParams: const SubscriptionsAcknowledgedNotification(


### PR DESCRIPTION
## Summary
- add a client-side subscriptions/listen handle that correlates stream notifications by subscription id
- validate subscription acknowledgments and notification filters before dispatching stream events
- preserve _meta on typed list-changed notifications so stdio clients can demultiplex subscription streams

## Validation
- dart analyze
- dart test test/types/subscriptions_test.dart
- dart test test/mcp_2026_07_28_test.dart --name "client .*subscription|listenSubscriptions"
- dart test
- dart pub global run coverage:test_with_coverage
- dart run bin/mcp_dart.dart conformance --suite all --json
- git diff --check