### PR TITLE
Validate result metadata JSON objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@
   `resource_link.annotations`.
 - Reused shared JSON-object validation for MRTR, task extension, subscription,
   and tool object fields.
+- Rejected non-JSON values in JSON-RPC envelope and remaining typed result
+  metadata fields.
 
 ## 2.2.0
 

--- a/lib/src/types/completion.dart
+++ b/lib/src/types/completion.dart
@@ -1,4 +1,5 @@
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// Sealed class representing a reference for autocompletion targets.
 sealed class Reference {
@@ -236,7 +237,7 @@ class CompleteResult implements BaseResultData {
   const CompleteResult({required this.completion, this.meta});
 
   factory CompleteResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(json['_meta'], 'CompleteResult._meta');
     return CompleteResult(
       completion: CompletionResultData.fromJson(
         json['completion'] as Map<String, dynamic>,
@@ -248,7 +249,7 @@ class CompleteResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         'completion': completion.toJson(),
-        if (meta != null) '_meta': meta,
+        if (meta != null) '_meta': readJsonObject(meta, 'CompleteResult._meta'),
       };
 }
 

--- a/lib/src/types/elicitation.dart
+++ b/lib/src/types/elicitation.dart
@@ -1,5 +1,6 @@
 import '../shared/json_schema/json_schema.dart';
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// Legacy alias for [JsonSchema] used in elicitation requests.
 typedef ElicitationInputSchema = JsonSchema;
@@ -281,7 +282,7 @@ class ElicitResult implements BaseResultData {
       content: content,
       url: json['url'] as String?,
       elicitationId: json['elicitationId'] as String?,
-      meta: (json['_meta'] as Map?)?.cast<String, dynamic>(),
+      meta: readOptionalJsonObject(json['_meta'], 'ElicitResult._meta'),
     );
   }
 
@@ -293,7 +294,7 @@ class ElicitResult implements BaseResultData {
     return {
       'action': resultAction,
       if (content != null) 'content': content,
-      if (meta != null) '_meta': meta,
+      if (meta != null) '_meta': readJsonObject(meta, 'ElicitResult._meta'),
     };
   }
 
@@ -368,7 +369,10 @@ class JsonRpcElicitationCompleteNotification extends JsonRpcNotification {
         "Missing params for elicitation complete notification",
       );
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      paramsMap['_meta'],
+      'JsonRpcElicitationCompleteNotification._meta',
+    );
     return JsonRpcElicitationCompleteNotification(
       completeParams: ElicitationCompleteNotification.fromJson(paramsMap),
       meta: meta,

--- a/lib/src/types/initialization.dart
+++ b/lib/src/types/initialization.dart
@@ -1,5 +1,6 @@
 import 'content.dart';
 import 'json_rpc.dart';
+import 'validation.dart';
 
 Map<String, dynamic>? _asJsonObject(dynamic value) {
   if (value == null) {
@@ -992,7 +993,8 @@ class InitializeResult implements BaseResultData {
   });
 
   factory InitializeResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta =
+        readOptionalJsonObject(json['_meta'], 'InitializeResult._meta');
     return InitializeResult(
       protocolVersion: json['protocolVersion'] as String,
       capabilities: ServerCapabilities.fromJson(
@@ -1012,7 +1014,8 @@ class InitializeResult implements BaseResultData {
         'capabilities': capabilities.toJson(),
         'serverInfo': serverInfo.toJson(),
         if (instructions != null) 'instructions': instructions,
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'InitializeResult._meta'),
       };
 }
 
@@ -1064,7 +1067,7 @@ class DiscoverResult implements BaseResultData {
         json['serverInfo'] as Map<String, dynamic>,
       ),
       instructions: json['instructions'] as String?,
-      meta: json['_meta'] as Map<String, dynamic>?,
+      meta: readOptionalJsonObject(json['_meta'], 'DiscoverResult._meta'),
     );
   }
 
