### PR TITLE
Dispatch numeric progress tokens end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,8 @@
 - Accepted finite numeric JSON-RPC request IDs and progress tokens, matching
   the stable and MCP 2026 `string | number` schema while continuing to reject
   non-finite numbers.
+- Allowed protocol progress handlers and `RequestHandlerExtra.sendProgress` to
+  dispatch finite numeric progress tokens end-to-end.
 
 ## 2.2.0
 

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -9,7 +9,8 @@ import 'transport.dart';
 
 final _logger = Logger("mcp_dart.shared.protocol");
 
-bool _isProgressToken(Object? token) => token is int || token is String;
+bool _isProgressToken(Object? token) =>
+    token is String || (token is num && token.isFinite);
 
 const Set<String> _statelessCacheableResultMethods = {
   Method.toolsList,
@@ -200,10 +201,10 @@ class RequestHandlerExtra {
       return;
     }
 
-    // progressToken can be int or string
-    if (progressToken is! int && progressToken is! String) {
+    if (!_isProgressToken(progressToken)) {
       _logger.warn(
-        "Invalid progressToken type: ${progressToken.runtimeType}. Expected int or String.",
+        "Invalid progressToken type: ${progressToken.runtimeType}. "
+        "Expected string or finite number.",
       );
       return;
     }
@@ -1426,7 +1427,8 @@ abstract class Protocol {
     if (!_isProgressToken(progressToken)) {
       _onerror(
         ArgumentError(
-          "Received invalid progressToken: $progressToken. Expected int or String.",
+          "Received invalid progressToken: $progressToken. "
+          "Expected string or finite number.",
         ),
       );
       return;
@@ -1648,7 +1650,8 @@ abstract class Protocol {
         if (!_isProgressToken(requestedProgressToken)) {
           return Future.error(
             ArgumentError(
-              'progressToken must be an int or String when onprogress is set.',
+              'progressToken must be a string or finite number when '
+              'onprogress is set.',
             ),
           );
         }

--- a/packages/mcp_dart_cli/README.md
+++ b/packages/mcp_dart_cli/README.md
@@ -127,7 +127,7 @@ The CLI supports `sampling/createMessage` requests from the server (often used b
 
 ### Conformance
 
-Run built-in fixture checks, MCP 2025-11-25 spec-critical checks, and deterministic fuzz checks for MCP protocol edge cases. The fixture suite covers JSON-RPC malformed-message handling, string and numeric request IDs, string and numeric progress tokens, and advertised protocol-version support. The spec suite covers raw-wire lifecycle, capability, elicitation, task-metadata, and progress-token negative cases.
+Run built-in fixture checks, MCP 2025-11-25 spec-critical checks, and deterministic fuzz checks for MCP protocol edge cases. The fixture suite covers JSON-RPC malformed-message handling, string and numeric request IDs, string and numeric progress tokens, and advertised protocol-version support. The spec suite covers raw-wire lifecycle, capability, elicitation, task-metadata, and progress-token dispatch and negative cases.
 
 ```bash
 # Run all built-in fixture cases

--- a/packages/mcp_dart_cli/lib/src/conformance_runner.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_runner.dart
@@ -168,6 +168,13 @@ class ConformanceRunner {
                 'Rejects progress notifications whose progressToken is not a string or finite number.',
             check: _rejectsMalformedProgressToken,
           ),
+          _ConformanceCase(
+            suite: _specSuite,
+            name: 'progress.dispatches-numeric-progress-token',
+            description:
+                'Dispatches progress notifications for finite numeric progress tokens.',
+            check: _dispatchesNumericProgressToken,
+          ),
         ];
 
   /// Runs one named conformance suite.
@@ -639,6 +646,64 @@ Future<void> _rejectsMalformedProgressToken() async {
       },
     }),
   );
+}
+
+Future<void> _dispatchesNumericProgressToken() async {
+  final transport = _ConformanceTransport();
+  final server = McpServer(
+    const Implementation(name: 'server', version: '1.0.0'),
+    options: const McpServerOptions(
+      capabilities: ServerCapabilities(tools: ServerCapabilitiesTools()),
+    ),
+  );
+  server.registerTool(
+    'progress_probe',
+    callback: (args, extra) async {
+      await extra.sendProgress(1, total: 2, message: 'halfway');
+      return const CallToolResult(
+        content: <Content>[TextContent(text: 'ok')],
+      );
+    },
+  );
+
+  await _initializeMcpServer(server, transport);
+  transport.emit(
+    const JsonRpcCallToolRequest(
+      id: 104,
+      params: <String, dynamic>{
+        'name': 'progress_probe',
+        'arguments': <String, dynamic>{},
+        '_meta': <String, dynamic>{
+          'progressToken': 1.5,
+        },
+      },
+    ),
+  );
+  await _settle();
+
+  final progressMessages = transport.sentMessages
+      .whereType<JsonRpcNotification>()
+      .where((message) => message.method == Method.notificationsProgress)
+      .toList();
+  if (progressMessages.length != 1) {
+    throw StateError(
+      'Expected one progress notification, got ${progressMessages.length}.',
+    );
+  }
+  final progress = ProgressNotification.fromJson(
+    progressMessages.single.params ?? const <String, dynamic>{},
+  );
+  if (progress.progressToken != 1.5) {
+    throw StateError('Expected numeric progress token to be preserved.');
+  }
+  if (progress.progress != 1 || progress.total != 2) {
+    throw StateError('Expected progress values to be preserved.');
+  }
+
+  final responses =
+      transport.sentMessages.whereType<JsonRpcResponse>().toList();
+  _expectSingleErrorFreeResponse(responses, id: 104);
+  await server.close();
 }
 
 Future<void> _rejectsInvalidJsonRpcVersion() async {

--- a/packages/mcp_dart_cli/test/src/conformance_command_test.dart
+++ b/packages/mcp_dart_cli/test/src/conformance_command_test.dart
@@ -42,6 +42,7 @@ void main() {
           'elicitation.rejects-invalid-form-url-union',
           'tasks.strips-unnegotiated-related-task-metadata',
           'progress.rejects-malformed-progress-token',
+          'progress.dispatches-numeric-progress-token',
         ]),
       );
       expect(

--- a/test/shared/progress_test.dart
+++ b/test/shared/progress_test.dart
@@ -264,6 +264,69 @@ void main() {
       expect(msg3, isA<JsonRpcResponse>());
     });
 
+    test('Server sends progress with finite numeric progress token', () async {
+      protocol.setRequestHandler<JsonRpcRequest>(
+        'test/numeric-token-task',
+        (request, extra) async {
+          await extra.sendProgress(10, total: 100, message: 'Starting');
+          return TestResult(value: 'success');
+        },
+        (id, params, meta) => JsonRpcRequest(
+          id: id,
+          method: 'test/numeric-token-task',
+          params: params,
+          meta: meta,
+        ),
+      );
+
+      const progressToken = 12345.5;
+      transport.receiveMessage(
+        const JsonRpcRequest(
+          id: 99,
+          method: 'test/numeric-token-task',
+          meta: {'progressToken': progressToken},
+        ),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(transport.sentMessages.length, 2);
+
+      final msg1 = transport.sentMessages[0];
+      expect(msg1, isA<JsonRpcNotification>());
+      expect((msg1 as JsonRpcNotification).method, 'notifications/progress');
+      expect(msg1.params, isNotNull);
+      expect(msg1.params!['progressToken'], progressToken);
+      expect(msg1.params!['progress'], 10);
+      expect(msg1.params!['message'], 'Starting');
+
+      final msg2 = transport.sentMessages[1];
+      expect(msg2, isA<JsonRpcResponse>());
+    });
+
+    test('RequestHandlerExtra ignores non-finite progress token', () async {
+      final sentNotifications = <JsonRpcNotification>[];
+      final extra = RequestHandlerExtra(
+        signal: BasicAbortController().signal,
+        requestId: 101,
+        meta: const {'progressToken': double.nan},
+        sendNotification: (notification, {relatedTask}) async {
+          sentNotifications.add(notification);
+        },
+        sendRequest: <T extends BaseResultData>(
+          JsonRpcRequest request,
+          T Function(Map<String, dynamic>) resultFactory,
+          RequestOptions options,
+        ) async {
+          return resultFactory({});
+        },
+      );
+
+      await extra.sendProgress(10);
+
+      expect(sentNotifications, isEmpty);
+    });
+
     test('RequestHandlerExtra rejects non-increasing progress', () async {
       final sentNotifications = <JsonRpcNotification>[];
       final extra = RequestHandlerExtra(

--- a/test/shared/protocol_test.dart
+++ b/test/shared/protocol_test.dart
@@ -617,6 +617,59 @@ void main() {
       expect(result.value, 'response-data');
     });
 
+    test('dispatches finite numeric progress tokens from request metadata',
+        () async {
+      await protocol.connect(transport);
+
+      final progressUpdates = <Progress>[];
+      final requestFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 1.5},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(
+              onprogress: progressUpdates.add,
+              timeout: const Duration(seconds: 1),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      expect(transport.sentMessages, hasLength(1));
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      expect(sentRequest.meta?['progressToken'], 1.5);
+
+      transport.receiveMessage(
+        JsonRpcProgressNotification(
+          progressParams: const ProgressNotification(
+            progressToken: 1.5,
+            progress: 50,
+            total: 100,
+            message: 'halfway',
+          ),
+        ),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(progressUpdates, hasLength(1));
+      expect(progressUpdates.single.progress, 50);
+      expect(progressUpdates.single.total, 100);
+      expect(progressUpdates.single.message, 'halfway');
+
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {'value': 'response-data'},
+        ),
+      );
+
+      final result = await requestFuture;
+      expect(result.value, 'response-data');
+    });
+
     test('task options serialize as task-augmented request params', () async {
       await protocol.connect(transport);
 
@@ -1136,6 +1189,27 @@ void main() {
             id: 0,
             method: 'test/method',
             meta: {'progressToken': false},
+          ),
+          (json) => TestResult(value: json['value'] as String),
+          RequestOptions(onprogress: (_) {}),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      expect(transport.sentMessages, isEmpty);
+    });
+
+    test(
+        'rejects non-finite request progress tokens when progress handler is set',
+        () async {
+      await protocol.connect(transport);
+
+      await expectLater(
+        protocol.request<TestResult>(
+          const JsonRpcRequest(
+            id: 0,
+            method: 'test/method',
+            meta: {'progressToken': double.nan},
           ),
           (json) => TestResult(value: json['value'] as String),
           RequestOptions(onprogress: (_) {}),


### PR DESCRIPTION
## Summary
- allow protocol progress-token validation to accept finite numeric values, not only integer/string values
- dispatch fractional numeric progress tokens through client progress handlers and server `RequestHandlerExtra.sendProgress`
- add protocol/progress regression tests plus a CLI conformance spec case for numeric progress dispatch

## Spec Context
- Official MCP stable and draft schemas define `ProgressToken` as `string | number`.
- This remains draft-only RC stack work and targets the previous stack branch, not `main`.

## Verification
- `dart format .`
- `dart analyze`
- `git diff --check`
- `dart test`
- `dart test test/shared/protocol_test.dart --name "progress tokens"`
- `dart test test/shared/progress_test.dart --name "progress token"`
- `cd packages/mcp_dart_cli && dart test test/src/conformance_command_test.dart`
- `cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json`
