### PR TITLE
Require enum for elicitation enum names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@
   or `ElicitResult` instead of accepting arbitrary result objects.
 - Rejected non-integer numeric `ElicitResult.content` values to match the
   stable and MCP 2026 schemas.
+- Rejected form elicitation schemas that provide legacy `enumNames` without the
+  required string `enum`.
 
 ## 2.2.0
 

--- a/lib/src/types/elicitation.dart
+++ b/lib/src/types/elicitation.dart
@@ -533,6 +533,9 @@ void _validateStringOrSingleEnumSchema(
       (enumNames is! List || enumNames.any((value) => value is! String))) {
     throw FormatException('$context.enumNames must be a string array.');
   }
+  if (enumNames != null && enumValues == null) {
+    throw FormatException('$context.enumNames requires enum.');
+  }
   final format = json['format'];
   if (format != null &&
       !const {'email', 'uri', 'date', 'date-time'}.contains(format)) {

--- a/test/elicitation_test.dart
+++ b/test/elicitation_test.dart
@@ -949,6 +949,26 @@ void main() {
         () => ElicitRequestParams.fromJson(
           requestWithProperty('value', {
             'type': 'string',
+            'enumNames': ['Ok'],
+          }),
+        ),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ElicitRequestParams.form(
+          message: 'Bad enum names',
+          requestedSchema: JsonObject(
+            properties: {
+              'value': JsonString(enumNames: ['Ok']),
+            },
+          ),
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ElicitRequestParams.fromJson(
+          requestWithProperty('value', {
+            'type': 'string',
             'oneOf': [
               {'const': 'ok'},
             ],


### PR DESCRIPTION
## Summary
- reject form elicitation schemas that include legacy enumNames without enum
- cover both JSON parsing and typed serialization paths
- document the stable and MCP 2026 schema alignment in the changelog

## Tests
- dart format lib/src/types/elicitation.dart test/elicitation_test.dart
- dart test test/elicitation_test.dart test/mcp_2025_11_25_test.dart test/mcp_2026_07_28_test.dart
- dart analyze
- dart format .
- git diff --check
- dart test