@@ -1075,7 +1078,7 @@ class DiscoverResult implements BaseResultData {
         'capabilities': capabilities.toJson(),
         'serverInfo': serverInfo.toJson(),
         if (instructions != null) 'instructions': instructions,
-        if (meta != null) '_meta': meta,
+        if (meta != null) '_meta': readJsonObject(meta, 'DiscoverResult._meta'),
       };
 }
 

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -378,17 +378,32 @@ sealed class JsonRpcMessage {
             JsonRpcElicitationCompleteNotification.fromJson(json),
           _ => JsonRpcNotification(
               method: method,
-              params: json['params'] as Map<String, dynamic>?,
-              meta: json['_meta'] as Map<String, dynamic>? ??
-                  (json['params'] as Map<String, dynamic>?)?['_meta']
-                      as Map<String, dynamic>?,
+              params: readOptionalJsonObject(
+                json['params'],
+                'JsonRpcNotification.params',
+              ),
+              meta: readOptionalJsonObject(
+                    json['_meta'],
+                    'JsonRpcNotification._meta',
+                  ) ??
+                  readOptionalJsonObject(
+                    readOptionalJsonObject(
+                      json['params'],
+                      'JsonRpcNotification.params',
+                    )?['_meta'],
+                    'JsonRpcNotification._meta',
+                  ),
             ),
         };
       }
     } else if (json.containsKey('result')) {
       final id = _parseResultResponseId(json['id']);
-      final resultData = json['result'] as Map<String, dynamic>;
-      final meta = resultData['_meta'] as Map<String, dynamic>?;
+      final resultData =
+          readJsonObject(json['result'], 'JsonRpcResponse.result');
+      final meta = readOptionalJsonObject(
+        resultData['_meta'],
+        'JsonRpcResponse._meta',
+      );
       final actualResult = Map<String, dynamic>.from(resultData)
         ..remove('_meta');
       return JsonRpcResponse(id: id, result: actualResult, meta: meta);
@@ -438,8 +453,10 @@ class JsonRpcRequest extends JsonRpcMessage {
         'method': method,
         if (params != null || meta != null)
           'params': <String, dynamic>{
-            ...?params,
-            if (meta != null) '_meta': meta,
+            if (params != null)
+              ...readJsonObject(params, 'JsonRpcRequest.params'),
+            if (meta != null)
+              '_meta': readJsonObject(meta, 'JsonRpcRequest._meta'),
           },
       };
 }
@@ -464,8 +481,10 @@ class JsonRpcNotification extends JsonRpcMessage {
         'method': method,
         if (params != null || meta != null)
           'params': <String, dynamic>{
-            ...?params,
-            if (meta != null) '_meta': meta,
+            if (params != null)
+              ...readJsonObject(params, 'JsonRpcNotification.params'),
+            if (meta != null)
+              '_meta': readJsonObject(meta, 'JsonRpcNotification._meta'),
           },
       };
 }
@@ -488,7 +507,11 @@ class JsonRpcResponse extends JsonRpcMessage {
   Map<String, dynamic> toJson() => {
         'jsonrpc': jsonrpc,
         'id': id,
-        'result': <String, dynamic>{...result, if (meta != null) '_meta': meta},
+        'result': <String, dynamic>{
+          ...readJsonObject(result, 'JsonRpcResponse.result'),
+          if (meta != null)
+            '_meta': readJsonObject(meta, 'JsonRpcResponse._meta'),
+        },
       };
 }
 // --- JSON-RPC Error ---

