### PR TITLE
Validate MRTR input request capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@
 - Allowed MCP 2026 `prompts/get` and `resources/read` handlers to return
   `InputRequiredResult`, and rejected MRTR input-required results on unsupported
   request methods.
+- Rejected MCP 2026 MRTR `inputRequests` whose embedded client request type is
+  not declared in the caller's per-request client capabilities.
 - Returned version-appropriate resource-not-found errors from high-level
   `resources/read` handlers: stable 2025 uses legacy `-32002`, while MCP 2026
   stateless requests use `-32602` with the missing `uri` in error data.

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -257,6 +257,22 @@ class Server extends Protocol {
     );
   }
 
+  McpError _missingInputRequestClientCapabilityError(
+    String inputRequestKey,
+    String method,
+    Map<String, dynamic> requiredCapabilities,
+  ) {
+    return McpError(
+      ErrorCode.missingRequiredClientCapability.value,
+      'Missing required client capability for input request',
+      {
+        'inputRequest': inputRequestKey,
+        'method': method,
+        'requiredCapabilities': requiredCapabilities,
+      },
+    );
+  }
+
   bool _isStatelessRequest(JsonRpcRequest request) {
     final requestedProtocolVersion = request.meta?[McpMetaKey.protocolVersion];
     return requestedProtocolVersion is String &&
@@ -412,6 +428,80 @@ class Server extends Protocol {
     }
   }
 
