### PR TITLE
Allow JSON-value structured tool output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@
 - Added client-side `subscriptions/listen` handles that correlate stream
   notifications by `io.modelcontextprotocol/subscriptionId`, validate the
   acknowledgment, and cancel long-lived streams with `notifications/cancelled`.
+- Allowed MCP 2026 tool `outputSchema` declarations to use any JSON Schema and
+  `structuredContent` results to carry any JSON value, while omitting non-object
+  structured output from stable 2025 responses.
 
 ## 2.2.0
 

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -46,6 +46,53 @@ List<McpIcon>? _iconsFromLegacyImage(ImageContent? image) {
   ];
 }
 
+bool _isDraft2026Request(String? protocolVersion) =>
+    protocolVersion != null && isStatelessProtocolVersion(protocolVersion);
+
+bool _isStableStructuredContentValue(Object? value) {
+  if (value is Map<String, dynamic>) {
+    return true;
+  }
+  if (value is Map) {
+    return value.keys.every((key) => key is String);
+  }
+  return false;
+}
+
+JsonSchema? _outputSchemaForProtocol(
+  JsonSchema? schema,
+  String? protocolVersion,
+) {
+  if (schema == null || _isDraft2026Request(protocolVersion)) {
+    return schema;
+  }
+
+  // MCP 2025-11-25 restricts tool output schemas to object roots. MCP 2026
+  // allows any JSON Schema, so omit non-object schemas for stable callers.
+  if (schema.toJson()['type'] == 'object') {
+    return schema;
+  }
+  return null;
+}
+
+CallToolResult _toolResultForProtocol(
+  CallToolResult result,
+  String? protocolVersion,
+) {
+  if (_isDraft2026Request(protocolVersion) ||
+      !result.hasStructuredContent ||
+      _isStableStructuredContentValue(result.structuredContent)) {
+    return result;
+  }
+
+  return CallToolResult(
+    content: result.content,
+    isError: result.isError,
+    meta: result.meta,
+    extra: result.extra,
+  );
+}
+
 /// Definition for a completable argument.
 class CompletableDef {
   /// The callback to invoke to get completion suggestions.
@@ -219,6 +266,7 @@ CallToolResult _withRelatedTaskMeta(CallToolResult result, String taskId) {
     content: result.content,
     isError: result.isError,
     structuredContent: result.structuredContent,
+    hasStructuredContent: result.hasStructuredContent,
     meta: meta,
     extra: result.extra,
   );
@@ -516,7 +564,7 @@ abstract class RegisteredTool {
   ToolInputSchema? get inputSchema;
 
   /// The output schema for the tool.
-  ToolOutputSchema? get outputSchema;
+  JsonSchema? get outputSchema;
 
   /// Annotations for the tool.
   ToolAnnotations? get annotations;
@@ -545,7 +593,7 @@ abstract class RegisteredTool {
     String? title,
     String? description,
     ToolInputSchema? inputSchema,
-    ToolOutputSchema? outputSchema,
+    JsonSchema? outputSchema,
     ToolAnnotations? annotations,
     ToolExecution? execution,
     ToolCallback? callback,
@@ -563,7 +611,7 @@ class _RegisteredToolImpl implements RegisteredTool {
   @override
   ToolInputSchema? inputSchema;
   @override
-  ToolOutputSchema? outputSchema;
+  JsonSchema? outputSchema;
   @override
   ToolAnnotations? annotations;
   final ImageContent? icon;
@@ -596,6 +644,7 @@ class _RegisteredToolImpl implements RegisteredTool {
   Tool toTool({
     bool includeExecution = true,
     ToolInputSchema? inputSchemaOverride,
+    String? protocolVersion,
   }) {
     return Tool(
       name: name,
@@ -603,7 +652,7 @@ class _RegisteredToolImpl implements RegisteredTool {
       description: description,
       inputSchema:
           inputSchemaOverride ?? inputSchema ?? const ToolInputSchema(),
-      outputSchema: outputSchema,
+      outputSchema: _outputSchemaForProtocol(outputSchema, protocolVersion),
       annotations: annotations,
       icon: icon,
       icons: _iconsFromLegacyImage(icon),
@@ -627,7 +676,7 @@ class _RegisteredToolImpl implements RegisteredTool {
     String? title,
     String? description,
     ToolInputSchema? inputSchema,
-    ToolOutputSchema? outputSchema,
+    JsonSchema? outputSchema,
     ToolAnnotations? annotations,
     ToolExecution? execution,
     ToolCallback? callback,
@@ -785,7 +834,7 @@ class ExperimentalMcpServerTasks {
     String? title,
     String? description,
     ToolInputSchema? inputSchema,
-    ToolOutputSchema? outputSchema,
+    JsonSchema? outputSchema,
     ToolAnnotations? annotations,
     Map<String, dynamic>? meta,
     ToolExecution? execution,
@@ -1424,6 +1473,8 @@ class McpServer {
                   inputSchemaOverride: isStatelessRequest
                       ? _toolInputSchemaForStatelessList(tool)
                       : null,
+                  protocolVersion:
+                      protocolVersion is String ? protocolVersion : null,
                 ),
               )
               .toList(),
@@ -1549,6 +1600,13 @@ class McpServer {
                 );
               }
             }
+          }
+
+          if (result is CallToolResult) {
+            return _toolResultForProtocol(
+              result,
+              protocolVersion is String ? protocolVersion : null,
+            );
           }
 
           return result;
@@ -1963,7 +2021,7 @@ class McpServer {
     String? title,
     String? description,
     ToolInputSchema? inputSchema,
-    ToolOutputSchema? outputSchema,
+    JsonSchema? outputSchema,
     ToolAnnotations? annotations,
     Map<String, dynamic>? meta,
     required ToolFunction callback,
@@ -1987,7 +2045,7 @@ class McpServer {
     String? title,
     String? description,
     ToolInputSchema? inputSchema,
-    ToolOutputSchema? outputSchema,
+    JsonSchema? outputSchema,
     ToolAnnotations? annotations,
     Map<String, dynamic>? meta,
     ToolExecution? execution,

--- a/lib/src/server/mcp_ui.dart
+++ b/lib/src/server/mcp_ui.dart
@@ -10,7 +10,7 @@ class McpUiAppToolConfig {
   final String? title;
   final String? description;
   final ToolInputSchema? inputSchema;
-  final ToolOutputSchema? outputSchema;
+  final JsonSchema? outputSchema;
   final ToolAnnotations? annotations;
   final Map<String, dynamic> meta;
 

--- a/lib/src/types/sampling.dart
+++ b/lib/src/types/sampling.dart
@@ -310,8 +310,11 @@ sealed class SamplingContent {
           final SamplingToolResultContent c => {
               'toolUseId': c.toolUseId,
               'content': c.contentBlocks.map((item) => item.toJson()).toList(),
-              if (c.structuredContent != null)
-                'structuredContent': c.structuredContent,
+              if (c.hasStructuredContent)
+                'structuredContent': readJsonValue(
+                  c.structuredContent,
+                  'SamplingToolResultContent.structuredContent',
+                ),
               if (c.isError != null) 'isError': c.isError,
               if (c.meta != null) '_meta': c.meta,
             },
@@ -431,7 +434,8 @@ class SamplingToolUseContent extends SamplingContent {
 class SamplingToolResultContent extends SamplingContent {
   final String toolUseId;
   final dynamic content;
-  final Map<String, dynamic>? structuredContent;
+  final Object? structuredContent;
+  final bool hasStructuredContent;
   final bool? isError;
   final Map<String, dynamic>? meta;
 
@@ -439,9 +443,12 @@ class SamplingToolResultContent extends SamplingContent {
     required this.toolUseId,
     required this.content,
     this.structuredContent,
+    bool? hasStructuredContent,
     this.isError,
     this.meta,
-  }) : super(type: 'tool_result');
+  })  : hasStructuredContent =
+            hasStructuredContent ?? structuredContent != null,
+        super(type: 'tool_result');
 
   /// Normalized content blocks for tool results.
   List<Content> get contentBlocks => _parseToolResultContent(content);
@@ -454,7 +461,13 @@ class SamplingToolResultContent extends SamplingContent {
     return SamplingToolResultContent(
       toolUseId: json['toolUseId'] as String,
       content: _parseToolResultWireContent(json['content']),
-      structuredContent: _asJsonObjectOrNull(json['structuredContent']),
+      structuredContent: json.containsKey('structuredContent')
+          ? readJsonValue(
+              json['structuredContent'],
+              'SamplingToolResultContent.structuredContent',
+            )
+          : null,
+      hasStructuredContent: json.containsKey('structuredContent'),
       isError: json['isError'] as bool?,
       meta: _asJsonObjectOrNull(json['_meta']),
     );

--- a/lib/src/types/tools.dart
+++ b/lib/src/types/tools.dart
@@ -9,7 +9,10 @@ import 'validation.dart';
 /// Legacy alias for [JsonObject] used as tool input schema.
 typedef ToolInputSchema = JsonObject;
 
-/// Legacy alias for [JsonObject] used as tool output schema.
+/// Legacy alias for object-root tool output schemas.
+///
+/// MCP 2026-07-28 allows [Tool.outputSchema] to be any JSON Schema. Use
+/// [JsonSchema] directly when the output schema root is not an object.
 typedef ToolOutputSchema = JsonObject;
 
 /// Additional properties describing a Tool to clients.
@@ -149,7 +152,7 @@ class Tool {
   /// JSON Schema defining the tool's input parameters.
   final JsonSchema inputSchema;
 
-  /// JSON Schema defining the tool's output parameters.
+  /// JSON Schema defining the tool's structured output.
   final JsonSchema? outputSchema;
 
   /// Optional additional properties describing the tool.
@@ -197,13 +200,6 @@ class Tool {
         _readOptionalJsonObject(json['outputSchema'], 'Tool.outputSchema');
     final outputSchema =
         outputSchemaJson == null ? null : JsonSchema.fromJson(outputSchemaJson);
-    if (outputSchema != null) {
-      _validateObjectRootSchema(
-        outputSchema,
-        'Tool.outputSchema',
-        formatException: true,
-      );
-    }
 
     return Tool(
       name: json['name'] as String,
@@ -231,9 +227,6 @@ class Tool {
 
   Map<String, dynamic> toJson() {
     _validateObjectRootSchema(inputSchema, 'Tool.inputSchema');
-    if (outputSchema != null) {
-      _validateObjectRootSchema(outputSchema!, 'Tool.outputSchema');
-    }
 
     return {
       'name': name,
@@ -390,7 +383,15 @@ class CallToolResult implements BaseResultData {
   final bool isError;
 
   /// Structured content returned by the tool.
-  final Map<String, dynamic>? structuredContent;
+  ///
+  /// MCP 2026-07-28 allows any JSON value: object, array, string, number,
+  /// boolean, or null.
+  final Object? structuredContent;
+
+  /// Whether [structuredContent] was explicitly present.
+  ///
+  /// This distinguishes an omitted field from an explicit JSON `null`.
+  final bool hasStructuredContent;
 
   /// Optional metadata.
   @override
@@ -403,24 +404,26 @@ class CallToolResult implements BaseResultData {
     required this.content,
     this.isError = false,
     this.structuredContent,
+    bool? hasStructuredContent,
     this.meta,
     this.extra,
-  });
+  }) : hasStructuredContent = hasStructuredContent ?? structuredContent != null;
 
   /// Creates a result from a list of content items.
   factory CallToolResult.fromContent(List<Content> content) {
     return CallToolResult(content: content);
   }
 
-  /// Creates a result from arbitrary structured data.
+  /// Creates a result from arbitrary structured JSON data.
   ///
   /// Automatically populates [content] with a JSON-serialized version of
   /// [content] for backward compatibility with clients that do not support
   /// [structuredContent].
-  factory CallToolResult.fromStructuredContent(Map<String, dynamic> content) {
+  factory CallToolResult.fromStructuredContent(Object? content) {
     return CallToolResult(
       content: [TextContent(text: jsonEncode(content))],
       structuredContent: content,
+      hasStructuredContent: true,
     );
   }
 
@@ -438,7 +441,13 @@ class CallToolResult implements BaseResultData {
           .map((e) => Content.fromJson(e as Map<String, dynamic>))
           .toList(),
       isError: json['isError'] as bool? ?? false,
-      structuredContent: json['structuredContent'] as Map<String, dynamic>?,
+      structuredContent: json.containsKey('structuredContent')
+          ? readJsonValue(
+              json['structuredContent'],
+              'CallToolResult.structuredContent',
+            )
+          : null,
+      hasStructuredContent: json.containsKey('structuredContent'),
       meta: json['_meta'] as Map<String, dynamic>?,
       extra: extra.isEmpty ? null : extra,
     );
@@ -448,7 +457,11 @@ class CallToolResult implements BaseResultData {
   Map<String, dynamic> toJson() => {
         'content': content.map((e) => e.toJson()).toList(),
         if (isError) 'isError': isError,
-        if (structuredContent != null) 'structuredContent': structuredContent,
+        if (hasStructuredContent)
+          'structuredContent': readJsonValue(
+            structuredContent,
+            'CallToolResult.structuredContent',
+          ),
         if (meta != null) '_meta': meta,
         ...?extra,
       };

--- a/lib/src/types/validation.dart
+++ b/lib/src/types/validation.dart
@@ -88,3 +88,31 @@ void validateCacheScope(String? value, String field) {
     );
   }
 }
+
+Object? readJsonValue(Object? value, String field) {
+  if (value == null || value is String || value is bool) {
+    return value;
+  }
+  if (value is num) {
+    if (!value.isFinite) {
+      throw FormatException('$field must be a finite JSON number');
+    }
+    return value;
+  }
+  if (value is List) {
+    return value.map((item) => readJsonValue(item, '$field[]')).toList();
+  }
+  if (value is Map) {
+    if (value.keys.any((key) => key is! String)) {
+      throw FormatException('$field must be a JSON object with string keys');
+    }
+    return {
+      for (final entry in value.entries)
+        entry.key as String: readJsonValue(
+          entry.value,
+          '$field.${entry.key}',
+        ),
+    };
+  }
+  throw FormatException('$field must be a JSON value');
+}

--- a/packages/templates/simple/__brick__/lib/mcp/tools/base_tool.dart
+++ b/packages/templates/simple/__brick__/lib/mcp/tools/base_tool.dart
@@ -25,8 +25,7 @@ abstract class BaseTool {
   ToolInputSchema get inputSchema;
 
   /// Optional JSON schema defining the output format.
-  /// Use [JsonSchema.object()] to create an object schema.
-  ToolOutputSchema? get outputSchema => null;
+  JsonSchema? get outputSchema => null;
 
   /// Optional tool annotations with hints about tool behavior.
   /// Includes readOnlyHint, destructiveHint, idempotentHint, etc.

--- a/packages/templates/simple/__brick__/lib/mcp/tools/calculator_tool.dart
+++ b/packages/templates/simple/__brick__/lib/mcp/tools/calculator_tool.dart
@@ -20,7 +20,7 @@ class CalculatorTool extends BaseTool {
       );
 
   @override
-  ToolOutputSchema? get outputSchema => ToolOutputSchema(
+  JsonSchema? get outputSchema => ToolOutputSchema(
         properties: {
           'result': JsonSchema.number(description: 'The sum of a and b'),
         },

--- a/test/client/client_tool_validation_test.dart
+++ b/test/client/client_tool_validation_test.dart
@@ -59,6 +59,21 @@ class MockTransport extends Transport
                 .toJson(),
           ),
         );
+      } else if (name == 'array_tool') {
+        _respond(
+          JsonRpcResponse(
+            id: message.id,
+            result: CallToolResult.fromStructuredContent(['alpha', 'beta'])
+                .toJson(),
+          ),
+        );
+      } else if (name == 'broken_array_tool') {
+        _respond(
+          JsonRpcResponse(
+            id: message.id,
+            result: CallToolResult.fromStructuredContent(['alpha', 1]).toJson(),
+          ),
+        );
       } else if (name == 'broken_tool') {
         // Returns data that violates the schema (missing 'result')
         _respond(
@@ -112,6 +127,16 @@ class MockTransport extends Transport
           },
           required: ['result'],
         ),
+      ),
+      Tool(
+        name: 'array_tool',
+        inputSchema: const ToolInputSchema(),
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
+      ),
+      Tool(
+        name: 'broken_array_tool',
+        inputSchema: const ToolInputSchema(),
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
       ),
       const Tool(
         name: 'task_required_tool',
@@ -248,7 +273,37 @@ void main() {
         const CallToolRequest(name: 'validated_tool'),
       );
 
-      expect(result.structuredContent?['result'], equals('success'));
+      final structured = result.structuredContent as Map<String, dynamic>;
+      expect(structured['result'], equals('success'));
+    });
+
+    test('validates non-object tool output schemas successfully', () async {
+      await client.connect(transport);
+      await client.listTools();
+
+      final result = await client.callTool(
+        const CallToolRequest(name: 'array_tool'),
+      );
+
+      expect(result.structuredContent, equals(['alpha', 'beta']));
+    });
+
+    test('throws when non-object tool output validation fails', () async {
+      await client.connect(transport);
+      await client.listTools();
+
+      expect(
+        () => client.callTool(
+          const CallToolRequest(name: 'broken_array_tool'),
+        ),
+        throwsA(
+          isA<McpError>().having(
+            (e) => e.message,
+            'message',
+            contains('Structured content does not match'),
+          ),
+        ),
+      );
     });
 
     test('throws when tool output validation fails', () async {

--- a/test/interop/ts/src/client.ts
+++ b/test/interop/ts/src/client.ts
@@ -238,15 +238,10 @@ async function assertRawDartServerWireShapes(client: Client): Promise<void> {
       );
     }
     if (tool.outputSchema !== undefined) {
-      const outputSchema = requireRecord(
+      requireRecord(
         tool.outputSchema,
         'raw tool outputSchema'
       );
-      if (outputSchema.type !== 'object') {
-        throw new Error(
-          `tool outputSchema was not object-root: ${JSON.stringify(tool)}`
-        );
-      }
     }
   }
 

--- a/test/server/output_validation_test.dart
+++ b/test/server/output_validation_test.dart
@@ -82,7 +82,137 @@ void main() {
       expect(response, isA<JsonRpcResponse>());
       final successResponse = response as JsonRpcResponse;
       final result = CallToolResult.fromJson(successResponse.result);
-      expect(result.structuredContent?['result'], equals('success'));
+      final structured = result.structuredContent as Map<String, dynamic>;
+      expect(structured['result'], equals('success'));
+    });
+
+    test('non-object output schema validates for MCP 2026 calls', () async {
+      mcpServer.registerTool(
+        'array_tool',
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
+        callback: (args, extra) async {
+          return CallToolResult.fromStructuredContent(['alpha', 'beta']);
+        },
+      );
+
+      await mcpServer.connect(transport);
+
+      final callRequest = JsonRpcCallToolRequest(
+        id: 2,
+        params: const CallToolRequest(name: 'array_tool').toJson(),
+        meta: _statelessMeta(),
+      );
+      transport.receiveMessage(callRequest);
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final response = transport.sentMessages.last;
+      expect(response, isA<JsonRpcResponse>());
+      final successResponse = response as JsonRpcResponse;
+      final result = CallToolResult.fromJson(successResponse.result);
+      expect(result.structuredContent, equals(['alpha', 'beta']));
+    });
+
+    test('non-object output schema validation failures are rejected', () async {
+      mcpServer.registerTool(
+        'invalid_array_tool',
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
+        callback: (args, extra) async {
+          return CallToolResult.fromStructuredContent(['alpha', 1]);
+        },
+      );
+
+      await mcpServer.connect(transport);
+
+      final callRequest = JsonRpcCallToolRequest(
+        id: 2,
+        params: const CallToolRequest(name: 'invalid_array_tool').toJson(),
+        meta: _statelessMeta(),
+      );
+      transport.receiveMessage(callRequest);
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final response = transport.sentMessages.last;
+      expect(response, isA<JsonRpcError>());
+      final errorResponse = response as JsonRpcError;
+      expect(errorResponse.error.code, equals(ErrorCode.invalidParams.value));
+      expect(errorResponse.error.message, contains('Output validation error'));
+    });
+
+    test('stable tools/list omits non-object output schemas', () async {
+      mcpServer.registerTool(
+        'array_tool',
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
+        callback: (args, extra) async {
+          return CallToolResult.fromStructuredContent(['alpha', 'beta']);
+        },
+      );
+
+      await mcpServer.connect(transport);
+      await _sendInit(transport);
+
+      transport.receiveMessage(const JsonRpcListToolsRequest(id: 2));
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final response = transport.sentMessages.last;
+      expect(response, isA<JsonRpcResponse>());
+      final successResponse = response as JsonRpcResponse;
+      final tools = successResponse.result['tools'] as List<dynamic>;
+      final tool = tools.single as Map<String, dynamic>;
+      expect(tool.containsKey('outputSchema'), isFalse);
+    });
+
+    test('MCP 2026 tools/list includes non-object output schemas', () async {
+      mcpServer.registerTool(
+        'array_tool',
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
+        callback: (args, extra) async {
+          return CallToolResult.fromStructuredContent(['alpha', 'beta']);
+        },
+      );
+
+      await mcpServer.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcListToolsRequest(
+          id: 2,
+          meta: _statelessMeta(),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final response = transport.sentMessages.last;
+      expect(response, isA<JsonRpcResponse>());
+      final successResponse = response as JsonRpcResponse;
+      final tools = successResponse.result['tools'] as List<dynamic>;
+      final tool = tools.single as Map<String, dynamic>;
+      expect(tool['outputSchema']['type'], equals('array'));
+      expect(tool['outputSchema']['items']['type'], equals('string'));
+    });
+
+    test('stable tool calls omit non-object structured content', () async {
+      mcpServer.registerTool(
+        'array_tool',
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
+        callback: (args, extra) async {
+          return CallToolResult.fromStructuredContent(['alpha', 'beta']);
+        },
+      );
+
+      await mcpServer.connect(transport);
+      await _sendInit(transport);
+
+      final callRequest = JsonRpcCallToolRequest(
+        id: 2,
+        params: const CallToolRequest(name: 'array_tool').toJson(),
+      );
+      transport.receiveMessage(callRequest);
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final response = transport.sentMessages.last;
+      expect(response, isA<JsonRpcResponse>());
+      final successResponse = response as JsonRpcResponse;
+      expect(successResponse.result.containsKey('structuredContent'), isFalse);
+      expect(successResponse.result['content'], isA<List<dynamic>>());
     });
 
     test('invalid output fails validation', () async {
@@ -225,6 +355,13 @@ void main() {
     });
   });
 }
+
+Map<String, dynamic> _statelessMeta() => {
+      McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
+      McpMetaKey.clientInfo:
+          const Implementation(name: 'TestClient', version: '1.0.0').toJson(),
+      McpMetaKey.clientCapabilities: const ClientCapabilities().toJson(),
+    };
 
 Future<void> _sendInit(MockTransport transport) async {
   final initRequest = JsonRpcInitializeRequest(

--- a/test/tool_schema_test.dart
+++ b/test/tool_schema_test.dart
@@ -184,6 +184,54 @@ void main() {
       );
     });
 
+    test('Tool preserves non-object output schemas for MCP 2026', () {
+      final tool = Tool(
+        name: 'list_results',
+        inputSchema: const JsonObject(),
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
+      );
+
+      final json = tool.toJson();
+      expect(json['outputSchema']['type'], equals('array'));
+      expect(json['outputSchema']['items']['type'], equals('string'));
+
+      final deserialized = Tool.fromJson(json);
+      expect(
+        deserialized.outputSchema?.toJson(),
+        equals(json['outputSchema']),
+      );
+    });
+
+    test('CallToolResult preserves arbitrary JSON structured content', () {
+      final values = <Object?>[
+        {'status': 'ok'},
+        ['alpha', 'beta'],
+        'complete',
+        42,
+        true,
+      ];
+
+      for (final value in values) {
+        final result = CallToolResult.fromStructuredContent(value);
+        final json = result.toJson();
+
+        expect(json['structuredContent'], equals(value));
+
+        final parsed = CallToolResult.fromJson(json);
+        expect(parsed.hasStructuredContent, isTrue);
+        expect(parsed.structuredContent, equals(value));
+      }
+
+      final nullResult = CallToolResult.fromStructuredContent(null);
+      final nullJson = nullResult.toJson();
+      expect(nullJson.containsKey('structuredContent'), isTrue);
+      expect(nullJson['structuredContent'], isNull);
+
+      final parsedNull = CallToolResult.fromJson(nullJson);
+      expect(parsedNull.hasStructuredContent, isTrue);
+      expect(parsedNull.structuredContent, isNull);
+    });
+
     test('Tool serializes JsonEnum properties as standard enum schema', () {
       const tool = Tool(
         name: 'configure_mode',

--- a/test/types/sampling_test.dart
+++ b/test/types/sampling_test.dart
@@ -235,6 +235,30 @@ void main() {
         expect((json['content'] as List).first['type'], equals('text'));
       });
 
+      test('toJson preserves arbitrary structured JSON values', () {
+        const content = SamplingToolResultContent(
+          toolUseId: 'res1',
+          content: [
+            TextContent(text: 'array result'),
+          ],
+          structuredContent: ['alpha', 'beta'],
+        );
+        final json = content.toJson();
+        expect(json['structuredContent'], equals(['alpha', 'beta']));
+
+        const nullContent = SamplingToolResultContent(
+          toolUseId: 'res2',
+          content: [
+            TextContent(text: 'null result'),
+          ],
+          structuredContent: null,
+          hasStructuredContent: true,
+        );
+        final nullJson = nullContent.toJson();
+        expect(nullJson.containsKey('structuredContent'), isTrue);
+        expect(nullJson['structuredContent'], isNull);
+      });
+
       test('fromJson parses correctly', () {
         final json = {
           'type': 'tool_result',
@@ -253,6 +277,35 @@ void main() {
         expect(result.structuredContent, equals({'status': 'ok'}));
         expect(result.content, hasLength(1));
         expect(result.content.first, isA<TextContent>());
+      });
+
+      test('fromJson parses arbitrary structured JSON values', () {
+        final json = {
+          'type': 'tool_result',
+          'toolUseId': 'tr1',
+          'content': [
+            {'type': 'text', 'text': 'result data'},
+          ],
+          'structuredContent': ['alpha', 'beta'],
+        };
+        final content = SamplingContent.fromJson(json);
+        expect(content, isA<SamplingToolResultContent>());
+        final result = content as SamplingToolResultContent;
+        expect(result.hasStructuredContent, isTrue);
+        expect(result.structuredContent, equals(['alpha', 'beta']));
+
+        final nullJson = {
+          'type': 'tool_result',
+          'toolUseId': 'tr2',
+          'content': [
+            {'type': 'text', 'text': 'result data'},
+          ],
+          'structuredContent': null,
+        };
+        final nullContent =
+            SamplingContent.fromJson(nullJson) as SamplingToolResultContent;
+        expect(nullContent.hasStructuredContent, isTrue);
+        expect(nullContent.structuredContent, isNull);
       });
     });
   });


### PR DESCRIPTION
## Summary
- allow MCP 2026 tool outputSchema to use any JSON Schema while preserving object-root inputSchema enforcement
- allow CallToolResult and sampling tool_result structuredContent to carry any JSON value, including explicit null
- keep stable 2025 callers compatible by omitting non-object output schemas and non-object structuredContent from stable server responses

## Validation
- dart format .
- dart analyze
- dart test test/tool_schema_test.dart test/types/sampling_test.dart test/client/client_tool_validation_test.dart test/server/output_validation_test.dart
- dart test
- git diff --check
- (packages/mcp_dart_cli) dart analyze
- (packages/mcp_dart_cli) dart test
- (packages/mcp_dart_cli) dart run bin/mcp_dart.dart conformance --suite all --json