--- a/lib/src/types/logging.dart
+++ b/lib/src/types/logging.dart
@@ -1,4 +1,5 @@
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// Severity levels for log messages (syslog levels).
 enum LoggingLevel {
@@ -102,7 +103,10 @@ class JsonRpcLoggingMessageNotification extends JsonRpcNotification {
         "Missing params for logging message notification",
       );
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      paramsMap['_meta'],
+      'JsonRpcLoggingMessageNotification._meta',
+    );
     return JsonRpcLoggingMessageNotification(
       logParams: LoggingMessageNotification.fromJson(paramsMap),
       meta: meta,

--- a/lib/src/types/misc.dart
+++ b/lib/src/types/misc.dart
@@ -10,7 +10,7 @@ class EmptyResult implements BaseResultData {
 
   @override
   Map<String, dynamic> toJson() => {
-        if (meta != null) '_meta': meta,
+        if (meta != null) '_meta': readJsonObject(meta, 'EmptyResult._meta'),
       };
 }
 
@@ -52,7 +52,10 @@ class JsonRpcCancelledNotification extends JsonRpcNotification {
     if (paramsMap == null) {
       throw const FormatException("Missing params for cancelled notification");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      paramsMap['_meta'],
+      'JsonRpcCancelledNotification._meta',
+    );
     return JsonRpcCancelledNotification(
       cancelParams: CancelledNotification.fromJson(paramsMap),
       meta: meta,
@@ -172,7 +175,10 @@ class JsonRpcProgressNotification extends JsonRpcNotification {
     if (paramsMap == null) {
       throw const FormatException("Missing params for progress notification");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      paramsMap['_meta'],
+      'JsonRpcProgressNotification._meta',
+    );
     return JsonRpcProgressNotification(
       progressParams: ProgressNotification.fromJson(paramsMap),
       meta: meta,

--- a/lib/src/types/prompts.dart
+++ b/lib/src/types/prompts.dart
@@ -90,7 +90,7 @@ class Prompt {
       icons: (json['icons'] as List<dynamic>?)
           ?.map((e) => McpIcon.fromJson(e as Map<String, dynamic>))
           .toList(),
-      meta: (json['_meta'] as Map?)?.cast<String, dynamic>(),
+      meta: readOptionalJsonObject(json['_meta'], 'Prompt._meta'),
     );
   }
 
@@ -102,7 +102,7 @@ class Prompt {
           'arguments': arguments!.map((a) => a.toJson()).toList(),
         if (icons != null)
           'icons': icons!.map((icon) => icon.toJson()).toList(),
-        if (meta != null) '_meta': meta,
+        if (meta != null) '_meta': readJsonObject(meta, 'Prompt._meta'),
       };
 }
 
@@ -171,7 +171,8 @@ class ListPromptsResult implements CacheableResultData {
   });
 
   factory ListPromptsResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta =
+        readOptionalJsonObject(json['_meta'], 'ListPromptsResult._meta');
     final prompts = json['prompts'];
     if (prompts is! List) {
       throw const FormatException('ListPromptsResult.prompts is required');
@@ -199,7 +200,8 @@ class ListPromptsResult implements CacheableResultData {
       if (nextCursor != null) 'nextCursor': nextCursor,
       if (ttlMs != null) 'ttlMs': ttlMs,
       if (cacheScope != null) 'cacheScope': cacheScope,
-      if (meta != null) '_meta': meta,
+      if (meta != null)
+        '_meta': readJsonObject(meta, 'ListPromptsResult._meta'),
     };
   }
 }
@@ -319,7 +321,7 @@ class GetPromptResult implements BaseResultData {
   const GetPromptResult({this.description, required this.messages, this.meta});
 
   factory GetPromptResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(json['_meta'], 'GetPromptResult._meta');
     final messages = json['messages'];
     if (messages is! List) {
       throw const FormatException('GetPromptResult.messages is required');
@@ -337,7 +339,8 @@ class GetPromptResult implements BaseResultData {
   Map<String, dynamic> toJson() => {
         if (description != null) 'description': description,
         'messages': messages.map((m) => m.toJson()).toList(),
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'GetPromptResult._meta'),
       };
 }
 

--- a/lib/src/types/resources.dart
+++ b/lib/src/types/resources.dart
@@ -117,7 +117,7 @@ class Resource {
               json['annotations'] as Map<String, dynamic>,
             )
           : null,
-      meta: (json['_meta'] as Map?)?.cast<String, dynamic>(),
+      meta: readOptionalJsonObject(json['_meta'], 'Resource._meta'),
     );
   }
 
@@ -132,7 +132,7 @@ class Resource {
           'icons': icons!.map((icon) => icon.toJson()).toList(),
         if (size != null) 'size': size,
         if (annotations != null) 'annotations': annotations!.toJson(),
-        if (meta != null) '_meta': meta,
+        if (meta != null) '_meta': readJsonObject(meta, 'Resource._meta'),
       };
 }
 
@@ -200,7 +200,7 @@ class ResourceTemplate {
               json['annotations'] as Map<String, dynamic>,
             )
           : null,