+  McpError? _validateInputRequiredClientCapabilities(
+    InputRequiredResult result,
+    JsonRpcRequest request,
+  ) {
+    final inputRequests = result.inputRequests;
+    if (inputRequests == null || inputRequests.isEmpty) {
+      return null;
+    }
+
+    final parsed = _clientCapabilitiesForRequest(request);
+    if (parsed.error != null) {
+      return parsed.error;
+    }
+
+    for (final entry in inputRequests.entries) {
+      final requiredCapabilities = _missingCapabilitiesForInputRequest(
+        entry.value,
+        parsed.capabilities,
+      );
+      if (requiredCapabilities != null) {
+        return _missingInputRequestClientCapabilityError(
+          entry.key,
+          entry.value.method,
+          requiredCapabilities,
+        );
+      }
+    }
+
+    return null;
+  }
+
+  Map<String, dynamic>? _missingCapabilitiesForInputRequest(
+    InputRequest inputRequest,
+    ClientCapabilities? capabilities,
+  ) {
+    switch (inputRequest.method) {
+      case Method.elicitationCreate:
+        final elicitParams = inputRequest.elicitParams;
+        final requiredMode = elicitParams.isUrlMode ? 'url' : 'form';
+        final elicitation = capabilities?.elicitation;
+        final supportsMode = requiredMode == 'url'
+            ? elicitation?.url != null
+            : elicitation?.form != null;
+        if (!supportsMode) {
+          return {
+            'elicitation': {
+              requiredMode: <String, dynamic>{},
+            },
+          };
+        }
+        return null;
+      case Method.samplingCreateMessage:
+        final createParams = inputRequest.createMessageParams;
+        final sampling = capabilities?.sampling;
+        if (sampling == null) {
+          return {'sampling': <String, dynamic>{}};
+        }
+        if ((createParams.tools != null || createParams.toolChoice != null) &&
+            !sampling.tools) {
+          return {
+            'sampling': {'tools': <String, dynamic>{}},
+          };
+        }
+        return null;
+      case Method.rootsList:
+        if (capabilities?.roots == null) {
+          return {'roots': <String, dynamic>{}};
+        }
+        return null;
+      default:
+        return null;
+    }
+  }
+
   McpError? _validateRequestTaskSemantics(JsonRpcRequest request) {
     final removedMethodError = _validateDraftTaskMethods(request);
     if (removedMethodError != null) {
@@ -464,9 +554,21 @@ class Server extends Protocol {
     BaseResultData result,
     JsonRpcRequest request,
   ) {
-    return result is InputRequiredResult &&
-        _isStatelessRequest(request) &&
-        _inputRequiredResultMethods.contains(request.method);
+    if (result is! InputRequiredResult ||
+        !_isStatelessRequest(request) ||
+        !_inputRequiredResultMethods.contains(request.method)) {
+      return false;
+    }
+
+    final capabilityError = _validateInputRequiredClientCapabilities(
+      result,
+      request,
+    );
+    if (capabilityError != null) {
+      throw capabilityError;
+    }
+
+    return true;
   }
 
   void _validateUnsupportedInputRequiredResult(

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -1402,6 +1402,152 @@ void main() {
       expect(response.result['requestState'], 'retry-state');
     });
 
+    test('stateless input required requests require client capabilities',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(tools: ServerCapabilitiesTools()),
+        ),
+      );
+      server.setRequestHandler<JsonRpcCallToolRequest>(
+        Method.toolsCall,
+        (request, extra) async {
+          final inputRequest = switch (request.callParams.name) {
+            'needs-form' => InputRequest.elicit(
+                ElicitRequest.form(
+                  message: 'Enter name',
+                  requestedSchema: JsonSchema.object(
+                    properties: {'name': JsonSchema.string()},
+                    required: ['name'],
+                  ),
+                ),
+              ),
+            'needs-url' => InputRequest.elicit(
+                const ElicitRequest.url(
+                  message: 'Open browser',
+                  url: 'https://example.com/authorize',
+                  elicitationId: 'auth-1',
+                ),
+              ),
+            'needs-roots' => InputRequest.listRoots(),
+            'needs-sampling-tools' => InputRequest.createMessage(
+                const CreateMessageRequest(
+                  messages: [
+                    SamplingMessage(
+                      role: SamplingMessageRole.user,
+                      content: SamplingTextContent(text: 'Search'),
+                    ),
+                  ],
+                  maxTokens: 16,
+                  tools: [
+                    Tool(name: 'lookup', inputSchema: JsonObject()),
+                  ],
+                ),
+              ),
+            _ => throw StateError('Unknown tool ${request.callParams.name}'),
+          };
+
+          return InputRequiredResult(
+            inputRequests: {request.callParams.name: inputRequest},
+          );
+        },
+        (id, params, meta) => JsonRpcCallToolRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      final missingCapabilityCases = [
+        (
+          name: 'needs-form',
+          meta: _clientMeta(),
+          method: Method.elicitationCreate,
+          requiredCapabilities: {
+            'elicitation': {'form': <String, dynamic>{}},
+          },
+        ),
+        (
+          name: 'needs-url',
+          meta: _clientMeta(
+            clientCapabilities: const ClientCapabilities(
+              elicitation: ClientElicitation.formOnly(),
+            ),
+          ),
+          method: Method.elicitationCreate,
+          requiredCapabilities: {
+            'elicitation': {'url': <String, dynamic>{}},
+          },
+        ),
+        (
+          name: 'needs-roots',
+          meta: _clientMeta(),
+          method: Method.rootsList,
+          requiredCapabilities: {'roots': <String, dynamic>{}},
+        ),
+        (
+          name: 'needs-sampling-tools',
+          meta: _clientMeta(
+            clientCapabilities: const ClientCapabilities(
+              sampling: ClientCapabilitiesSampling(),
+            ),
+          ),
+          method: Method.samplingCreateMessage,
+          requiredCapabilities: {
+            'sampling': {'tools': <String, dynamic>{}},
+          },
+        ),
+      ];
+
+      for (final scenario in missingCapabilityCases) {
+        transport.sentMessages.clear();
+        transport.receive(
+          JsonRpcCallToolRequest(
+            id: scenario.name,
+            params: CallToolRequest(name: scenario.name).toJson(),
+            meta: scenario.meta,
+          ),
+        );
+        await _pump();
+
+        final response = transport.sentMessages.single as JsonRpcError;
+        expect(
+          response.error.code,
+          ErrorCode.missingRequiredClientCapability.value,
+        );
+        expect(response.error.data['inputRequest'], scenario.name);
+        expect(response.error.data['method'], scenario.method);
+        expect(
+          response.error.data['requiredCapabilities'],
+          scenario.requiredCapabilities,
+        );
+      }
+
+      transport.sentMessages.clear();
+      transport.receive(
+        JsonRpcCallToolRequest(
+          id: 'allowed-form',
+          params: const CallToolRequest(name: 'needs-form').toJson(),
+          meta: _clientMeta(
+            clientCapabilities: const ClientCapabilities(
+              elicitation: ClientElicitation.formOnly(),
+            ),
+          ),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      expect(response.result['resultType'], resultTypeInputRequired);
+      expect(
+        response.result['inputRequests']['needs-form']['method'],
+        Method.elicitationCreate,
+      );
+    });
+
     test('stateless prompts/get permits input required results', () async {
       final server = McpServer(
         const Implementation(name: 'server', version: '1.0.0'),


### PR DESCRIPTION
## Summary
- validate MCP 2026 MRTR inputRequests against per-request client capabilities
- reject missing elicitation form/url, roots, sampling, and sampling.tools support with missingRequiredClientCapability
- add coverage for denied and allowed stateless input-required tool responses

## Validation
- dart format .
- dart analyze
- dart test test/mcp_2026_07_28_test.dart --name "stateless input required requests require client capabilities"
- dart test test/mcp_2026_07_28_test.dart test/mcp_2025_11_25_test.dart test/server/server_test.dart test/server/output_validation_test.dart
- dart test
