### PR TITLE
Sanitize stateless HTTP session headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@
   clients on generic transports.
 - Rejected stateless MCP 2026 responses that omit `resultType` or required
   cacheable-result fields.
+- Stripped caller-supplied `Mcp-Session-Id` headers case-insensitively from
+  MCP 2026 stateless Streamable HTTP requests.
 
 ## 2.2.0
 

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -537,6 +537,19 @@ class StreamableHttpClientTransport
     return headers;
   }
 
+  void _removeHeaderCaseInsensitive(
+    Map<String, String> headers,
+    String headerName,
+  ) {
+    final normalizedHeaderName = headerName.toLowerCase();
+    final matchingKeys = headers.keys
+        .where((key) => key.toLowerCase() == normalizedHeaderName)
+        .toList();
+    for (final key in matchingKeys) {
+      headers.remove(key);
+    }
+  }
+
   Map<String, String> _headersForMessage(JsonRpcMessage message) {
     final headers = <String, String>{};
     final protocolVersion = _protocolVersion ?? _protocolVersionFrom(message);
@@ -1218,7 +1231,7 @@ class StreamableHttpClientTransport
       final isStatelessRequest = protocolVersion != null &&
           isStatelessProtocolVersion(protocolVersion);
       if (isStatelessRequest) {
-        headers.remove('mcp-session-id');
+        _removeHeaderCaseInsensitive(headers, 'mcp-session-id');
       }
       final requestSessionId = headers['mcp-session-id'];
       headers['content-type'] = 'application/json';

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -1089,6 +1089,11 @@ void main() {
       transport = StreamableHttpClientTransport(
         Uri.parse('http://localhost:${server.port}/mcp'),
         opts: const StreamableHttpClientTransportOptions(
+          requestInit: {
+            'headers': {
+              'Mcp-Session-Id': 'custom-session',
+            },
+          },
           sessionId: 'legacy-session',
         ),
       )..protocolVersion = draftProtocolVersion2026_07_28;


### PR DESCRIPTION
## Summary
- strip `Mcp-Session-Id` headers case-insensitively from MCP 2026 stateless Streamable HTTP requests
- cover caller-supplied mixed-case session headers in the existing stateless HTTP metadata regression
- document the behavior in the RC changelog

## Validation
- `dart format .`
- `dart analyze`
- `dart test test/client/streamable_https_test.dart --name "send adds 2026 stateless HTTP metadata headers"`
- `dart test test/client/streamable_https_test.dart`
- `dart test test/mcp_2026_07_28_test.dart`
- `dart test`
- `git diff --check`
- `(cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json)`