-      meta: (json['_meta'] as Map?)?.cast<String, dynamic>(),
+      meta: readOptionalJsonObject(json['_meta'], 'ResourceTemplate._meta'),
     );
   }
 
@@ -214,7 +214,8 @@ class ResourceTemplate {
         if (icons != null)
           'icons': icons!.map((icon) => icon.toJson()).toList(),
         if (annotations != null) 'annotations': annotations!.toJson(),
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'ResourceTemplate._meta'),
       };
 }
 
@@ -291,7 +292,10 @@ class ListResourcesResult implements CacheableResultData {
 
   /// Creates from JSON.
   factory ListResourcesResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      json['_meta'],
+      'ListResourcesResult._meta',
+    );
     final resources = json['resources'];
     if (resources is! List) {
       throw const FormatException('ListResourcesResult.resources is required');
@@ -320,7 +324,8 @@ class ListResourcesResult implements CacheableResultData {
       if (nextCursor != null) 'nextCursor': nextCursor,
       if (ttlMs != null) 'ttlMs': ttlMs,
       if (cacheScope != null) 'cacheScope': cacheScope,
-      if (meta != null) '_meta': meta,
+      if (meta != null)
+        '_meta': readJsonObject(meta, 'ListResourcesResult._meta'),
     };
   }
 }
@@ -395,7 +400,10 @@ class ListResourceTemplatesResult implements CacheableResultData {
   });
 
   factory ListResourceTemplatesResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      json['_meta'],
+      'ListResourceTemplatesResult._meta',
+    );
     final resourceTemplates = json['resourceTemplates'];
     if (resourceTemplates is! List) {
       throw const FormatException(
@@ -428,7 +436,8 @@ class ListResourceTemplatesResult implements CacheableResultData {
       if (nextCursor != null) 'nextCursor': nextCursor,
       if (ttlMs != null) 'ttlMs': ttlMs,
       if (cacheScope != null) 'cacheScope': cacheScope,
-      if (meta != null) '_meta': meta,
+      if (meta != null)
+        '_meta': readJsonObject(meta, 'ListResourceTemplatesResult._meta'),
     };
   }
 }
@@ -520,7 +529,10 @@ class ReadResourceResult implements CacheableResultData {
   });
 
   factory ReadResourceResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      json['_meta'],
+      'ReadResourceResult._meta',
+    );
     final contents = json['contents'];
     if (contents is! List) {
       throw const FormatException('ReadResourceResult.contents is required');
@@ -546,7 +558,8 @@ class ReadResourceResult implements CacheableResultData {
       'contents': contents.map((c) => c.toJson()).toList(),
       if (ttlMs != null) 'ttlMs': ttlMs,
       if (cacheScope != null) 'cacheScope': cacheScope,
-      if (meta != null) '_meta': meta,
+      if (meta != null)
+        '_meta': readJsonObject(meta, 'ReadResourceResult._meta'),
     };
   }
 }
@@ -673,7 +686,10 @@ class JsonRpcResourceUpdatedNotification extends JsonRpcNotification {
         "Missing params for resource updated notification",
       );
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      paramsMap['_meta'],
+      'JsonRpcResourceUpdatedNotification._meta',
+    );
     return JsonRpcResourceUpdatedNotification(
       updatedParams: ResourceUpdatedNotification.fromJson(paramsMap),
       meta: meta,

--- a/lib/src/types/roots.dart
+++ b/lib/src/types/roots.dart
@@ -1,4 +1,5 @@
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// Represents a root directory or file the server can operate on.
 class Root {
@@ -25,14 +26,14 @@ class Root {
     return Root(
       uri: json['uri'] as String,
       name: json['name'] as String?,
-      meta: (json['_meta'] as Map?)?.cast<String, dynamic>(),
+      meta: readOptionalJsonObject(json['_meta'], 'Root._meta'),
     );
   }
 
   Map<String, dynamic> toJson() => {
         'uri': uri,
         if (name != null) 'name': name,
-        if (meta != null) '_meta': meta,
+        if (meta != null) '_meta': readJsonObject(meta, 'Root._meta'),
       };
 }
 
@@ -61,7 +62,7 @@ class ListRootsResult implements BaseResultData {
   const ListRootsResult({required this.roots, this.meta});
 
   factory ListRootsResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(json['_meta'], 'ListRootsResult._meta');
     final roots = json['roots'];
     if (roots is! List) {
       throw const FormatException('ListRootsResult.roots is required');
@@ -76,7 +77,8 @@ class ListRootsResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         'roots': roots.map((r) => r.toJson()).toList(),
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'ListRootsResult._meta'),
       };
 }
 

