### PR TITLE
Allow MRTR input-required prompt and resource results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@
 - Allowed MCP 2026 tool `outputSchema` declarations to use any JSON Schema and
   `structuredContent` results to carry any JSON value, while omitting non-object
   structured output from stable 2025 responses.
+- Allowed MCP 2026 `prompts/get` and `resources/read` handlers to return
+  `InputRequiredResult`, and rejected MRTR input-required results on unsupported
+  request methods.
 
 ## 2.2.0
 

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -157,7 +157,7 @@ final class InterfaceToolCallback extends ToolCallback {
 }
 
 /// Callback signature for prompts.
-typedef PromptCallback = FutureOr<GetPromptResult> Function(
+typedef PromptCallback = FutureOr<BaseResultData> Function(
   Map<String, dynamic>? args,
   RequestHandlerExtra? extra,
 );
@@ -196,13 +196,13 @@ typedef ListResourcesCallback = FutureOr<ListResourcesResult> Function(
 );
 
 /// Callback to read a specific resource.
-typedef ReadResourceCallback = FutureOr<ReadResourceResult> Function(
+typedef ReadResourceCallback = FutureOr<BaseResultData> Function(
   Uri uri,
   RequestHandlerExtra extra,
 );
 
 /// Callback to read a resource template.
-typedef ReadResourceTemplateCallback = FutureOr<ReadResourceResult> Function(
+typedef ReadResourceTemplateCallback = FutureOr<BaseResultData> Function(
   Uri uri,
   TemplateVariables variables,
   RequestHandlerExtra extra,

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -77,6 +77,12 @@ class Server extends Protocol {
     Method.notificationsRootsListChanged,
   };
 
+  static const Set<String> _inputRequiredResultMethods = {
+    Method.toolsCall,
+    Method.promptsGet,
+    Method.resourcesRead,
+  };
+
   /// Callback to be notified when the server is fully initialized.
   void Function()? oninitialized;
 
@@ -419,7 +425,7 @@ class Server extends Protocol {
     if (result is CallToolResult) {
       return true;
     }
-    if (result is InputRequiredResult && _isStatelessRequest(request)) {
+    if (_allowsInputRequiredResult(result, request)) {
       return true;
     }
     if (result is CreateTaskExtensionResult && _isStatelessRequest(request)) {
@@ -428,6 +434,43 @@ class Server extends Protocol {
     }
 
     return false;
+  }
+
+  bool _allowsPromptGetResult(BaseResultData result, JsonRpcRequest request) {
+    return result is GetPromptResult ||
+        _allowsInputRequiredResult(result, request);
+  }
+
+  bool _allowsResourceReadResult(
+    BaseResultData result,
+    JsonRpcRequest request,
+  ) {
+    return result is ReadResourceResult ||
+        _allowsInputRequiredResult(result, request);
+  }
+
+  bool _allowsInputRequiredResult(
+    BaseResultData result,
+    JsonRpcRequest request,
+  ) {
+    return result is InputRequiredResult &&
+        _isStatelessRequest(request) &&
+        _inputRequiredResultMethods.contains(request.method);
+  }
+
+  void _validateUnsupportedInputRequiredResult(
+    BaseResultData result,
+    JsonRpcRequest request,
+  ) {
+    if (result is! InputRequiredResult) {
+      return;
+    }
+
+    throw McpError(
+      ErrorCode.invalidParams.value,
+      'Invalid ${request.method} result: InputRequiredResult is only supported '
+      'by ${_inputRequiredResultMethods.join(', ')} in MCP stateless requests.',
+    );
   }
 
   bool _allowsTaskExtensionResult(
@@ -708,6 +751,38 @@ class Server extends Protocol {
       }
 
       super.setRequestHandler(method, wrappedHandler, requestFactory);
+    } else if (method == Method.promptsGet) {
+      Future<BaseResultData> wrappedHandler(
+        ReqT request,
+        RequestHandlerExtra extra,
+      ) async {
+        final result = await handler(request, extra);
+        if (!_allowsPromptGetResult(result, request)) {
+          throw McpError(
+            ErrorCode.invalidParams.value,
+            'Invalid prompts/get result: Expected GetPromptResult',
+          );
+        }
+        return result;
+      }
+
+      super.setRequestHandler(method, wrappedHandler, requestFactory);
+    } else if (method == Method.resourcesRead) {
+      Future<BaseResultData> wrappedHandler(
+        ReqT request,
+        RequestHandlerExtra extra,
+      ) async {
+        final result = await handler(request, extra);
+        if (!_allowsResourceReadResult(result, request)) {
+          throw McpError(
+            ErrorCode.invalidParams.value,
+            'Invalid resources/read result: Expected ReadResourceResult',
+          );
+        }
+        return result;
+      }
+
+      super.setRequestHandler(method, wrappedHandler, requestFactory);
     } else if (method == Method.tasksGet ||
         method == Method.tasksCancel ||
         method == Method.tasksUpdate) {
@@ -727,7 +802,16 @@ class Server extends Protocol {
 
       super.setRequestHandler(method, wrappedHandler, requestFactory);
     } else {
-      super.setRequestHandler(method, handler, requestFactory);
+      Future<BaseResultData> wrappedHandler(
+        ReqT request,
+        RequestHandlerExtra extra,
+      ) async {
+        final result = await handler(request, extra);
+        _validateUnsupportedInputRequiredResult(result, request);
+        return result;
+      }
+
+      super.setRequestHandler(method, wrappedHandler, requestFactory);
     }
   }
 

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -1356,6 +1356,95 @@ void main() {
       expect(response.result['requestState'], 'retry-state');
     });
 
+    test('stateless prompts/get permits input required results', () async {
+      final server = McpServer(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+      server.registerPrompt(
+        'needs_input',
+        callback: (args, extra) =>
+            const InputRequiredResult(requestState: 'prompt-state'),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcGetPromptRequest(
+          id: 'prompt-1',
+          getParams: const GetPromptRequest(name: 'needs_input'),
+          meta: _clientMeta(),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      expect(response.result['resultType'], resultTypeInputRequired);
+      expect(response.result['requestState'], 'prompt-state');
+    });
+
+    test('stateless resources/read permits input required results', () async {
+      final server = McpServer(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+      server.registerResource(
+        'needs_input',
+        'memory://needs-input',
+        null,
+        (uri, extra) =>
+            const InputRequiredResult(requestState: 'resource-state'),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcReadResourceRequest(
+          id: 'resource-1',
+          readParams: const ReadResourceRequest(uri: 'memory://needs-input'),
+          meta: _clientMeta(),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      expect(response.result['resultType'], resultTypeInputRequired);
+      expect(response.result['requestState'], 'resource-state');
+    });
+
+    test('stateless unsupported methods reject input required results',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities:
+              ServerCapabilities(prompts: ServerCapabilitiesPrompts()),
+        ),
+      );
+      server.setRequestHandler<JsonRpcListPromptsRequest>(
+        Method.promptsList,
+        (request, extra) async =>
+            const InputRequiredResult(requestState: 'list-state'),
+        (id, params, meta) => JsonRpcListPromptsRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcListPromptsRequest(id: 'prompts', meta: _clientMeta()),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcError;
+      expect(response.error.code, ErrorCode.invalidParams.value);
+      expect(response.error.message, contains('InputRequiredResult'));
+      expect(response.error.message, contains(Method.promptsGet));
+      expect(response.error.message, contains(Method.resourcesRead));
+      expect(response.error.message, contains(Method.toolsCall));
+    });
+
     test('stateless required legacy task tool resolves to final result',
         () async {
       final server = McpServer(


### PR DESCRIPTION
## Summary
- allow MCP 2026 stateless `prompts/get` and `resources/read` handlers to return `InputRequiredResult`
- reject MRTR `InputRequiredResult` responses from unsupported request methods
- widen prompt and resource callback typedefs to `BaseResultData` so high-level APIs can return MRTR results
- add regression coverage and changelog entry for the new RC behavior

## Stack
- Stacked on #208 / `spec/2026-json-schema-structured-content`
- Draft PR while the MCP 2026-07-28 spec remains RC

## Validation
- `dart format .`
- `dart analyze`
- `dart test test/mcp_2026_07_28_test.dart test/server/mcp_test.dart test/server/server_test.dart`
- `dart test`
- `(cd packages/mcp_dart_cli && dart analyze)`
- `(cd packages/mcp_dart_cli && dart test)`
- `(cd packages/mcp_dart_cli && dart run bin/mcp_dart.dart conformance --suite all --json)`
- `git diff --check`
