### PR TITLE
Reject stateless server requests on clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,8 @@
   metadata fields.
 - Prevented stateless MCP 2026 clients from sending core request and
   notification methods removed from that protocol revision.
+- Rejected server-initiated JSON-RPC requests received by stateless MCP 2026
+  clients on generic transports.
 
 ## 2.2.0
 

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -617,6 +617,14 @@ class McpClient extends Protocol {
 
   @override
   McpError? validateIncomingRequest(JsonRpcRequest request) {
+    if (_usesStatelessProtocol) {
+      return McpError(
+        ErrorCode.invalidRequest.value,
+        'Server-initiated JSON-RPC requests are not supported in stateless '
+        'MCP; return input_required with inputRequests instead.',
+      );
+    }
+
     if (_sentInitialized || request.method == Method.ping) {
       return null;
     }

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -2485,6 +2485,29 @@ void main() {
       expect(transport.sentMessages, isEmpty);
     });
 
+    test('stateless client rejects server-initiated requests on transport',
+        () async {
+      final transport = DiscoveringClientTransport();
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(
+          capabilities: ClientCapabilities(roots: ClientCapabilitiesRoots()),
+          useServerDiscover: true,
+        ),
+      );
+      await client.connect(transport);
+      transport.sentMessages.clear();
+
+      transport.onmessage?.call(const JsonRpcListRootsRequest(id: 'roots-1'));
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcError;
+      expect(response.id, 'roots-1');
+      expect(response.error.code, ErrorCode.invalidRequest.value);
+      expect(response.error.message, contains('input_required'));
+      expect(response.error.message, contains('inputRequests'));
+    });
+
     test('client listenSubscriptions requires a connected transport', () {
       final client = McpClient(
         const Implementation(name: 'client', version: '1.0.0'),


### PR DESCRIPTION
## Summary
- reject incoming server-initiated JSON-RPC requests after a client negotiates stateless MCP 2026
- align generic transports with the existing Streamable HTTP stateless response-stream behavior
- add 2026 RC regression coverage for direct transport-delivered server requests

## Validation
- dart format .
- dart analyze
- dart test test/mcp_2026_07_28_test.dart
- dart test test/client/client_test.dart test/mcp_2025_11_25_test.dart
- dart test
- git diff --check
- (cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json)