--- a/lib/src/types/tasks.dart
+++ b/lib/src/types/tasks.dart
@@ -99,7 +99,7 @@ class Task implements BaseResultData {
     final createdAt = _readRequiredTaskString(json, 'createdAt');
     final lastUpdatedAt = _readRequiredTaskString(json, 'lastUpdatedAt');
 
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(json['_meta'], 'Task._meta');
     return Task(
       taskId: _readRequiredTaskString(json, 'taskId'),
       status: TaskStatusName.fromString(
@@ -123,7 +123,8 @@ class Task implements BaseResultData {
         if (pollInterval != null) 'pollInterval': pollInterval,
         'createdAt': createdAt,
         'lastUpdatedAt': lastUpdatedAt,
-        if (includeMeta && meta != null) '_meta': meta,
+        if (includeMeta && meta != null)
+          '_meta': readJsonObject(meta, 'Task._meta'),
       };
 
   /// Serializes this task where MCP expects the bare `Task` schema.
@@ -232,7 +233,7 @@ class ListTasksResult implements BaseResultData {
   const ListTasksResult({required this.tasks, this.nextCursor, this.meta});
 
   factory ListTasksResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(json['_meta'], 'ListTasksResult._meta');
     final tasks = json['tasks'];
     if (tasks is! List) {
       throw const FormatException('ListTasksResult.tasks is required');
@@ -249,7 +250,8 @@ class ListTasksResult implements BaseResultData {
   Map<String, dynamic> toJson() => {
         'tasks': tasks.map((t) => t.toBareJson()).toList(),
         if (nextCursor != null) 'nextCursor': nextCursor,
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'ListTasksResult._meta'),
       };
 }
 
@@ -459,7 +461,8 @@ class CreateTaskResult implements BaseResultData {
   const CreateTaskResult({required this.task, this.meta});
 
   factory CreateTaskResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta =
+        readOptionalJsonObject(json['_meta'], 'CreateTaskResult._meta');
     return CreateTaskResult(
       task: Task.fromJson(json['task'] as Map<String, dynamic>),
       meta: meta,
@@ -469,7 +472,8 @@ class CreateTaskResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         'task': task.toBareJson(),
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'CreateTaskResult._meta'),
       };
 }
 

--- a/lib/src/types/tools.dart
+++ b/lib/src/types/tools.dart
@@ -305,7 +305,7 @@ class ListToolsResult implements CacheableResultData {
         json['cacheScope'],
         'ListToolsResult.cacheScope',
       ),
-      meta: json['_meta'] as Map<String, dynamic>?,
+      meta: readOptionalJsonObject(json['_meta'], 'ListToolsResult._meta'),
     );
   }
 
@@ -318,7 +318,7 @@ class ListToolsResult implements CacheableResultData {
       if (nextCursor != null) 'nextCursor': nextCursor,
       if (ttlMs != null) 'ttlMs': ttlMs,
       if (cacheScope != null) 'cacheScope': cacheScope,
-      if (meta != null) '_meta': meta,
+      if (meta != null) '_meta': readJsonObject(meta, 'ListToolsResult._meta'),
     };
   }
 }

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -613,6 +613,34 @@ void main() {
       );
     });
 
