### PR TITLE
Align resource not found errors by protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@
 - Allowed MCP 2026 `prompts/get` and `resources/read` handlers to return
   `InputRequiredResult`, and rejected MRTR input-required results on unsupported
   request methods.
+- Returned version-appropriate resource-not-found errors from high-level
+  `resources/read` handlers: stable 2025 uses legacy `-32002`, while MCP 2026
+  stateless requests use `-32602` with the missing `uri` in error data.
 
 ## 2.2.0
 

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -93,6 +93,19 @@ CallToolResult _toolResultForProtocol(
   );
 }
 
+McpError _resourceNotFoundErrorForProtocol(
+  String uri,
+  String? protocolVersion,
+) {
+  return McpError(
+    _isDraft2026Request(protocolVersion)
+        ? ErrorCode.invalidParams.value
+        : ErrorCode.resourceNotFound.value,
+    'Resource not found',
+    {'uri': uri},
+  );
+}
+
 /// Definition for a completable argument.
 class CompletableDef {
   /// The callback to invoke to get completion suggestions.
@@ -1809,9 +1822,10 @@ class McpServer {
             return await Future.value(entry.readCallback(uri, vars, extra));
           }
         }
-        throw McpError(
-          ErrorCode.invalidParams.value,
-          "Resource not found: $uriString",
+        final protocolVersion = extra.meta?[McpMetaKey.protocolVersion];
+        throw _resourceNotFoundErrorForProtocol(
+          uriString,
+          protocolVersion is String ? protocolVersion : null,
         );
       },
       (id, params, meta) => JsonRpcReadResourceRequest.fromJson({

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -457,6 +457,9 @@ enum ErrorCode {
   /// code. [requestTimeout] is retained for older SDK behavior.
   headerMismatch(-32001),
 
+  /// Resource not found in stable MCP 2025-11-25.
+  resourceNotFound(-32002),
+
   /// Required per-request client capabilities were not declared.
   missingRequiredClientCapability(-32003),
 

--- a/test/server/mcp_server_test.dart
+++ b/test/server/mcp_server_test.dart
@@ -695,6 +695,63 @@ void main() {
       final contents = response.result['contents'] as List;
       expect(contents.first['text'], equals('Hello from resource'));
     });
+
+    test('legacy resource miss uses stable resource-not-found error', () async {
+      server.registerResource(
+        'Known Resource',
+        'test://known',
+        null,
+        (uri, extra) async => ReadResourceResult(
+          contents: [
+            TextResourceContents(uri: uri.toString(), text: 'known'),
+          ],
+        ),
+      );
+
+      await server.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcReadResourceRequest(
+          id: 'missing-resource',
+          readParams: const ReadResourceRequestParams(uri: 'test://missing'),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      final response = transport.sentMessages.last as JsonRpcError;
+      expect(response.error.code, ErrorCode.resourceNotFound.value);
+      expect(response.error.message, 'Resource not found');
+      expect(response.error.data, {'uri': 'test://missing'});
+    });
+
+    test('stateless resource miss uses 2026 invalid params error', () async {
+      server.registerResource(
+        'Known Resource',
+        'test://known',
+        null,
+        (uri, extra) async => ReadResourceResult(
+          contents: [
+            TextResourceContents(uri: uri.toString(), text: 'known'),
+          ],
+        ),
+      );
+
+      await server.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcReadResourceRequest(
+          id: 'missing-resource',
+          readParams: const ReadResourceRequestParams(uri: 'test://missing'),
+          meta: _statelessMeta(),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      final response = transport.sentMessages.last as JsonRpcError;
+      expect(response.error.code, ErrorCode.invalidParams.value);
+      expect(response.error.message, 'Resource not found');
+      expect(response.error.data, {'uri': 'test://missing'});
+    });
   });
 
   group('McpServer Prompt Registration', () {

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -13,6 +13,7 @@ void main() {
     test('ErrorCode.fromValue finds all standard codes', () {
       expect(ErrorCode.fromValue(-32000), equals(ErrorCode.connectionClosed));
       expect(ErrorCode.fromValue(-32001), equals(ErrorCode.requestTimeout));
+      expect(ErrorCode.fromValue(-32002), equals(ErrorCode.resourceNotFound));
       expect(ErrorCode.fromValue(-32700), equals(ErrorCode.parseError));
       expect(ErrorCode.fromValue(-32600), equals(ErrorCode.invalidRequest));
       expect(ErrorCode.fromValue(-32601), equals(ErrorCode.methodNotFound));


### PR DESCRIPTION
## Summary
- return stable MCP 2025 resource misses with the legacy `-32002` resource-not-found code
- return MCP 2026 stateless resource misses with `-32602` Invalid Params
- include the missing resource `uri` in high-level `resources/read` error data for both paths
- add stable and stateless regression coverage plus an `ErrorCode` lookup case

## Spec Evidence
- MCP 2025-11-25 resources docs list resource-not-found as `-32002`
- MCP 2026-07-28 RC resources docs standardize resource-not-found as `-32602` and note clients should also accept `-32002` for backwards compatibility

## Stack
- Stacked on #209 / `spec/2026-mrtr-prompt-resource-results`
- Draft PR while the MCP 2026-07-28 spec remains RC

## Validation
- `dart format .`
- `dart test test/server/mcp_server_test.dart test/types_edge_cases_test.dart`
- `dart analyze`
- `dart test test/mcp_2026_07_28_test.dart test/server/mcp_server_test.dart test/types_edge_cases_test.dart`
- `git diff --check`
- `dart test`
- `(cd packages/mcp_dart_cli && dart analyze)`
- `(cd packages/mcp_dart_cli && dart test)`
- `(cd packages/mcp_dart_cli && dart run bin/mcp_dart.dart conformance --suite all --json)`
