### PR TITLE
Validate stateless result shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@
   notification methods removed from that protocol revision.
 - Rejected server-initiated JSON-RPC requests received by stateless MCP 2026
   clients on generic transports.
+- Rejected stateless MCP 2026 responses that omit `resultType` or required
+  cacheable-result fields.
 
 ## 2.2.0
 

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -479,6 +479,9 @@ class McpClient extends Protocol {
           _logger.debug(
             "server/discover not available; falling back to initialize.",
           );
+          if (transport is ProtocolVersionAwareTransport) {
+            (transport as ProtocolVersionAwareTransport).protocolVersion = null;
+          }
         }
       }
 

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -11,6 +11,14 @@ final _logger = Logger("mcp_dart.shared.protocol");
 
 bool _isProgressToken(Object? token) => token is int || token is String;
 
+const Set<String> _statelessCacheableResultMethods = {
+  Method.toolsList,
+  Method.promptsList,
+  Method.resourcesList,
+  Method.resourcesTemplatesList,
+  Method.resourcesRead,
+};
+
 final _lastProgressByExtra = Expando<double>();
 final _subscriptionStateByExtra = Expando<_SubscriptionStreamState>();
 
@@ -508,13 +516,41 @@ abstract class Protocol {
 
     final resultType = resultJson['resultType'];
     if (resultType == null) {
-      return;
+      throw const FormatException(
+        'MCP stateless responses must include resultType',
+      );
     }
     if (resultType is! String) {
       throw const FormatException('MCP resultType must be a string');
     }
     if (!isRecognizedResultType(resultType)) {
       throw FormatException('Unrecognized MCP resultType "$resultType"');
+    }
+
+    if (resultType == resultTypeComplete &&
+        _statelessCacheableResultMethods.contains(request.method)) {
+      _validateStatelessCacheableResult(request, resultJson);
+    }
+  }
+
+  void _validateStatelessCacheableResult(
+    JsonRpcRequest request,
+    Map<String, dynamic> resultJson,
+  ) {
+    final ttlMs = resultJson['ttlMs'];
+    if (ttlMs is! int || ttlMs < 0) {
+      throw FormatException(
+        'MCP stateless ${request.method} responses must include '
+        'a non-negative integer ttlMs',
+      );
+    }
+
+    final cacheScope = resultJson['cacheScope'];
+    if (cacheScope != CacheScope.private && cacheScope != CacheScope.public) {
+      throw FormatException(
+        'MCP stateless ${request.method} responses must include '
+        'cacheScope "private" or "public"',
+      );
     }
   }
 

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -47,7 +47,12 @@ class DiscoveringClientTransport extends Transport
     this.capabilities = const ServerCapabilities(
       tools: ServerCapabilitiesTools(),
     ),
-    this.toolsListResult = const {'tools': []},
+    this.toolsListResult = const {
+      'resultType': resultTypeComplete,
+      'tools': [],
+      'ttlMs': 0,
+      'cacheScope': CacheScope.private,
+    },
   });
 
   final List<String> discoverVersions;
@@ -2928,12 +2933,45 @@ void main() {
       transport.onmessage?.call(
         JsonRpcResponse(
           id: subscription.id,
-          result: const EmptyResult().toJson(),
+          result: const {'resultType': resultTypeComplete},
         ),
       );
 
       await acknowledgedExpectation;
       await doneExpectation;
+    });
+
+    test('client rejects missing stateless resultType values', () async {
+      final transport = DiscoveringClientTransport(
+        toolsListResult: const {
+          'tools': [],
+          'ttlMs': 0,
+          'cacheScope': CacheScope.private,
+        },
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+
+      await client.connect(transport);
+
+      await expectLater(
+        client.listTools(),
+        throwsA(
+          isA<McpError>()
+              .having(
+                (error) => error.code,
+                'code',
+                ErrorCode.internalError.value,
+              )
+              .having(
+                (error) => error.data.toString(),
+                'data',
+                contains('must include resultType'),
+              ),
+        ),
+      );
     });
 
     test('client rejects unrecognized stateless resultType values', () async {
@@ -3004,6 +3042,77 @@ void main() {
         ),
       );
     });
+
+    for (final scenario in [
+      (
+        name: 'missing ttlMs',
+        result: const {
+          'resultType': resultTypeComplete,
+          'tools': [],
+          'cacheScope': CacheScope.private,
+        },
+        message: 'ttlMs',
+      ),
+      (
+        name: 'missing cacheScope',
+        result: const {
+          'resultType': resultTypeComplete,
+          'tools': [],
+          'ttlMs': 0,
+        },
+        message: 'cacheScope',
+      ),
+      (
+        name: 'negative ttlMs',
+        result: const {
+          'resultType': resultTypeComplete,
+          'tools': [],
+          'ttlMs': -1,
+          'cacheScope': CacheScope.private,
+        },
+        message: 'ttlMs',
+      ),
+      (
+        name: 'invalid cacheScope',
+        result: const {
+          'resultType': resultTypeComplete,
+          'tools': [],
+          'ttlMs': 0,
+          'cacheScope': 'shared',
+        },
+        message: 'cacheScope',
+      ),
+    ]) {
+      test('client rejects stateless cacheable result ${scenario.name}',
+          () async {
+        final transport = DiscoveringClientTransport(
+          toolsListResult: scenario.result,
+        );
+        final client = McpClient(
+          const Implementation(name: 'client', version: '1.0.0'),
+          options: const McpClientOptions(useServerDiscover: true),
+        );
+
+        await client.connect(transport);
+
+        await expectLater(
+          client.listTools(),
+          throwsA(
+            isA<McpError>()
+                .having(
+                  (error) => error.code,
+                  'code',
+                  ErrorCode.internalError.value,
+                )
+                .having(
+                  (error) => error.data.toString(),
+                  'data',
+                  contains(scenario.message),
+                ),
+          ),
+        );
+      });
+    }
 
     test('client accepts advertised task extension resultType values',
         () async {


### PR DESCRIPTION
## Summary
- require `resultType` on parsed stateless MCP 2026 responses
- require `ttlMs` and `cacheScope` on cacheable list/read complete results
- clear stale draft transport protocol state when falling back from `server/discover` to legacy `initialize`
- add 2026 RC negative regressions while preserving stable fallback compatibility

## Validation
- `dart format .`
- `dart analyze`
- `dart test test/mcp_2026_07_28_test.dart`
- `dart test test/client/client_test.dart test/mcp_2025_11_25_test.dart`
- `dart test`
- `git diff --check`
- `(cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json)`