+    test('Result metadata fields reject non-JSON Dart maps', () {
+      expect(
+        () => Root.fromJson({
+          'uri': 'file:///repo',
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ListResourcesResult.fromJson({
+          'resources': [],
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => JsonRpcMessage.fromJson({
+          'jsonrpc': jsonRpcVersion,
+          'id': 1,
+          'result': {
+            'ok': true,
+            '_meta': {'bad': Object()},
+          },
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
     group('Tasks API Types', () {
       test('GetTaskRequestParams serialization', () {
         final params = const GetTaskRequestParams(taskId: 'task-123');

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -437,6 +437,39 @@ void main() {
       );
     });
 
+    test('rejects non-JSON result metadata values', () {
+      expect(
+        () => DiscoverResult.fromJson({
+          'resultType': 'complete',
+          'supportedVersions': [draftProtocolVersion2026_07_28],
+          'capabilities': <String, dynamic>{},
+          'serverInfo': {'name': 'server', 'version': '1.0.0'},
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const DiscoverResult(
+          supportedVersions: [draftProtocolVersion2026_07_28],
+          capabilities: ServerCapabilities(),
+          serverInfo: Implementation(name: 'server', version: '1.0.0'),
+          meta: {'bad': Object()},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => JsonRpcMessage.fromJson({
+          'jsonrpc': jsonRpcVersion,
+          'id': 1,
+          'result': {
+            'resultType': 'complete',
+            '_meta': {'bad': Object()},
+          },
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
     test('serializes server/discover request and result', () {
       final request = JsonRpcServerDiscoverRequest(
         id: 'discover-1',

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -45,6 +45,41 @@ void main() {
       expect(json['result']['_meta']['metaKey'], equals('metaValue'));
     });
 
+    test('JSON-RPC envelope metadata rejects non-JSON Dart maps', () {
+      final invalidMeta = {'bad': Object()};
+
+      expect(
+        () => JsonRpcRequest(
+          id: 1,
+          method: 'custom/request',
+          meta: invalidMeta,
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => JsonRpcNotification(
+          method: 'custom/notification',
+          meta: invalidMeta,
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => JsonRpcMessage.fromJson({
+          'jsonrpc': jsonRpcVersion,
+          'method': 'custom/notification',
+          'params': {'_meta': invalidMeta},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const JsonRpcResponse(
+          id: 1,
+          result: {'bad': Object()},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
     test('JsonRpcError serialization and deserialization', () {
       final error = JsonRpcError(
         id: 1,
@@ -131,6 +166,135 @@ void main() {
         ),
       ]) {
         expectMeta(result);
+      }
+    });
+
+    test('typed metadata rejects non-JSON Dart maps', () {
+      final invalidMeta = {'bad': Object()};
+      final task = Task(
+        taskId: 'task-1',
+        status: TaskStatus.completed,
+        ttl: null,
+        createdAt: '2026-05-25T00:00:00.000Z',
+        lastUpdatedAt: '2026-05-25T00:00:01.000Z',
+        meta: invalidMeta,
+      );
+
+      for (final serialize in <Map<String, dynamic> Function()>[
+        () => Root(uri: 'file:///repo', meta: invalidMeta).toJson(),
+        () => Resource(
+              uri: 'file:///repo/readme.md',
+              name: 'readme',
+              meta: invalidMeta,
+            ).toJson(),
+        () => ResourceTemplate(
+              uriTemplate: 'file:///repo/{name}',
+              name: 'repo-file',
+              meta: invalidMeta,
+            ).toJson(),
+        () => Prompt(name: 'summary', meta: invalidMeta).toJson(),
+        () => EmptyResult(meta: invalidMeta).toJson(),
+        () => InitializeResult(
+              protocolVersion: latestProtocolVersion,
+              capabilities: const ServerCapabilities(),
+              serverInfo: const Implementation(name: 'server', version: '1.0'),
+              meta: invalidMeta,
+            ).toJson(),
+        () => DiscoverResult(
+              supportedVersions: const [draftProtocolVersion2026_07_28],
+              capabilities: const ServerCapabilities(),
+              serverInfo: const Implementation(name: 'server', version: '1.0'),
+              meta: invalidMeta,
+            ).toJson(),
+        () => ListRootsResult(roots: const [], meta: invalidMeta).toJson(),
+        () => ListResourcesResult(resources: const [], meta: invalidMeta)
+            .toJson(),
+        () => ListResourceTemplatesResult(
+              resourceTemplates: const [],
+              meta: invalidMeta,
+            ).toJson(),
+        () =>
+            ReadResourceResult(contents: const [], meta: invalidMeta).toJson(),
+        () => ListPromptsResult(prompts: const [], meta: invalidMeta).toJson(),
+        () => GetPromptResult(messages: const [], meta: invalidMeta).toJson(),
+        () => CompleteResult(
+              completion: CompletionResultData(values: const []),
+              meta: invalidMeta,
+            ).toJson(),
+        () => ElicitResult(action: 'accept', meta: invalidMeta).toJson(),
+        () => ListToolsResult(tools: const [], meta: invalidMeta).toJson(),
+        () => task.toJson(),
+        () => ListTasksResult(tasks: const [], meta: invalidMeta).toJson(),
+        () => CreateTaskResult(task: task, meta: invalidMeta).toJson(),
+        () => JsonRpcResponse(
+              id: 1,
+              result: const {'ok': true},
+              meta: invalidMeta,
+            ).toJson(),
+      ]) {
+        expect(serialize, throwsA(isA<FormatException>()));
+      }
+
+      for (final parse in <Object Function()>[
+        () => Root.fromJson({'uri': 'file:///repo', '_meta': invalidMeta}),
+        () => Resource.fromJson({
+              'uri': 'file:///repo/readme.md',
+              'name': 'readme',
+              '_meta': invalidMeta,
+            }),
+        () => ResourceTemplate.fromJson({
+              'uriTemplate': 'file:///repo/{name}',
+              'name': 'repo-file',
+              '_meta': invalidMeta,
+            }),
+        () => Prompt.fromJson({'name': 'summary', '_meta': invalidMeta}),
+        () => ListRootsResult.fromJson({'roots': [], '_meta': invalidMeta}),
+        () => ListResourcesResult.fromJson({
+              'resources': [],
+              '_meta': invalidMeta,
+            }),
+        () => ListResourceTemplatesResult.fromJson({
+              'resourceTemplates': [],
+              '_meta': invalidMeta,
+            }),
+        () => ReadResourceResult.fromJson({
+              'contents': [],
+              '_meta': invalidMeta,
+            }),
+        () => ListPromptsResult.fromJson({'prompts': [], '_meta': invalidMeta}),
+        () => GetPromptResult.fromJson({'messages': [], '_meta': invalidMeta}),
+        () => CompleteResult.fromJson({
+              'completion': {'values': []},
+              '_meta': invalidMeta,
+            }),
+        () => ElicitResult.fromJson({'action': 'accept', '_meta': invalidMeta}),
+        () => ListToolsResult.fromJson({'tools': [], '_meta': invalidMeta}),
+        () => Task.fromJson({
+              'taskId': 'task-1',
+              'status': 'completed',
+              'ttl': null,
+              'createdAt': '2026-05-25T00:00:00.000Z',
+              'lastUpdatedAt': '2026-05-25T00:00:01.000Z',
+              '_meta': invalidMeta,
+            }),
+        () => ListTasksResult.fromJson({'tasks': [], '_meta': invalidMeta}),
+        () => CreateTaskResult.fromJson({
+              'task': const {
+                'taskId': 'task-1',
+                'status': 'completed',
+                'ttl': null,
+                'createdAt': '2026-05-25T00:00:00.000Z',
+                'lastUpdatedAt': '2026-05-25T00:00:01.000Z',
+              },
+              '_meta': invalidMeta,
+            }),
+        () => JsonRpcMessage.fromJson({
+              'jsonrpc': jsonRpcVersion,
+              'id': 1,
+              'result': {'ok': true, '_meta': invalidMeta},
+            }),
+      ]) {
+        expect(parse, throwsA(isA<FormatException>()));
       }
     });
   });


### PR DESCRIPTION
## Summary
- validate remaining typed result, descriptor, notification `_meta` fields with shared JSON-object validation
- validate generic JSON-RPC envelope `params`, `result`, and `_meta` maps against JSON values
- add stable 2025-11-25 and 2026-07-28 RC regression coverage

## Validation
- dart format .
- dart analyze
- dart test test/types_test.dart test/mcp_2025_11_25_test.dart test/mcp_2026_07_28_test.dart
- dart test
- git diff --check
- (cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json)