### PR TITLE
Validate URL elicitation URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@
   required string `enum`.
 - Rejected `ElicitResult.content` when the result action is `decline` or
   `cancel`.
+- Rejected URL elicitation values that are not absolute URIs to match the stable
+  and MCP 2026 `format: uri` schemas.
 
 ## 2.2.0
 

--- a/lib/src/types/elicitation.dart
+++ b/lib/src/types/elicitation.dart
@@ -114,6 +114,7 @@ class ElicitRequest {
       if (url is! String) {
         throw const FormatException('URL elicitation requires url.');
       }
+      _validateUrlElicitationUri(url, formatException: true);
       if (elicitationId is! String) {
         throw const FormatException('URL elicitation requires elicitationId.');
       }
@@ -159,6 +160,7 @@ class ElicitRequest {
       if (url == null) {
         throw ArgumentError('URL elicitation requires url.');
       }
+      _validateUrlElicitationUri(url!);
       if (elicitationId == null) {
         throw ArgumentError('URL elicitation requires elicitationId.');
       }
@@ -685,4 +687,24 @@ void _validateUrlElicitations(
       );
     }
   }
+}
+
+void _validateUrlElicitationUri(
+  String url, {
+  bool formatException = false,
+}) {
+  final uri = Uri.tryParse(url);
+  if (uri != null && uri.hasScheme) {
+    return;
+  }
+  if (formatException) {
+    throw const FormatException(
+      'URL elicitation url must be an absolute URI.',
+    );
+  }
+  throw ArgumentError.value(
+    url,
+    'url',
+    'URL elicitation url must be an absolute URI.',
+  );
 }

--- a/test/elicitation_test.dart
+++ b/test/elicitation_test.dart
@@ -746,6 +746,23 @@ void main() {
         () => ElicitRequestParams.fromJson({
           'mode': 'url',
           'message': 'Please authenticate',
+          'url': 'relative/callback',
+          'elicitationId': 'oauth-123',
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ElicitRequestParams.url(
+          message: 'Please authenticate',
+          url: 'relative/callback',
+          elicitationId: 'oauth-123',
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => ElicitRequestParams.fromJson({
+          'mode': 'url',
+          'message': 'Please authenticate',
           'url': 'https://oauth.example.com/authorize',
           'elicitationId': 'oauth-123',
           'requestedSchema': {

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -253,6 +253,26 @@ void main() {
       expect(deserialized.elicitationId, 'ui-123');
     });
 
+    test('Elicitation URL must be absolute URI', () {
+      expect(
+        () => ElicitRequestParams.fromJson({
+          'mode': 'url',
+          'message': 'test',
+          'url': '/relative/ui',
+          'elicitationId': 'ui-123',
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ElicitRequestParams.url(
+          message: 'test',
+          url: '/relative/ui',
+          elicitationId: 'ui-123',
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
     test('JsonEnum SEP-1330', () {
       final schema = const JsonEnum(
         [

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -317,6 +317,26 @@ void main() {
       }
     });
 
+    test('rejects URL elicitation relative URI values', () {
+      expect(
+        () => ElicitRequestParams.fromJson({
+          'mode': 'url',
+          'message': 'Open browser',
+          'url': 'authorize/callback',
+          'elicitationId': 'auth-1',
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ElicitRequestParams.url(
+          message: 'Open browser',
+          url: 'authorize/callback',
+          elicitationId: 'auth-1',
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
     test('serializes server/discover request and result', () {
       final request = JsonRpcServerDiscoverRequest(
         id: 'discover-1',


### PR DESCRIPTION
## Summary
- enforce absolute URI validation for URL-mode elicitation payloads on parse and serialization
- add stable 2025-11-25, 2026-07-28 RC, and general elicitation regression coverage
- document the schema-alignment change in the changelog

## Validation
- dart format .
- dart analyze
- dart test test/elicitation_test.dart
- dart test test/mcp_2025_11_25_test.dart
- dart test test/mcp_2026_07_28_test.dart
- dart test
- dart run mcp_dart_cli:mcp_dart conformance --suite all --json