### PR TITLE
Validate shared JSON object helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@
   `tool_use.input`, sampling metadata, annotations, and `_meta` maps.
 - Rejected non-JSON values in common content/resource metadata fields and
   `resource_link.annotations`.
+- Reused shared JSON-object validation for MRTR, task extension, subscription,
+  and tool object fields.
 
 ## 2.2.0
 

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -276,15 +276,7 @@ Map<String, dynamic>? _parseRequestMeta(Object? value) {
   if (value == null) {
     return null;
   }
-  if (value is! Map) {
-    throw FormatException(
-      'Invalid _meta: expected object, got ${value.runtimeType}',
-    );
-  }
-  if (value.keys.any((key) => key is! String)) {
-    throw const FormatException('Invalid _meta: expected string keys');
-  }
-  return validateRequestMeta(Map<String, dynamic>.from(value));
+  return validateRequestMeta(readJsonObject(value, '_meta'));
 }
 
 /// Extracts request metadata from either top-level or params-nested `_meta`.
@@ -741,7 +733,8 @@ class InputRequest {
 
   Map<String, dynamic> toJson() => {
         'method': method,
-        if (params != null) 'params': params,
+        if (params != null)
+          'params': readJsonObject(params, 'InputRequest.params'),
       };
 }
 
@@ -788,7 +781,7 @@ class InputResponse {
     );
   }
 
-  Map<String, dynamic> toJson() => Map<String, dynamic>.from(value);
+  Map<String, dynamic> toJson() => readJsonObject(value, 'InputResponse');
 }
 
 bool _isValidInputResponse(Map<String, dynamic> json) {
@@ -875,22 +868,14 @@ class InputRequiredResult implements BaseResultData {
       if (inputRequests != null)
         'inputRequests': InputRequest.mapToJson(inputRequests!),
       if (requestState != null) 'requestState': requestState,
-      if (meta != null) '_meta': meta,
+      if (meta != null)
+        '_meta': readJsonObject(meta, 'InputRequiredResult._meta'),
     };
   }
 }
 
 Map<String, dynamic> _readRequiredJsonObject(Object? value, String field) {
-  if (value is Map<String, dynamic>) {
-    return value;
-  }
-  if (value is Map) {
-    if (value.keys.any((key) => key is! String)) {
-      throw FormatException('$field must be an object with string keys');
-    }
-    return value.cast<String, dynamic>();
-  }
-  throw FormatException('$field must be an object');
+  return readJsonObject(value, field);
 }
 
 Map<String, dynamic>? _readOptionalJsonObject(Object? value, String field) {

--- a/lib/src/types/subscriptions.dart
+++ b/lib/src/types/subscriptions.dart
@@ -1,5 +1,6 @@
 import 'initialization.dart';
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// Notification filter requested by `subscriptions/listen`.
 class SubscriptionFilter {
@@ -292,14 +293,5 @@ Map<String, dynamic>? _readOptionalJsonObject(Object? value, String field) {
   if (value == null) {
     return null;
   }
-  if (value is Map<String, dynamic>) {
-    return value;
-  }
-  if (value is Map) {
-    if (value.keys.any((key) => key is! String)) {
-      throw FormatException('$field must be an object with string keys');
-    }
-    return value.cast<String, dynamic>();
-  }
-  throw FormatException('$field must be an object');
+  return readJsonObject(value, field);
 }

--- a/lib/src/types/tasks.dart
+++ b/lib/src/types/tasks.dart
@@ -1,5 +1,6 @@
 import '../types.dart';
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// The current state of a task execution.
 enum TaskStatus {
@@ -609,7 +610,8 @@ class TaskExtensionTask {
         if (pollIntervalMs != null) 'pollIntervalMs': pollIntervalMs,
         if (inputRequests != null)
           'inputRequests': InputRequest.mapToJson(inputRequests!),
-        if (result != null) 'result': result,
+        if (result != null)
+          'result': readJsonObject(result, 'TaskExtensionTask.result'),
         if (error != null) 'error': error!.toJson(),
       };
 }
@@ -643,7 +645,8 @@ class CreateTaskExtensionResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         ...task.toJson(resultType: resultTypeTask),
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'CreateTaskExtensionResult._meta'),
       };
 }
 
