### PR TITLE
Validate capability object entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@
   request methods.
 - Rejected MCP 2026 MRTR `inputRequests` whose embedded client request type is
   not declared in the caller's per-request client capabilities.
+- Rejected non-object `experimental` and `extensions` capability entries to
+  match the stable and MCP 2026 capability schemas.
 - Returned version-appropriate resource-not-found errors from high-level
   `resources/read` handlers: stable 2025 uses legacy `-32002`, while MCP 2026
   stateless requests use `-32602` with the missing `uri` in error data.

--- a/lib/src/types/initialization.dart
+++ b/lib/src/types/initialization.dart
@@ -17,6 +17,74 @@ Map<String, dynamic>? _asJsonObject(dynamic value) {
   throw FormatException('Expected object capability, got ${value.runtimeType}');
 }
 
+Map<String, dynamic>? _asStrictJsonObject(Object? value, String field) {
+  if (value == null) {
+    return null;
+  }
+  if (value is Map<String, dynamic>) {
+    return value;
+  }
+  if (value is Map) {
+    if (value.keys.any((key) => key is! String)) {
+      throw FormatException('$field must be an object with string keys');
+    }
+    return value.cast<String, dynamic>();
+  }
+  throw FormatException('$field must be an object');
+}
+
+Map<String, dynamic>? _asJsonObjectMap(Object? value, String field) {
+  final map = _asStrictJsonObject(value, field);
+  if (map == null) {
+    return null;
+  }
+
+  return map.map((key, item) {
+    final object = _asStrictJsonObject(item, '$field.$key');
+    if (object == null) {
+      throw FormatException('$field.$key must be an object');
+    }
+    return MapEntry(key, object);
+  });
+}
+
+Map<String, dynamic>? _serializeJsonObjectMap(
+  Map<String, dynamic>? value,
+  String field,
+) {
+  if (value == null) {
+    return null;
+  }
+
+  return value.map((key, item) {
+    final object = _asStrictJsonObject(item, '$field.$key');
+    if (object == null) {
+      throw ArgumentError.value(item, '$field.$key', 'must be an object');
+    }
+    return MapEntry(key, object);
+  });
+}
+
+Map<String, Map<String, dynamic>>? _asExtensionMap(
+  Object? value,
+  String field,
+) {
+  final map = _asJsonObjectMap(value, field);
+  return map?.map(
+    (key, value) => MapEntry(key, value.cast<String, dynamic>()),
+  );
+}
+
+Map<String, Map<String, dynamic>>? _serializeExtensionMap(
+  Map<String, Map<String, dynamic>>? value,
+  String field,
+) {
+  final map = _serializeJsonObjectMap(value, field);
+  return map?.map(
+    (key, value) => MapEntry(key, value.cast<String, dynamic>()),
+  );
+}
+
 bool? _capabilityDeclared(dynamic value) {
   if (value == null) {
     return null;
@@ -380,6 +448,9 @@ class ClientCapabilitiesTasks {
 /// Capabilities a client may support.
 class ClientCapabilities {
   /// Experimental, non-standard capabilities.
+  ///
+  /// Each capability value must be a JSON object. Use an empty object to
+  /// advertise support without settings.
   final Map<String, dynamic>? experimental;
 
   /// Present if the client supports sampling (`sampling/createMessage`).
@@ -414,10 +485,16 @@ class ClientCapabilities {
     final elicitationMap = _asJsonObject(json['elicitation']);
     final tasksMap = _asJsonObject(json['tasks']);
     final samplingMap = _asJsonObject(json['sampling']);
-    final extensionsMap = _asJsonObject(json['extensions']);
+    final extensionsMap = _asExtensionMap(
+      json['extensions'],
+      'ClientCapabilities.extensions',
+    );
 
     return ClientCapabilities(
-      experimental: json['experimental'] as Map<String, dynamic>?,
+      experimental: _asJsonObjectMap(
+        json['experimental'],
+        'ClientCapabilities.experimental',
+      ),
       sampling: samplingMap == null
           ? null
           : ClientCapabilitiesSampling.fromJson(samplingMap),
@@ -428,19 +505,25 @@ class ClientCapabilities {
           : ClientElicitation.fromJson(elicitationMap),
       tasks:
           tasksMap == null ? null : ClientCapabilitiesTasks.fromJson(tasksMap),
-      extensions: extensionsMap?.map(
-        (key, value) => MapEntry(key, Map<String, dynamic>.from(value as Map)),
-      ),
+      extensions: extensionsMap,
     );
   }
 
   Map<String, dynamic> toJson() => {
-        if (experimental != null) 'experimental': experimental,
+        if (experimental != null)
+          'experimental': _serializeJsonObjectMap(
+            experimental,
+            'ClientCapabilities.experimental',
+          ),
         if (sampling != null) 'sampling': sampling!.toJson(),
         if (roots != null) 'roots': roots!.toJson(),
         if (elicitation != null) 'elicitation': elicitation!.toJson(),
         if (tasks != null) 'tasks': tasks!.toJson(),
-        if (extensions != null) 'extensions': extensions,
+        if (extensions != null)
+          'extensions': _serializeExtensionMap(
+            extensions,
+            'ClientCapabilities.extensions',
+          ),
       };
 
   /// Whether the MCP Tasks extension is declared.
@@ -778,6 +861,9 @@ class ServerCapabilitiesTasks {
 /// Capabilities a server may support.
 class ServerCapabilities {
   /// Experimental, non-standard capabilities.
+  ///
+  /// Each capability value must be a JSON object. Use an empty object to
+  /// advertise support without settings.
   final Map<String, dynamic>? experimental;
 
   /// Present if the server supports sending log messages (`notifications/message`).
@@ -829,10 +915,16 @@ class ServerCapabilities {
     final tMap = _asJsonObject(json['tools']);
     final tasksMap = _asJsonObject(json['tasks']);
     final elicitationMap = _asJsonObject(json['elicitation']);
-    final extensionsMap = _asJsonObject(json['extensions']);
+    final extensionsMap = _asExtensionMap(
+      json['extensions'],
+      'ServerCapabilities.extensions',
+    );
 
     return ServerCapabilities(
-      experimental: json['experimental'] as Map<String, dynamic>?,
+      experimental: _asJsonObjectMap(
+        json['experimental'],
+        'ServerCapabilities.experimental',
+      ),
       logging: json['logging'] as Map<String, dynamic>?,
       prompts: pMap == null ? null : ServerCapabilitiesPrompts.fromJson(pMap),
       resources:
@@ -845,21 +937,27 @@ class ServerCapabilities {
       elicitation: elicitationMap == null
           ? null
           : ServerCapabilitiesElicitation.fromJson(elicitationMap),
-      extensions: extensionsMap?.map(
-        (key, value) => MapEntry(key, Map<String, dynamic>.from(value as Map)),
-      ),
+      extensions: extensionsMap,
     );
   }
 
   Map<String, dynamic> toJson() => {
-        if (experimental != null) 'experimental': experimental,
+        if (experimental != null)
+          'experimental': _serializeJsonObjectMap(
+            experimental,
+            'ServerCapabilities.experimental',
+          ),
         if (logging != null) 'logging': logging,
         if (prompts != null) 'prompts': prompts!.toJson(),
         if (resources != null) 'resources': resources!.toJson(),
         if (tools != null) 'tools': tools!.toJson(),
         if (completions != null) 'completions': completions!.toJson(),
         if (tasks != null) 'tasks': tasks!.toJson(),
-        if (extensions != null) 'extensions': extensions,
+        if (extensions != null)
+          'extensions': _serializeExtensionMap(
+            extensions,
+            'ServerCapabilities.extensions',
+          ),
       };
 
   /// Whether the MCP Tasks extension is declared.

--- a/test/client/client_test.dart
+++ b/test/client/client_test.dart
@@ -56,14 +56,14 @@ void main() {
 
     test('registerCapabilities merges capabilities', () {
       final initialCapabilities =
-          const ClientCapabilities(experimental: {'feature1': true});
+          const ClientCapabilities(experimental: {'feature1': {}});
       client = Client(
         clientInfo,
         options: McpClientOptions(capabilities: initialCapabilities),
       );
 
       final additionalCapabilities = const ClientCapabilities(
-        experimental: {'feature2': true},
+        experimental: {'feature2': {}},
         roots: ClientCapabilitiesRoots(listChanged: true),
       );
 

--- a/test/integration/completions_capability_test.dart
+++ b/test/integration/completions_capability_test.dart
@@ -92,7 +92,7 @@ void main() {
     test('Completions capability survives serialization round-trip', () {
       final originalCaps = const ServerCapabilities(
         completions: ServerCapabilitiesCompletions(listChanged: true),
-        experimental: {'test': true},
+        experimental: {'test': {}},
       );
 
       final json = originalCaps.toJson();
@@ -100,7 +100,7 @@ void main() {
 
       expect(deserializedCaps.completions, isNotNull);
       expect(json['completions'], isEmpty);
-      expect(deserializedCaps.experimental?['test'], equals(true));
+      expect(deserializedCaps.experimental?['test'], isEmpty);
     });
 
     test('legacy completions listChanged payload still parses', () {

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -1898,6 +1898,23 @@ void main() {
         ),
       );
       expect(
+        validateToolRequest({
+          McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
+          McpMetaKey.clientInfo: {
+            'name': 'client',
+            'version': '1.0.0',
+          },
+          McpMetaKey.clientCapabilities: {
+            'experimental': {'feature': true},
+          },
+        }),
+        isA<McpError>().having(
+          (error) => error.message,
+          'message',
+          contains('Invalid stateless request metadata.'),
+        ),
+      );
+      expect(
         validateToolRequest(_clientMeta(logLevel: 'verbose')),
         isA<McpError>().having(
           (error) => error.message,

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -510,7 +510,7 @@ void main() {
 
     test('handles null roots and elicitation maps', () {
       final json = {
-        'experimental': {'feature': true},
+        'experimental': {'feature': <String, dynamic>{}},
         'sampling': {'enabled': true},
         'roots': null,
         'elicitation': null,
@@ -542,7 +542,7 @@ void main() {
 
     test('handles null capability maps', () {
       final json = {
-        'experimental': {'feature': true},
+        'experimental': {'feature': <String, dynamic>{}},
         'logging': {'level': 'info'},
         'prompts': null,
         'resources': null,

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -9,7 +9,9 @@ void main() {
         initParams: const InitializeRequestParams(
           protocolVersion: latestProtocolVersion,
           capabilities: ClientCapabilities(
-            experimental: {'featureX': true},
+            experimental: {
+              'featureX': <String, dynamic>{},
+            },
             sampling: ClientCapabilitiesSampling(),
           ),
           clientInfo: Implementation(name: 'test-client', version: '1.0.0'),
@@ -165,7 +167,9 @@ void main() {
 
     test('ServerCapabilities includes completions', () {
       final capabilities = const ServerCapabilities(
-        experimental: {'featureY': true},
+        experimental: {
+          'featureY': <String, dynamic>{},
+        },
         logging: {'enabled': true},
         prompts: ServerCapabilitiesPrompts(listChanged: true),
         resources:
@@ -175,7 +179,7 @@ void main() {
       );
 
       final json = capabilities.toJson();
-      expect(json['experimental']['featureY'], equals(true));
+      expect(json['experimental']['featureY'], isEmpty);
       expect(json['logging']['enabled'], equals(true));
       expect(json['prompts']['listChanged'], equals(true));
       expect(json['resources']['subscribe'], equals(true));
@@ -190,7 +194,9 @@ void main() {
 
     test('ServerCapabilities serialization and deserialization', () {
       final capabilities = const ServerCapabilities(
-        experimental: {'featureY': true},
+        experimental: {
+          'featureY': <String, dynamic>{},
+        },
         logging: {'enabled': true},
         prompts: ServerCapabilitiesPrompts(listChanged: true),
         resources:
@@ -199,7 +205,7 @@ void main() {
       );
 
       final json = capabilities.toJson();
-      expect(json['experimental']['featureY'], equals(true));
+      expect(json['experimental']['featureY'], isEmpty);
       expect(json['logging']['enabled'], equals(true));
       expect(json['prompts']['listChanged'], equals(true));
       expect(json['resources']['subscribe'], equals(true));
@@ -212,18 +218,70 @@ void main() {
 
     test('ClientCapabilities serialization and deserialization', () {
       final capabilities = const ClientCapabilities(
-        experimental: {'featureZ': true},
+        experimental: {
+          'featureZ': <String, dynamic>{},
+        },
         sampling: ClientCapabilitiesSampling(),
         roots: ClientCapabilitiesRoots(listChanged: true),
       );
 
       final json = capabilities.toJson();
-      expect(json['experimental']['featureZ'], equals(true));
+      expect(json['experimental']['featureZ'], isEmpty);
       expect(json['sampling'], isNotNull);
       expect(json['roots']['listChanged'], equals(true));
 
       final deserialized = ClientCapabilities.fromJson(json);
       expect(deserialized.roots?.listChanged, equals(true));
+    });
+
+    test('experimental capability values must be objects', () {
+      expect(
+        () => ClientCapabilities.fromJson(
+          const {
+            'experimental': {'feature': true},
+          },
+        ),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ServerCapabilities.fromJson(
+          const {
+            'experimental': {'feature': true},
+          },
+        ),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ClientCapabilities(
+          experimental: {'feature': true},
+        ).toJson(),
+        throwsA(anyOf(isA<FormatException>(), isA<ArgumentError>())),
+      );
+      expect(
+        () => const ServerCapabilities(
+          experimental: {'feature': true},
+        ).toJson(),
+        throwsA(anyOf(isA<FormatException>(), isA<ArgumentError>())),
+      );
+    });
+
+    test('extension capability values must be objects', () {
+      expect(
+        () => ClientCapabilities.fromJson(
+          const {
+            'extensions': {'io.example/feature': true},
+          },
+        ),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ServerCapabilities.fromJson(
+          const {
+            'extensions': {'io.example/feature': true},
+          },
+        ),
+        throwsA(isA<FormatException>()),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- reject non-object experimental capability values for client and server capabilities
- reject non-object extension capability values during wire parsing
- update existing capability tests to use empty objects for feature markers and cover malformed stateless metadata

## Spec evidence
- MCP 2025-11-25 and MCP 2026-07-28 RC schemas define `capabilities.experimental` entries as JSON objects
- MCP 2026-07-28 RC schemas define `capabilities.extensions` entries as JSON objects

## Validation
- dart format .
- dart analyze
- dart test test/types_test.dart test/types_edge_cases_test.dart test/client/client_test.dart test/integration/completions_capability_test.dart test/mcp_2026_07_28_test.dart test/mcp_2025_11_25_test.dart test/server/server_validation_test.dart test/server/server_test.dart
- dart test
- dart run mcp_dart_cli:mcp_dart conformance --suite all --json (from packages/mcp_dart_cli)
