### PR TITLE
Restrict elicitation content to accept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@
   stable and MCP 2026 schemas.
 - Rejected form elicitation schemas that provide legacy `enumNames` without the
   required string `enum`.
+- Rejected `ElicitResult.content` when the result action is `decline` or
+  `cancel`.
 
 ## 2.2.0
 

--- a/lib/src/types/elicitation.dart
+++ b/lib/src/types/elicitation.dart
@@ -267,9 +267,16 @@ class ElicitResult implements BaseResultData {
       throw FormatException('Invalid elicitation action: $action');
     }
 
+    final content = _parseElicitResultContent(json['content']);
+    _validateElicitResultContentForAction(
+      action,
+      content,
+      formatException: true,
+    );
+
     return ElicitResult(
       action: action,
-      content: _parseElicitResultContent(json['content']),
+      content: content,
       url: json['url'] as String?,
       elicitationId: json['elicitationId'] as String?,
       meta: (json['_meta'] as Map?)?.cast<String, dynamic>(),
@@ -278,9 +285,11 @@ class ElicitResult implements BaseResultData {
 
   @override
   Map<String, dynamic> toJson() {
+    final resultAction = action;
+    _validateElicitResultContentForAction(resultAction, content);
     _validateElicitResultContent(content);
     return {
-      'action': action,
+      'action': resultAction,
       if (content != null) 'content': content,
       if (meta != null) '_meta': meta,
     };
@@ -636,6 +645,26 @@ void _validateElicitResultContent(
       'ElicitResult content values must be string, integer, boolean, or string[]',
     );
   }
+}
+
+void _validateElicitResultContentForAction(
+  String action,
+  Map<String, dynamic>? content, {
+  bool formatException = false,
+}) {
+  if (content == null || action == 'accept') {
+    return;
+  }
+  if (formatException) {
+    throw const FormatException(
+      'ElicitResult.content is only allowed when action is accept.',
+    );
+  }
+  throw ArgumentError.value(
+    content,
+    'content',
+    'ElicitResult.content is only allowed when action is accept.',
+  );
 }
 
 void _validateUrlElicitations(

--- a/test/elicitation_test.dart
+++ b/test/elicitation_test.dart
@@ -1052,6 +1052,15 @@ void main() {
         throwsA(isA<FormatException>()),
       );
       expect(
+        () => ElicitResult.fromJson({
+          'action': 'decline',
+          'content': {
+            'name': 'Alice',
+          },
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
         () => const ElicitResult(
           action: 'accept',
           content: {
@@ -1065,6 +1074,15 @@ void main() {
           action: 'accept',
           content: {
             'ratio': 0.5,
+          },
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => const ElicitResult(
+          action: 'cancel',
+          content: {
+            'name': 'Alice',
           },
         ).toJson(),
         throwsA(isA<ArgumentError>()),


### PR DESCRIPTION
## Summary
- reject ElicitResult.content when action is decline or cancel
- cover both JSON parsing and typed serialization paths
- document the stable and MCP 2026 behavior alignment in the changelog

## Tests
- dart format lib/src/types/elicitation.dart test/elicitation_test.dart
- dart test test/elicitation_test.dart test/mcp_2025_11_25_test.dart test/mcp_2026_07_28_test.dart
- dart analyze
- dart format .
- git diff --check
- dart test