### PR TITLE
Reject non-finite JSON numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@
   `cancel`.
 - Rejected URL elicitation values that are not absolute URIs to match the stable
   and MCP 2026 `format: uri` schemas.
+- Rejected non-finite numeric values for progress, annotation priority, model
+  priority, and sampling temperature fields so SDK-built payloads remain valid
+  JSON numbers.
 
 ## 2.2.0
 

--- a/lib/src/types/misc.dart
+++ b/lib/src/types/misc.dart
@@ -1,4 +1,5 @@
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// A response that indicates success but carries no specific data.
 class EmptyResult implements BaseResultData {
@@ -91,17 +92,21 @@ class Progress {
 
   factory Progress.fromJson(Map<String, dynamic> json) {
     return Progress(
-      progress: json['progress'] as num,
-      total: json['total'] as num?,
+      progress: readFiniteNumber(json['progress'], 'Progress.progress'),
+      total: readOptionalFiniteNumber(json['total'], 'Progress.total'),
       message: json['message'] as String?,
     );
   }
 
-  Map<String, dynamic> toJson() => {
-        'progress': progress,
-        if (total != null) 'total': total,
-        if (message != null) 'message': message,
-      };
+  Map<String, dynamic> toJson() {
+    validateFiniteNumber(progress, 'Progress.progress');
+    validateOptionalFiniteNumber(total, 'Progress.total');
+    return {
+      'progress': progress,
+      if (total != null) 'total': total,
+      if (message != null) 'message': message,
+    };
+  }
 }
 
 /// Parameters for the `notifications/progress` notification.

--- a/lib/src/types/sampling.dart
+++ b/lib/src/types/sampling.dart
@@ -625,7 +625,10 @@ class CreateMessageRequest {
       systemPrompt: json['systemPrompt'] as String?,
       includeContext:
           ctxStr == null ? null : IncludeContext.values.byName(ctxStr),
-      temperature: (json['temperature'] as num?)?.toDouble(),
+      temperature: readOptionalFiniteDouble(
+        json['temperature'],
+        'CreateMessageRequest.temperature',
+      ),
       maxTokens: json['maxTokens'] as int,
       stopSequences: (json['stopSequences'] as List<dynamic>?)?.cast<String>(),
       metadata: _asJsonObjectOrNull(json['metadata']),
@@ -642,20 +645,26 @@ class CreateMessageRequest {
   }
 
   /// Converts to JSON.
-  Map<String, dynamic> toJson() => {
-        'messages': messages.map((m) => m.toJson()).toList(),
-        if (task != null) 'task': task!.toJson(),
-        if (systemPrompt != null) 'systemPrompt': systemPrompt,
-        if (includeContext != null) 'includeContext': includeContext!.name,
-        if (temperature != null) 'temperature': temperature,
-        'maxTokens': maxTokens,
-        if (stopSequences != null) 'stopSequences': stopSequences,
-        if (metadata != null) 'metadata': metadata,
-        if (modelPreferences != null)
-          'modelPreferences': modelPreferences!.toJson(),
-        if (tools != null) 'tools': tools!.map((t) => t.toJson()).toList(),
-        if (toolChoiceConfig != null) 'toolChoice': toolChoiceConfig!.toJson(),
-      };
+  Map<String, dynamic> toJson() {
+    validateOptionalFiniteNumber(
+      temperature,
+      'CreateMessageRequest.temperature',
+    );
+    return {
+      'messages': messages.map((m) => m.toJson()).toList(),
+      if (task != null) 'task': task!.toJson(),
+      if (systemPrompt != null) 'systemPrompt': systemPrompt,
+      if (includeContext != null) 'includeContext': includeContext!.name,
+      if (temperature != null) 'temperature': temperature,
+      'maxTokens': maxTokens,
+      if (stopSequences != null) 'stopSequences': stopSequences,
+      if (metadata != null) 'metadata': metadata,
+      if (modelPreferences != null)
+        'modelPreferences': modelPreferences!.toJson(),
+      if (tools != null) 'tools': tools!.map((t) => t.toJson()).toList(),
+      if (toolChoiceConfig != null) 'toolChoice': toolChoiceConfig!.toJson(),
+    };
+  }
 }
 
 /// Request sent from server to client to sample an LLM.

--- a/lib/src/types/validation.dart
+++ b/lib/src/types/validation.dart
@@ -1,11 +1,9 @@
 double? readUnitDouble(Object? value, String field) {
-  if (value == null) {
+  final number = readOptionalFiniteNumber(value, field);
+  final result = number?.toDouble();
+  if (result == null) {
     return null;
   }
-  if (value is! num) {
-    throw FormatException('$field must be a number between 0 and 1');
-  }
-  final result = value.toDouble();
   if (result < 0 || result > 1) {
     throw FormatException('$field must be between 0 and 1');
   }
@@ -16,9 +14,40 @@ void validateUnitDouble(double? value, String field) {
   if (value == null) {
     return;
   }
-  if (value < 0 || value > 1) {
+  if (!value.isFinite || value < 0 || value > 1) {
     throw ArgumentError.value(value, field, 'must be between 0 and 1');
   }
+}
+
+num readFiniteNumber(Object? value, String field) {
+  if (value is num && value.isFinite) {
+    return value;
+  }
+  throw FormatException('$field must be a finite JSON number');
+}
+
+num? readOptionalFiniteNumber(Object? value, String field) {
+  if (value == null) {
+    return null;
+  }
+  return readFiniteNumber(value, field);
+}
+
+double? readOptionalFiniteDouble(Object? value, String field) {
+  return readOptionalFiniteNumber(value, field)?.toDouble();
+}
+
+void validateFiniteNumber(num value, String field) {
+  if (!value.isFinite) {
+    throw ArgumentError.value(value, field, 'must be a finite JSON number');
+  }
+}
+
+void validateOptionalFiniteNumber(num? value, String field) {
+  if (value == null) {
+    return;
+  }
+  validateFiniteNumber(value, field);
 }
 
 int? readOptionalInteger(Object? value, String field) {

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -1264,6 +1264,14 @@ void main() {
           throwsA(isA<FormatException>()),
         );
         expect(
+          () => Annotations(priority: double.nan).toJson(),
+          throwsA(anyOf(isA<AssertionError>(), isA<ArgumentError>())),
+        );
+        expect(
+          () => Annotations.fromJson({'priority': double.infinity}),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
           () => CompletionResultData(
             values: List.generate(101, (index) => '$index'),
           ).toJson(),

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -337,6 +337,36 @@ void main() {
       );
     });
 
+    test('rejects non-finite JSON numbers', () {
+      expect(
+        () => ProgressNotification.fromJson({
+          'progressToken': 'progress-1',
+          'progress': double.nan,
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ProgressNotification(
+          progressToken: 'progress-1',
+          progress: double.infinity,
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => CreateMessageRequest.fromJson({
+          'messages': [
+            {
+              'role': 'user',
+              'content': {'type': 'text', 'text': 'Hello'},
+            },
+          ],
+          'maxTokens': 16,
+          'temperature': double.nan,
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
     test('serializes server/discover request and result', () {
       final request = JsonRpcServerDiscoverRequest(
         id: 'discover-1',

--- a/test/types/sampling_test.dart
+++ b/test/types/sampling_test.dart
@@ -76,6 +76,19 @@ void main() {
       expect(prefs.hints, isNull);
       expect(prefs.costPriority, isNull);
     });
+
+    test('rejects non-finite priorities', () {
+      for (final value in [double.nan, double.infinity]) {
+        expect(
+          () => ModelPreferences.fromJson({'costPriority': value}),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => ModelPreferences(costPriority: value).toJson(),
+          throwsA(anyOf(isA<AssertionError>(), isA<ArgumentError>())),
+        );
+      }
+    });
   });
 
   group('SamplingContent', () {
@@ -440,6 +453,38 @@ void main() {
       expect(params.messages, hasLength(1));
       expect(params.maxTokens, equals(200));
       expect(params.includeContext, equals(IncludeContext.allServers));
+    });
+
+    test('rejects non-finite temperature values', () {
+      final messages = [
+        {
+          'role': 'user',
+          'content': {'type': 'text', 'text': 'Hello'},
+        },
+      ];
+      for (final value in [double.nan, double.infinity]) {
+        expect(
+          () => CreateMessageRequestParams.fromJson({
+            'messages': messages,
+            'maxTokens': 100,
+            'temperature': value,
+          }),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => CreateMessageRequestParams(
+            messages: const [
+              SamplingMessage(
+                role: SamplingMessageRole.user,
+                content: SamplingTextContent(text: 'Hello'),
+              ),
+            ],
+            maxTokens: 100,
+            temperature: value,
+          ).toJson(),
+          throwsA(isA<ArgumentError>()),
+        );
+      }
     });
   });
 

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -212,6 +212,27 @@ void main() {
       expect(json.containsKey('total'), isFalse);
     });
 
+    test('rejects non-finite progress numbers', () {
+      for (final value in [double.nan, double.infinity]) {
+        expect(
+          () => Progress.fromJson({'progress': value}),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => Progress(progress: value).toJson(),
+          throwsA(isA<ArgumentError>()),
+        );
+        expect(
+          () => Progress.fromJson({'progress': 1, 'total': value}),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => Progress(progress: 1, total: value).toJson(),
+          throwsA(isA<ArgumentError>()),
+        );
+      }
+    });
+
     test('rejects malformed progressToken wire values', () {
       for (final progressToken in [
         null,


### PR DESCRIPTION
## Summary
- add shared finite JSON-number validation helpers
- reject NaN and infinity for progress values, annotation/model priorities, and sampling temperature on parse/serialization
- cover stable 2025-11-25 and 2026-07-28 RC numeric schema regressions

## Validation
- dart format .
- dart test test/types_edge_cases_test.dart
- dart test test/types/sampling_test.dart
- dart test test/mcp_2025_11_25_test.dart
- dart test test/mcp_2026_07_28_test.dart
- dart analyze
- dart test
- dart run mcp_dart_cli:mcp_dart conformance --suite all --json