### PR TITLE
Reject negative MCP cache TTLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@
   stateless requests use `-32602` with the missing `uri` in error data.
 - Enforced MCP 2026 `_meta` key-name grammar on stateless request metadata and
   the 2026 request metadata builder while preserving legacy metadata parsing.
+- Rejected negative cacheable-result `ttlMs` values during parsing instead of
+  clamping malformed wire values to zero.
 
 ## 2.2.0
 

--- a/lib/src/types/validation.dart
+++ b/lib/src/types/validation.dart
@@ -49,7 +49,10 @@ int? readOptionalTtlMs(Object? value, String field) {
   if (ttlMs == null) {
     return null;
   }
-  return ttlMs < 0 ? 0 : ttlMs;
+  if (ttlMs < 0) {
+    throw FormatException('$field must be greater than or equal to 0');
+  }
+  return ttlMs;
 }
 
 void validateTtlMs(int? value, String field) {

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -413,8 +413,8 @@ void main() {
 
       expect(const ListToolsResult(tools: []).toJson(), {'tools': []});
       expect(
-        ListToolsResult.fromJson(const {'tools': [], 'ttlMs': -1}).ttlMs,
-        0,
+        () => ListToolsResult.fromJson(const {'tools': [], 'ttlMs': -1}),
+        throwsFormatException,
       );
       expect(
         () => ListToolsResult.fromJson(


### PR DESCRIPTION
## Summary
- reject negative cacheable-result `ttlMs` values while parsing wire JSON
- keep constructor/serialization validation aligned with the same minimum-0 rule
- update 2026 RC regression coverage and changelog

## Tests
- dart format .
- dart analyze
- dart test test/mcp_2026_07_28_test.dart
- git diff --check
- dart test test/client/streamable_https_advanced_test.dart -p vm --plain-name "Streamable HTTPS Advanced Integration invalid resumed SSE message reports parser errors"
- dart test