@@ -676,7 +679,8 @@ class GetTaskExtensionResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         ...task.toJson(resultType: resultTypeComplete),
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'GetTaskExtensionResult._meta'),
       };
 }
 
@@ -707,7 +711,11 @@ class TaskExtensionAcknowledgementResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         'resultType': resultTypeComplete,
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(
+            meta,
+            'TaskExtensionAcknowledgementResult._meta',
+          ),
       };
 }
 
@@ -838,7 +846,10 @@ class JsonRpcTaskStatusNotification extends JsonRpcNotification {
         "Missing params for task status notification",
       );
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = _readOptionalJsonObject(
+      paramsMap['_meta'],
+      'JsonRpcTaskStatusNotification._meta',
+    );
     return JsonRpcTaskStatusNotification(
       statusParams: TaskStatusNotification.fromJson(paramsMap),
       meta: meta,
@@ -870,16 +881,7 @@ class JsonRpcTaskNotification extends JsonRpcNotification {
 }
 
 Map<String, dynamic> _readRequiredJsonObject(Object? value, String field) {
-  if (value is Map<String, dynamic>) {
-    return value;
-  }
-  if (value is Map) {
-    if (value.keys.any((key) => key is! String)) {
-      throw FormatException('$field must be an object with string keys');
-    }
-    return value.cast<String, dynamic>();
-  }
-  throw FormatException('$field must be an object');
+  return readJsonObject(value, field);
 }
 
 Map<String, dynamic>? _readOptionalJsonObject(Object? value, String field) {

--- a/lib/src/types/tools.dart
+++ b/lib/src/types/tools.dart
@@ -212,7 +212,7 @@ class Tool {
               json['annotations'] as Map<String, dynamic>,
             )
           : null,
-      meta: json['_meta'] as Map<String, dynamic>?,
+      meta: readOptionalJsonObject(json['_meta'], 'Tool._meta'),
       execution: json['execution'] != null
           ? ToolExecution.fromJson(json['execution'] as Map<String, dynamic>)
           : null,
@@ -235,7 +235,7 @@ class Tool {
       'inputSchema': inputSchema.toJson(),
       if (outputSchema != null) 'outputSchema': outputSchema!.toJson(),
       if (annotations != null) 'annotations': annotations!.toJson(),
-      if (meta != null) '_meta': meta,
+      if (meta != null) '_meta': readJsonObject(meta, 'Tool._meta'),
       if (execution != null) 'execution': execution!.toJson(),
       if (icons != null) 'icons': icons!.map((icon) => icon.toJson()).toList(),
     };
@@ -353,7 +353,7 @@ class CallToolRequest {
       name: json['name'] as String,
       arguments: arguments == null
           ? const {}
-          : (arguments as Map).cast<String, dynamic>(),
+          : _readJsonObject(arguments, 'CallToolRequest.arguments'),
       inputResponses: InputResponse.mapFromJson(
         json['inputResponses'],
         'CallToolRequest.inputResponses',
@@ -367,7 +367,7 @@ class CallToolRequest {
 
   Map<String, dynamic> toJson() => {
         'name': name,
-        'arguments': arguments,
+        'arguments': readJsonObject(arguments, 'CallToolRequest.arguments'),
         if (inputResponses != null)
           'inputResponses': InputResponse.mapToJson(inputResponses!),
         if (requestState != null) 'requestState': requestState,
@@ -448,8 +448,9 @@ class CallToolResult implements BaseResultData {
             )
           : null,
       hasStructuredContent: json.containsKey('structuredContent'),
-      meta: json['_meta'] as Map<String, dynamic>?,
-      extra: extra.isEmpty ? null : extra,
+      meta: readOptionalJsonObject(json['_meta'], 'CallToolResult._meta'),
+      extra:
+          extra.isEmpty ? null : readJsonObject(extra, 'CallToolResult.extra'),
     );
   }
 
@@ -462,8 +463,8 @@ class CallToolResult implements BaseResultData {
             structuredContent,
             'CallToolResult.structuredContent',
           ),
-        if (meta != null) '_meta': meta,
-        ...?extra,
+        if (meta != null) '_meta': readJsonObject(meta, 'CallToolResult._meta'),
+        if (extra != null) ...readJsonObject(extra, 'CallToolResult.extra'),
       };
 }
 
@@ -511,14 +512,5 @@ Map<String, dynamic>? _readOptionalJsonObject(Object? value, String field) {
 }
 
 Map<String, dynamic> _readJsonObject(Object? value, String field) {
-  if (value is Map<String, dynamic>) {
-    return value;
-  }
-  if (value is Map) {
-    if (value.keys.any((key) => key is! String)) {
-      throw FormatException('$field must be an object with string keys');
-    }
-    return value.cast<String, dynamic>();
-  }
-  throw FormatException('$field must be an object');
+  return readJsonObject(value, field);
 }

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -588,6 +588,31 @@ void main() {
       );
     });
 
