### PR TITLE
Align MRTR input response result shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,8 @@
   `params._meta` metadata for direct JSON-RPC transport sends.
 - Allowed Streamable MCP server CORS preflights for 2026 stateless routing and
   tool parameter headers, including requested `Mcp-Param-*` headers.
+- Serialized MRTR `ElicitResult` and `ListRootsResult` input responses with the
+  MCP 2026 embedded client-result shapes that omit common Result `_meta`.
 
 ## 2.2.0
 

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -770,17 +770,13 @@ class InputResponse {
 
   /// Creates an input response from a typed MCP result.
   factory InputResponse.fromResult(BaseResultData result) {
-    return InputResponse.raw(result.toJson());
+    return InputResponse.raw(_inputResponseJsonForResult(result));
   }
 
   factory InputResponse.fromJson(Map<String, dynamic> json) {
-    if (!_isValidInputResponse(json)) {
-      throw const FormatException(
-        'InputResponse must be a CreateMessageResult, ListRootsResult, '
-        'or ElicitResult',
-      );
-    }
-    return InputResponse.raw(Map<String, dynamic>.from(json));
+    final value = Map<String, dynamic>.from(json);
+    _validateInputResponse(value);
+    return InputResponse.raw(value);
   }
 
   /// Parses an input response map.
@@ -804,13 +800,49 @@ class InputResponse {
     );
   }
 
-  Map<String, dynamic> toJson() => readJsonObject(value, 'InputResponse');
+  Map<String, dynamic> toJson() {
+    final json = readJsonObject(value, 'InputResponse');
+    _validateInputResponse(json);
+    return json;
+  }
 }
 
-bool _isValidInputResponse(Map<String, dynamic> json) {
-  return _canParseInputResponse(CreateMessageResult.fromJson, json) ||
-      _canParseInputResponse(ListRootsResult.fromJson, json) ||
-      _canParseInputResponse(ElicitResult.fromJson, json);
+Map<String, dynamic> _inputResponseJsonForResult(BaseResultData result) {
+  final json = Map<String, dynamic>.from(result.toJson());
+  if (result is ElicitResult || result is ListRootsResult) {
+    json.remove('_meta');
+  }
+  _validateInputResponse(json);
+  return json;
+}
+
+void _validateInputResponse(Map<String, dynamic> json) {
+  if (_canParseInputResponse(CreateMessageResult.fromJson, json)) {
+    return;
+  }
+
+  if (_canParseInputResponse(ListRootsResult.fromJson, json)) {
+    _rejectInputResponseMeta(json, 'ListRootsResult');
+    return;
+  }
+
+  if (_canParseInputResponse(ElicitResult.fromJson, json)) {
+    _rejectInputResponseMeta(json, 'ElicitResult');
+    return;
+  }
+
+  throw const FormatException(
+    'InputResponse must be a CreateMessageResult, ListRootsResult, '
+    'or ElicitResult',
+  );
+}
+
+void _rejectInputResponseMeta(Map<String, dynamic> json, String resultName) {
+  if (json.containsKey('_meta')) {
+    throw FormatException(
+      'InputResponse $resultName must not include _meta in MCP 2026',
+    );
+  }
 }
 
 bool _canParseInputResponse(

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -657,10 +657,22 @@ void main() {
           const ElicitResult(
             action: 'accept',
             content: {'name': 'octocat'},
+            meta: {'stable': true},
           ),
         ),
         'roots': InputResponse.fromResult(
-          ListRootsResult(roots: [Root(uri: 'file:///repo')]),
+          ListRootsResult(
+            roots: [Root(uri: 'file:///repo')],
+            meta: const {'stable': true},
+          ),
+        ),
+        'capital_of_france': InputResponse.fromResult(
+          const CreateMessageResult(
+            model: 'model',
+            role: SamplingMessageRole.assistant,
+            content: SamplingTextContent(text: 'Paris'),
+            meta: {'preserved': true},
+          ),
         ),
       };
 
@@ -672,6 +684,14 @@ void main() {
       );
       final toolJson = toolRequest.toJson();
       expect(toolJson['inputResponses']['github_login']['action'], 'accept');
+      expect(
+        toolJson['inputResponses']['github_login'],
+        isNot(contains('_meta')),
+      );
+      expect(toolJson['inputResponses']['roots'], isNot(contains('_meta')));
+      expect(toolJson['inputResponses']['capital_of_france']['_meta'], {
+        'preserved': true,
+      });
       expect(toolJson['requestState'], 'opaque-state');
 
       final parsedToolRequest = CallToolRequest.fromJson(toolJson);
@@ -799,6 +819,27 @@ void main() {
             },
           },
         ),
+        throwsFormatException,
+      );
+      expect(
+        () => ReadResourceRequest.fromJson(
+          const {
+            'uri': 'file:///repo/README.md',
+            'inputResponses': {
+              'roots': {
+                'roots': [],
+                '_meta': {'trace': 'not-in-draft-client-result'},
+              },
+            },
+          },
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => const InputResponse.raw({
+          'action': 'accept',
+          '_meta': {'trace': 'not-in-draft-client-result'},
+        }).toJson(),
         throwsFormatException,
       );
     });


### PR DESCRIPTION
## Summary
- serialize MRTR ElicitResult and ListRootsResult input responses using the MCP 2026 embedded client-result shapes without common Result _meta
- preserve CreateMessageResult sampling metadata where the draft schema still permits message _meta
- validate raw/wire MRTR input responses so deprecated client-result _meta is rejected in 2026 inputResponses

## Validation
- dart format .
- dart analyze
- git diff --check
- dart test test/mcp_2026_07_28_test.dart --name "serializes MRTR retry fields on supported client requests|rejects malformed MRTR wire shapes"
- dart test test/mcp_2026_07_28_test.dart
- dart test
- (cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json)