### PR TITLE
Guard stateless clients from removed RPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@
   and tool object fields.
 - Rejected non-JSON values in JSON-RPC envelope and remaining typed result
   metadata fields.
+- Prevented stateless MCP 2026 clients from sending core request and
+  notification methods removed from that protocol revision.
 
 ## 2.2.0
 

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -4,6 +4,7 @@ import 'package:mcp_dart/src/shared/json_schema/json_schema_validator.dart';
 import 'package:mcp_dart/src/shared/logging.dart';
 import 'package:mcp_dart/src/shared/mcp_header_validation.dart';
 import 'package:mcp_dart/src/shared/protocol.dart';
+import 'package:mcp_dart/src/shared/task_interfaces.dart';
 import 'package:mcp_dart/src/shared/transport.dart';
 import 'package:mcp_dart/src/types.dart';
 
@@ -107,6 +108,21 @@ dynamic _deepCopy(dynamic value) {
     return value;
   }
 }
+
+const Set<String> _statelessRemovedRequestMethods = {
+  Method.initialize,
+  Method.ping,
+  Method.loggingSetLevel,
+  Method.resourcesSubscribe,
+  Method.resourcesUnsubscribe,
+  Method.tasksList,
+  Method.tasksResult,
+};
+
+const Set<String> _statelessRemovedNotificationMethods = {
+  Method.notificationsInitialized,
+  Method.notificationsRootsListChanged,
+};
 
 /// An MCP client implementation built on top of a pluggable [Transport].
 ///
@@ -481,6 +497,8 @@ class McpClient extends Protocol {
     RequestOptions? options,
     int? relatedRequestId,
   ]) async {
+    _assertStatelessRequestAllowed(requestData.method);
+
     final outboundRequest =
         _usesStatelessProtocol && requestData.method != Method.serverDiscover
             ? JsonRpcRequest(
@@ -535,6 +553,44 @@ class McpClient extends Protocol {
         relatedRequestId,
       );
     }
+  }
+
+  @override
+  Future<void> notification(
+    JsonRpcNotification notificationData, {
+    RelatedTaskMetadata? relatedTask,
+    int? relatedRequestId,
+  }) async {
+    _assertStatelessNotificationAllowed(notificationData.method);
+    await super.notification(
+      notificationData,
+      relatedTask: relatedTask,
+      relatedRequestId: relatedRequestId,
+    );
+  }
+
+  void _assertStatelessRequestAllowed(String method) {
+    if (!_usesStatelessProtocol ||
+        !_statelessRemovedRequestMethods.contains(method)) {
+      return;
+    }
+
+    throw McpError(
+      ErrorCode.methodNotFound.value,
+      'MCP $_negotiatedProtocolVersion does not define $method.',
+    );
+  }
+
+  void _assertStatelessNotificationAllowed(String method) {
+    if (!_usesStatelessProtocol ||
+        !_statelessRemovedNotificationMethods.contains(method)) {
+      return;
+    }
+
+    throw McpError(
+      ErrorCode.methodNotFound.value,
+      'MCP $_negotiatedProtocolVersion does not define $method.',
+    );
   }
 
   /// Gets the server's reported capabilities after successful initialization.

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -2355,6 +2355,136 @@ void main() {
       expect(listRequest.meta?[McpMetaKey.clientCapabilities], {});
     });
 
+    test('stateless client rejects removed request methods before send',
+        () async {
+      final transport = DiscoveringClientTransport();
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+      transport.sentMessages.clear();
+
+      final removedRequests = <({String method, Future<void> Function() call})>[
+        (
+          method: Method.ping,
+          call: () async {
+            await client.ping();
+          },
+        ),
+        (
+          method: Method.loggingSetLevel,
+          call: () async {
+            await client.setLoggingLevel(LoggingLevel.debug);
+          },
+        ),
+        (
+          method: Method.resourcesSubscribe,
+          call: () async {
+            await client.subscribeResource(
+              const SubscribeRequest(uri: 'file:///tmp/example.txt'),
+            );
+          },
+        ),
+        (
+          method: Method.resourcesUnsubscribe,
+          call: () async {
+            await client.unsubscribeResource(
+              const UnsubscribeRequest(uri: 'file:///tmp/example.txt'),
+            );
+          },
+        ),
+        (
+          method: Method.tasksList,
+          call: () async {
+            await client.request<ListTasksResult>(
+              JsonRpcListTasksRequest(id: -1),
+              ListTasksResult.fromJson,
+            );
+          },
+        ),
+        (
+          method: Method.tasksResult,
+          call: () async {
+            await client.request<CallToolResult>(
+              JsonRpcTaskResultRequest(
+                id: -1,
+                resultParams: const TaskResultRequest(taskId: 'task-1'),
+              ),
+              CallToolResult.fromJson,
+            );
+          },
+        ),
+      ];
+
+      for (final scenario in removedRequests) {
+        await expectLater(
+          scenario.call(),
+          throwsA(
+            isA<McpError>()
+                .having(
+                  (error) => error.code,
+                  'code',
+                  ErrorCode.methodNotFound.value,
+                )
+                .having(
+                  (error) => error.message,
+                  'message',
+                  contains(scenario.method),
+                ),
+          ),
+        );
+      }
+
+      expect(transport.sentMessages, isEmpty);
+    });
+
+    test('stateless client rejects removed notifications before send',
+        () async {
+      final transport = DiscoveringClientTransport();
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+      transport.sentMessages.clear();
+
+      final removedNotifications =
+          <({String method, Future<void> Function() call})>[
+        (
+          method: Method.notificationsInitialized,
+          call: () => client.notification(
+                const JsonRpcInitializedNotification(),
+              ),
+        ),
+        (
+          method: Method.notificationsRootsListChanged,
+          call: client.sendRootsListChanged,
+        ),
+      ];
+
+      for (final scenario in removedNotifications) {
+        await expectLater(
+          scenario.call(),
+          throwsA(
+            isA<McpError>()
+                .having(
+                  (error) => error.code,
+                  'code',
+                  ErrorCode.methodNotFound.value,
+                )
+                .having(
+                  (error) => error.message,
+                  'message',
+                  contains(scenario.method),
+                ),
+          ),
+        );
+      }
+
+      expect(transport.sentMessages, isEmpty);
+    });
+
     test('client listenSubscriptions requires a connected transport', () {
       final client = McpClient(
         const Implementation(name: 'client', version: '1.0.0'),


### PR DESCRIPTION
## Summary
- reject client-side sends for request methods removed from the MCP 2026 stateless protocol
- reject removed stateless client notifications before they reach the transport
- add 2026 RC regression coverage while preserving legacy client helper behavior

## Validation
- dart format .
- dart analyze
- dart test test/mcp_2026_07_28_test.dart
- dart test test/client/client_test.dart test/client/task_client_test.dart test/mcp_2025_11_25_test.dart
- dart test
- git diff --check
- (cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json)