### PR TITLE
Reject non-integer elicitation content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@
   clamping malformed wire values to zero.
 - Validated MRTR `inputResponses` as `CreateMessageResult`, `ListRootsResult`,
   or `ElicitResult` instead of accepting arbitrary result objects.
+- Rejected non-integer numeric `ElicitResult.content` values to match the
+  stable and MCP 2026 schemas.
 
 ## 2.2.0
 

--- a/lib/src/types/elicitation.dart
+++ b/lib/src/types/elicitation.dart
@@ -616,7 +616,7 @@ void _validateElicitResultContent(
   }
   for (final entry in content.entries) {
     final value = entry.value;
-    if (value is String || value is num || value is bool) {
+    if (value is String || value is int || value is bool) {
       continue;
     }
     if (value is List && value.every((item) => item is String)) {
@@ -624,13 +624,13 @@ void _validateElicitResultContent(
     }
     if (formatException) {
       throw FormatException(
-        'ElicitResult.content.${entry.key} must be string, number, boolean, or string[]',
+        'ElicitResult.content.${entry.key} must be string, integer, boolean, or string[]',
       );
     }
     throw ArgumentError.value(
       value,
       'content.${entry.key}',
-      'ElicitResult content values must be string, number, boolean, or string[]',
+      'ElicitResult content values must be string, integer, boolean, or string[]',
     );
   }
 }

--- a/test/elicitation_test.dart
+++ b/test/elicitation_test.dart
@@ -1023,10 +1023,28 @@ void main() {
         throwsA(isA<FormatException>()),
       );
       expect(
+        () => ElicitResult.fromJson({
+          'action': 'accept',
+          'content': {
+            'ratio': 0.5,
+          },
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
         () => const ElicitResult(
           action: 'accept',
           content: {
             'values': [1, 2],
+          },
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => const ElicitResult(
+          action: 'accept',
+          content: {
+            'ratio': 0.5,
           },
         ).toJson(),
         throwsA(isA<ArgumentError>()),


### PR DESCRIPTION
## Summary
- tighten ElicitResult.content validation to reject non-integer numeric values
- cover both parse and serialization paths with regression tests
- document the stable and MCP 2026 schema alignment in the changelog

## Tests
- dart format .
- dart analyze
- dart test test/elicitation_test.dart test/mcp_2025_11_25_test.dart test/mcp_2026_07_28_test.dart
- git diff --check
- dart test