### PR TITLE
Derive stateless HTTP headers from nested metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@
   cacheable-result fields.
 - Stripped caller-supplied `Mcp-Session-Id` headers case-insensitively from
   MCP 2026 stateless Streamable HTTP requests.
+- Derived MCP 2026 stateless Streamable HTTP headers from nested
+  `params._meta` metadata for direct JSON-RPC transport sends.
 
 ## 2.2.0
 

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -715,11 +715,24 @@ class StreamableHttpClientTransport
   }
 
   Map<String, dynamic>? _metaFrom(JsonRpcMessage message) {
+    final Map<String, dynamic>? directMeta;
     if (message is JsonRpcRequest) {
-      return message.meta;
+      directMeta = message.meta;
+    } else if (message is JsonRpcNotification) {
+      directMeta = message.meta;
+    } else {
+      return null;
     }
-    if (message is JsonRpcNotification) {
-      return message.meta;
+    if (directMeta != null) {
+      return directMeta;
+    }
+
+    final paramsMeta = _paramsFrom(message)?['_meta'];
+    if (paramsMeta is Map<String, dynamic>) {
+      return paramsMeta;
+    }
+    if (paramsMeta is Map) {
+      return paramsMeta.cast<String, dynamic>();
     }
     return null;
   }

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -1124,6 +1124,68 @@ void main() {
       expect(transport.sessionId, 'legacy-session');
     });
 
+    test('send derives 2026 stateless HTTP headers from nested metadata',
+        () async {
+      final capturedHeaders = <String, String?>{};
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        capturedHeaders['protocolVersion'] =
+            request.headers.value('mcp-protocol-version');
+        capturedHeaders['method'] = request.headers.value('mcp-method');
+        capturedHeaders['name'] = request.headers.value('mcp-name');
+        capturedHeaders['session'] = request.headers.value('mcp-session-id');
+        final body = jsonDecode(await utf8.decodeStream(request))
+            as Map<String, dynamic>;
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(
+            jsonEncode(
+              JsonRpcResponse(
+                id: body['id'],
+                result: const {'content': []},
+              ).toJson(),
+            ),
+          );
+        await request.response.close();
+      });
+
+      transport = StreamableHttpClientTransport(
+        Uri.parse('http://localhost:${server.port}/mcp'),
+        opts: const StreamableHttpClientTransportOptions(
+          sessionId: 'legacy-session',
+        ),
+      );
+      await transport.start();
+
+      final completer = Completer<JsonRpcMessage>();
+      transport.onmessage = completer.complete;
+
+      await transport.send(
+        const JsonRpcRequest(
+          id: 1,
+          method: Method.toolsCall,
+          params: {
+            'name': 'echo',
+            'arguments': {'message': 'hello'},
+            '_meta': {
+              McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
+            },
+          },
+        ),
+      );
+      await completer.future.timeout(const Duration(seconds: 5));
+
+      expect(
+        capturedHeaders['protocolVersion'],
+        draftProtocolVersion2026_07_28,
+      );
+      expect(capturedHeaders['method'], Method.toolsCall);
+      expect(capturedHeaders['name'], 'echo');
+      expect(capturedHeaders['session'], isNull);
+    });
+
     test('send maps 2026 stateless headers for standard request types',
         () async {
       final capturedHeaders = <Map<String, String?>>[];

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -1186,6 +1186,63 @@ void main() {
       expect(capturedHeaders['session'], isNull);
     });
 
+    test('send accepts generic map nested metadata for stateless headers',
+        () async {
+      final capturedHeaders = <String, String?>{};
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        capturedHeaders['protocolVersion'] =
+            request.headers.value('mcp-protocol-version');
+        capturedHeaders['method'] = request.headers.value('mcp-method');
+        capturedHeaders['name'] = request.headers.value('mcp-name');
+        final body = jsonDecode(await utf8.decodeStream(request))
+            as Map<String, dynamic>;
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(
+            jsonEncode(
+              JsonRpcResponse(
+                id: body['id'],
+                result: const {'content': []},
+              ).toJson(),
+            ),
+          );
+        await request.response.close();
+      });
+
+      transport = StreamableHttpClientTransport(
+        Uri.parse('http://localhost:${server.port}/mcp'),
+      );
+      await transport.start();
+
+      final completer = Completer<JsonRpcMessage>();
+      transport.onmessage = completer.complete;
+
+      await transport.send(
+        const JsonRpcRequest(
+          id: 1,
+          method: Method.toolsCall,
+          params: {
+            'name': 'echo',
+            'arguments': {'message': 'hello'},
+            '_meta': <Object, Object>{
+              McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
+            },
+          },
+        ),
+      );
+      await completer.future.timeout(const Duration(seconds: 5));
+
+      expect(
+        capturedHeaders['protocolVersion'],
+        draftProtocolVersion2026_07_28,
+      );
+      expect(capturedHeaders['method'], Method.toolsCall);
+      expect(capturedHeaders['name'], 'echo');
+    });
+
     test('send maps 2026 stateless headers for standard request types',
         () async {
       final capturedHeaders = <Map<String, String?>>[];


### PR DESCRIPTION
## Summary
- derive MCP 2026 Streamable HTTP protocol/header behavior from `params._meta` when typed message `meta` is absent
- ensure direct raw JSON-RPC transport sends still emit `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` headers
- ensure nested-metadata stateless sends strip legacy session headers

## Validation
- `dart format .`
- `dart analyze`
- `dart test test/client/streamable_https_test.dart --name "send derives 2026 stateless HTTP headers from nested metadata"`
- `dart test test/client/streamable_https_test.dart`
- `dart test test/mcp_2026_07_28_test.dart`
- `dart test`
- `git diff --check`
- `(cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json)`