### PR TITLE
Validate MCP input responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@
   the 2026 request metadata builder while preserving legacy metadata parsing.
 - Rejected negative cacheable-result `ttlMs` values during parsing instead of
   clamping malformed wire values to zero.
+- Validated MRTR `inputResponses` as `CreateMessageResult`, `ListRootsResult`,
+  or `ElicitResult` instead of accepting arbitrary result objects.
 
 ## 2.2.0
 

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -758,6 +758,12 @@ class InputResponse {
   }
 
   factory InputResponse.fromJson(Map<String, dynamic> json) {
+    if (!_isValidInputResponse(json)) {
+      throw const FormatException(
+        'InputResponse must be a CreateMessageResult, ListRootsResult, '
+        'or ElicitResult',
+      );
+    }
     return InputResponse.raw(Map<String, dynamic>.from(json));
   }
 
@@ -783,6 +789,28 @@ class InputResponse {
   }
 
   Map<String, dynamic> toJson() => Map<String, dynamic>.from(value);
+}
+
+bool _isValidInputResponse(Map<String, dynamic> json) {
+  return _canParseInputResponse(CreateMessageResult.fromJson, json) ||
+      _canParseInputResponse(ListRootsResult.fromJson, json) ||
+      _canParseInputResponse(ElicitResult.fromJson, json);
+}
+
+bool _canParseInputResponse(
+  BaseResultData Function(Map<String, dynamic> json) parser,
+  Map<String, dynamic> json,
+) {
+  try {
+    parser(json);
+    return true;
+  } on FormatException {
+    return false;
+  } on ArgumentError {
+    return false;
+  } on TypeError {
+    return false;
+  }
 }
 
 /// Result returned when a request needs extra client input before retry.

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -603,6 +603,17 @@ void main() {
         ),
         throwsFormatException,
       );
+      expect(
+        () => ReadResourceRequest.fromJson(
+          const {
+            'uri': 'file:///repo/README.md',
+            'inputResponses': {
+              'unknown': {'unexpected': true},
+            },
+          },
+        ),
+        throwsFormatException,
+      );
     });
 
     test('server acknowledges subscriptions/listen with subscription id',


### PR DESCRIPTION
## Summary
- validate MRTR `inputResponses` as one of CreateMessageResult, ListRootsResult, or ElicitResult when parsing wire JSON
- keep `InputResponse.raw` available for explicit low-level construction
- add malformed input response regression coverage and changelog entry

## Tests
- dart format .
- dart analyze
- dart test test/mcp_2026_07_28_test.dart
- git diff --check
- dart test