+    test('Tool JSON object fields reject non-JSON Dart maps', () {
+      expect(
+        () => Tool.fromJson({
+          'name': 'search',
+          'inputSchema': {'type': 'object'},
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => CallToolRequest.fromJson({
+          'name': 'search',
+          'arguments': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => CallToolResult.fromJson({
+          'content': <Map<String, dynamic>>[],
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
     group('Tasks API Types', () {
       test('GetTaskRequestParams serialization', () {
         final params = const GetTaskRequestParams(taskId: 'task-123');
@@ -1255,7 +1280,7 @@ void main() {
             isA<FormatException>().having(
               (error) => error.message,
               'message',
-              contains('Tool.inputSchema must be an object'),
+              contains('Tool.inputSchema must be a JSON object'),
             ),
           ),
         );
@@ -1269,7 +1294,7 @@ void main() {
             isA<FormatException>().having(
               (error) => error.message,
               'message',
-              contains('Tool.outputSchema must be an object'),
+              contains('Tool.outputSchema must be a JSON object'),
             ),
           ),
         );

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -698,6 +698,21 @@ void main() {
         throwsFormatException,
       );
       expect(
+        () => InputRequiredResult.fromJson({
+          'resultType': resultTypeInputRequired,
+          'requestState': 'state',
+          '_meta': {'bad': Object()},
+        }),
+        throwsFormatException,
+      );
+      expect(
+        () => const InputRequiredResult(
+          requestState: 'state',
+          meta: {'bad': Object()},
+        ).toJson(),
+        throwsFormatException,
+      );
+      expect(
         () => InputRequiredResult.fromJson(
           const {
             'resultType': resultTypeInputRequired,
@@ -712,6 +727,20 @@ void main() {
         () => CallToolRequest.fromJson(
           const {'name': 'deploy', 'requestState': 1},
         ),
+        throwsFormatException,
+      );
+      expect(
+        () => CallToolRequest.fromJson({
+          'name': 'deploy',
+          'arguments': {'bad': Object()},
+        }),
+        throwsFormatException,
+      );
+      expect(
+        () => const CallToolRequest(
+          name: 'deploy',
+          arguments: {'bad': Object()},
+        ).toJson(),
         throwsFormatException,
       );
       expect(

--- a/test/tool_schema_test.dart
+++ b/test/tool_schema_test.dart
@@ -232,6 +232,60 @@ void main() {
       expect(parsedNull.structuredContent, isNull);
     });
 
+    test('Tool JSON object fields reject non-JSON Dart map values', () {
+      expect(
+        () => Tool.fromJson({
+          'name': 'search',
+          'inputSchema': {'type': 'object'},
+          '_meta': {'bad': Object()},
+        }),
+        throwsFormatException,
+      );
+      expect(
+        () => const Tool(
+          name: 'search',
+          inputSchema: JsonObject(),
+          meta: {'bad': Object()},
+        ).toJson(),
+        throwsFormatException,
+      );
+      expect(
+        () => CallToolRequest.fromJson({
+          'name': 'search',
+          'arguments': {'bad': Object()},
+        }),
+        throwsFormatException,
+      );
+      expect(
+        () => const CallToolRequest(
+          name: 'search',
+          arguments: {'bad': Object()},
+        ).toJson(),
+        throwsFormatException,
+      );
+      expect(
+        () => CallToolResult.fromJson({
+          'content': <Map<String, dynamic>>[],
+          '_meta': {'bad': Object()},
+        }),
+        throwsFormatException,
+      );
+      expect(
+        () => const CallToolResult(
+          content: [],
+          meta: {'bad': Object()},
+        ).toJson(),
+        throwsFormatException,
+      );
+      expect(
+        () => CallToolResult.fromJson({
+          'content': <Map<String, dynamic>>[],
+          'x-extra': Object(),
+        }),
+        throwsFormatException,
+      );
+    });
+
     test('Tool serializes JsonEnum properties as standard enum schema', () {
       const tool = Tool(
         name: 'configure_mode',

--- a/test/types/subscriptions_test.dart
+++ b/test/types/subscriptions_test.dart
@@ -284,6 +284,16 @@ void main() {
         ),
         throwsFormatException,
       );
+      expect(
+        () => JsonRpcSubscriptionsAcknowledgedNotification.fromJson({
+          'method': Method.notificationsSubscriptionsAcknowledged,
+          'params': {
+            'notifications': {'toolsListChanged': true},
+            '_meta': {'bad': Object()},
+          },
+        }),
+        throwsFormatException,
+      );
     });
   });
 

--- a/test/types/tasks_extension_test.dart
+++ b/test/types/tasks_extension_test.dart
@@ -127,6 +127,46 @@ void main() {
       expect(parsed.meta, {'trace': 'abc'});
     });
 
+    test('rejects non-JSON task extension object values', () {
+      final taskJson = {
+        'taskId': 'task-1',
+        'status': 'completed',
+        'createdAt': '2026-07-28T00:00:00Z',
+        'lastUpdatedAt': '2026-07-28T00:02:00Z',
+        'ttlMs': 60000,
+        'result': {'bad': Object()},
+      };
+
+      expect(
+        () => TaskExtensionTask.fromJson(taskJson),
+        throwsFormatException,
+      );
+      expect(
+        () => const TaskExtensionTask(
+          taskId: 'task-1',
+          status: TaskStatus.completed,
+          createdAt: '2026-07-28T00:00:00Z',
+          lastUpdatedAt: '2026-07-28T00:02:00Z',
+          ttlMs: 60000,
+          result: {'bad': Object()},
+        ).toJson(),
+        throwsFormatException,
+      );
+      expect(
+        () => TaskExtensionAcknowledgementResult.fromJson({
+          'resultType': resultTypeComplete,
+          '_meta': {'bad': Object()},
+        }),
+        throwsFormatException,
+      );
+      expect(
+        () => const TaskExtensionAcknowledgementResult(
+          meta: {'bad': Object()},
+        ).toJson(),
+        throwsFormatException,
+      );
+    });
+
     test('serializes notifications/tasks with detailed task state', () {
       final notification = JsonRpcTaskNotification(
         task: const TaskExtensionTask(


### PR DESCRIPTION
## Summary
- route duplicated JSON object readers through the shared validator so nested non-JSON Dart values are rejected
- validate tool, MRTR, task extension, subscription, and request metadata object fields during parsing and serialization where these helpers are used
- add 2025-11-25 and 2026-07-28 RC regression coverage for non-JSON object values

## Validation
- `dart format .`
- `dart analyze`
- `dart test test/mcp_2025_11_25_test.dart test/mcp_2026_07_28_test.dart test/tool_schema_test.dart test/types/tasks_extension_test.dart test/types/subscriptions_test.dart`
- `dart test`
- `git diff --check`
- `(cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json)`

Spec status: stacked draft RC work; keep unreleased until the official spec release.