### PR TITLE
Validate MCP 2026 metadata keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@
 - Returned version-appropriate resource-not-found errors from high-level
   `resources/read` handlers: stable 2025 uses legacy `-32002`, while MCP 2026
   stateless requests use `-32602` with the missing `uri` in error data.
+- Enforced MCP 2026 `_meta` key-name grammar on stateless request metadata and
+  the 2026 request metadata builder while preserving legacy metadata parsing.
 
 ## 2.2.0
 

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -4,6 +4,7 @@ import 'package:mcp_dart/src/shared/json_schema/json_schema_validator.dart';
 import 'package:mcp_dart/src/shared/logging.dart';
 import 'package:mcp_dart/src/shared/protocol.dart';
 import 'package:mcp_dart/src/types.dart';
+import 'package:mcp_dart/src/types/json_rpc.dart' as json_rpc;
 
 final _logger = Logger("mcp_dart.server");
 
@@ -156,6 +157,16 @@ class Server extends Protocol {
 
   McpError? _validateStatelessRequestMetadata(JsonRpcRequest request) {
     final meta = request.meta;
+    try {
+      json_rpc.validateRequestMeta(meta, validateKeys: true);
+    } on FormatException catch (error) {
+      return McpError(
+        ErrorCode.invalidRequest.value,
+        'Invalid stateless request metadata.',
+        error.message,
+      );
+    }
+
     final requestedVersion = meta?[McpMetaKey.protocolVersion];
     if (requestedVersion is! String || requestedVersion.isEmpty) {
       return McpError(

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -9,6 +9,7 @@ export 'types/json_rpc.dart'
         extractRequestMeta,
         parseProgressToken,
         parseRequestId,
+        validateMetaKeyName,
         validateRequestMeta;
 export 'types/mcp_ui.dart';
 export 'types/misc.dart';

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -82,6 +82,7 @@ Map<String, dynamic> buildProtocolRequestMeta({
   Map<String, dynamic>? meta,
   Object? logLevel,
 }) {
+  validateRequestMeta(meta, validateKeys: true);
   return <String, dynamic>{
     ...?meta,
     McpMetaKey.protocolVersion: protocolVersion,
@@ -203,12 +204,66 @@ RequestId? _parseErrorResponseId(Map<String, dynamic> json) {
   return parseRequestId(json['id']);
 }
 
+final _metaPrefixLabelPattern = RegExp(
+  r'^[A-Za-z](?:[A-Za-z0-9-]*[A-Za-z0-9])?$',
+);
+final _metaNamePattern = RegExp(
+  r'^(?:[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?)?$',
+);
+
+/// Validates an MCP 2026 `_meta` key name.
+///
+/// MCP 2026 constrains metadata keys to an optional dot-separated prefix
+/// followed by `/`, plus a name segment. Earlier protocol versions did not
+/// define this grammar, so callers choose when to enforce it.
+void validateMetaKeyName(String key, {String fieldName = '_meta'}) {
+  final slashIndex = key.indexOf('/');
+  final prefix = slashIndex == -1 ? null : key.substring(0, slashIndex);
+  final name = slashIndex == -1 ? key : key.substring(slashIndex + 1);
+
+  if (prefix != null) {
+    if (prefix.isEmpty) {
+      throw FormatException(
+        'Invalid $fieldName key "$key": prefix must not be empty',
+      );
+    }
+    final labels = prefix.split('.');
+    for (final label in labels) {
+      if (!_metaPrefixLabelPattern.hasMatch(label)) {
+        throw FormatException(
+          'Invalid $fieldName key "$key": invalid prefix label "$label"',
+        );
+      }
+    }
+  }
+
+  if (!_metaNamePattern.hasMatch(name)) {
+    throw FormatException(
+      'Invalid $fieldName key "$key": invalid name segment "$name"',
+    );
+  }
+}
+
 /// Validates request metadata that can affect protocol behavior.
 ///
 /// `_meta.progressToken` is an MCP wire token and must be a string or integer
-/// when present. Other `_meta` fields are preserved without interpretation.
-Map<String, dynamic>? validateRequestMeta(Map<String, dynamic>? meta) {
-  if (meta != null && meta.containsKey('progressToken')) {
+/// when present. [validateKeys] opts in to the MCP 2026 `_meta` key-name
+/// grammar without changing stable/legacy request parsing.
+Map<String, dynamic>? validateRequestMeta(
+  Map<String, dynamic>? meta, {
+  bool validateKeys = false,
+}) {
+  if (meta == null) {
+    return null;
+  }
+
+  if (validateKeys) {
+    for (final key in meta.keys) {
+      validateMetaKeyName(key);
+    }
+  }
+
+  if (meta.containsKey('progressToken')) {
     parseProgressToken(
       meta['progressToken'],
       fieldName: '_meta.progressToken',

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -234,12 +234,14 @@ class CompletedTaskHandler extends CancelTaskResultHandler {
 Map<String, dynamic> _clientMeta({
   String? protocolVersion,
   ClientCapabilities clientCapabilities = const ClientCapabilities(),
+  Map<String, dynamic>? meta,
   Object? logLevel,
 }) {
   return buildProtocolRequestMeta(
     protocolVersion: protocolVersion ?? draftProtocolVersion2026_07_28,
     clientInfo: const Implementation(name: 'client', version: '1.0.0'),
     clientCapabilities: clientCapabilities,
+    meta: meta,
     logLevel: logLevel,
   );
 }
@@ -265,11 +267,15 @@ void main() {
         protocolVersion: draftProtocolVersion2026_07_28,
         clientInfo: const Implementation(name: 'client', version: '1.0.0'),
         clientCapabilities: const ClientCapabilities(),
-        meta: const {'caller': 'value'},
+        meta: const {
+          'caller': 'value',
+          'com.example.trace/id': 'trace-1',
+        },
         logLevel: 'debug',
       );
 
       expect(meta['caller'], 'value');
+      expect(meta['com.example.trace/id'], 'trace-1');
       expect(
         meta[McpMetaKey.protocolVersion],
         draftProtocolVersion2026_07_28,
@@ -280,6 +286,35 @@ void main() {
       });
       expect(meta[McpMetaKey.clientCapabilities], <String, dynamic>{});
       expect(meta[McpMetaKey.logLevel], 'debug');
+    });
+
+    test('rejects invalid 2026 request metadata keys during construction', () {
+      for (final key in [
+        '/name',
+        '1bad/name',
+        'bad prefix/value',
+        'com.example./name',
+        'com.example/name_',
+      ]) {
+        expect(
+          () => buildProtocolRequestMeta(
+            protocolVersion: draftProtocolVersion2026_07_28,
+            clientInfo: const Implementation(
+              name: 'client',
+              version: '1.0.0',
+            ),
+            clientCapabilities: const ClientCapabilities(),
+            meta: {key: 'value'},
+          ),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains(key),
+            ),
+          ),
+        );
+      }
     });
 
     test('serializes server/discover request and result', () {
@@ -1712,6 +1747,29 @@ void main() {
           'message',
           contains(McpMetaKey.logLevel),
         ),
+      );
+      expect(
+        validateToolRequest({
+          ..._clientMeta(),
+          'bad prefix/value': 'value',
+        }),
+        isA<McpError>()
+            .having(
+              (error) => error.code,
+              'code',
+              ErrorCode.invalidRequest.value,
+            )
+            .having(
+              (error) => error.data,
+              'data',
+              contains('bad prefix/value'),
+            ),
+      );
+      expect(
+        validateToolRequest(
+          _clientMeta(meta: const {'com.example.trace/id': 'trace-1'}),
+        ),
+        isNull,
       );
     });
 


### PR DESCRIPTION
## Summary
- enforce MCP 2026 `_meta` key-name grammar in the stateless request metadata path
- validate caller metadata passed to the 2026 request metadata builder
- add regression coverage for invalid and valid custom metadata keys

## Tests
- dart format .
- dart analyze
- dart test test/mcp_2026_07_28_test.dart
- git diff --check
- dart test