### PR TITLE
Allow stateless HTTP CORS parameter headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,8 @@
   MCP 2026 stateless Streamable HTTP requests.
 - Derived MCP 2026 stateless Streamable HTTP headers from nested
   `params._meta` metadata for direct JSON-RPC transport sends.
+- Allowed Streamable MCP server CORS preflights for 2026 stateless routing and
+  tool parameter headers, including requested `Mcp-Param-*` headers.
 
 ## 2.2.0
 

--- a/lib/src/server/streamable_mcp_server.dart
+++ b/lib/src/server/streamable_mcp_server.dart
@@ -7,8 +7,22 @@ import 'package:mcp_dart/src/server/dns_rebinding_protection.dart';
 import 'package:mcp_dart/src/server/mcp_server.dart';
 import 'package:mcp_dart/src/server/streamable_https.dart';
 import 'package:mcp_dart/src/shared/logging.dart';
+import 'package:mcp_dart/src/shared/mcp_header_validation.dart';
 import 'package:mcp_dart/src/shared/uuid.dart';
 import 'package:mcp_dart/src/types.dart';
+
+const List<String> _defaultCorsAllowedHeaders = [
+  'Origin',
+  'X-Requested-With',
+  'Content-Type',
+  'Accept',
+  'mcp-session-id',
+  'Last-Event-ID',
+  'Authorization',
+  'MCP-Protocol-Version',
+  'Mcp-Method',
+  'Mcp-Name',
+];
 
 String _quoteHeaderValue(String value) {
   const backslash = '\\';
@@ -344,7 +358,7 @@ class StreamableMcpServer {
   }
 
   Future<void> _handleRequest(HttpRequest request) async {
-    _setCorsHeaders(request.response);
+    _setCorsHeaders(request, request.response);
 
     if (enableDnsRebindingProtection &&
         !isRequestAllowedByDnsRebindingProtection(
@@ -899,13 +913,46 @@ class StreamableMcpServer {
     await response.close();
   }
 
-  void _setCorsHeaders(HttpResponse response) {
+  String _corsAllowedHeaders(HttpRequest request) {
+    final allowedHeaders = <String>[];
+    final seenHeaders = <String>{};
+
+    void addAllowedHeader(String headerName) {
+      final normalized = headerName.toLowerCase();
+      if (seenHeaders.add(normalized)) {
+        allowedHeaders.add(headerName);
+      }
+    }
+
+    for (final headerName in _defaultCorsAllowedHeaders) {
+      addAllowedHeader(headerName);
+    }
+
+    final requestedHeaders =
+        request.headers.value('access-control-request-headers');
+    if (requestedHeaders == null) {
+      return allowedHeaders.join(', ');
+    }
+
+    for (final rawHeaderName in requestedHeaders.split(',')) {
+      final headerName = rawHeaderName.trim();
+      if (headerName.isEmpty ||
+          !headerName.codeUnits.every(isHttpFieldNameTokenChar)) {
+        continue;
+      }
+      addAllowedHeader(headerName);
+    }
+
+    return allowedHeaders.join(', ');
+  }
+
+  void _setCorsHeaders(HttpRequest request, HttpResponse response) {
     response.headers.set('Access-Control-Allow-Origin', '*');
     response.headers
         .set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
     response.headers.set(
       'Access-Control-Allow-Headers',
-      'Origin, X-Requested-With, Content-Type, Accept, mcp-session-id, Last-Event-ID, Authorization, MCP-Protocol-Version',
+      _corsAllowedHeaders(request),
     );
     response.headers.set('Access-Control-Allow-Credentials', 'true');
     response.headers.set('Access-Control-Max-Age', defaultCorsMaxAgeSeconds);

--- a/test/server/streamable_mcp_server_test.dart
+++ b/test/server/streamable_mcp_server_test.dart
@@ -227,6 +227,28 @@ void main() {
       }
     });
 
+    test('CORS preflight allows stateless routing and parameter headers',
+        () async {
+      final client = http.Client();
+      try {
+        final req = http.Request('OPTIONS', Uri.parse(baseUrl))
+          ..headers['Access-Control-Request-Method'] = 'POST'
+          ..headers['Access-Control-Request-Headers'] =
+              'Mcp-Method, Mcp-Name, Mcp-Param-Region';
+        final streamedRes = await client.send(req);
+        final res = await http.Response.fromStream(streamedRes);
+        final allowedHeaders =
+            res.headers['access-control-allow-headers']!.toLowerCase();
+
+        expect(res.statusCode, HttpStatus.ok);
+        expect(allowedHeaders, contains('mcp-method'));
+        expect(allowedHeaders, contains('mcp-name'));
+        expect(allowedHeaders, contains('mcp-param-region'));
+      } finally {
+        client.close();
+      }
+    });
+
     test('initialize session flow', () async {
       final initRequest = JsonRpcRequest(
         id: 1,


### PR DESCRIPTION
## Summary
- include MCP 2026 stateless routing headers in StreamableMcpServer CORS allow-list
- echo syntactically valid requested preflight headers so browser clients can send tool-specific Mcp-Param-* headers
- cover stateless routing and parameter header preflight behavior

## Validation
- dart format .
- dart analyze
- git diff --check
- dart test test/server/streamable_mcp_server_test.dart --name "CORS preflight allows stateless routing and parameter headers"
- dart test test/server/streamable_mcp_server_test.dart
- dart test test/server/streamable_https_test.dart
- dart test test/client/streamable_https_test.dart
- dart test test/mcp_2026_07_28_test.dart
- dart test
- (cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json)