### PR TITLE
Preserve related request ID shapes in protocol APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,8 @@
   non-finite numbers.
 - Allowed protocol progress handlers and `RequestHandlerExtra.sendProgress` to
   dispatch finite numeric progress tokens end-to-end.
+- Widened protocol `relatedRequestId` API parameters to preserve string and
+  finite numeric JSON-RPC request IDs through request and notification routing.
 
 ## 2.2.0
 

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -498,7 +498,7 @@ class McpClient extends Protocol {
     JsonRpcRequest requestData,
     T Function(Map<String, dynamic> resultJson) resultFactory, [
     RequestOptions? options,
-    int? relatedRequestId,
+    RequestId? relatedRequestId,
   ]) async {
     _assertStatelessRequestAllowed(requestData.method);
 
@@ -562,7 +562,7 @@ class McpClient extends Protocol {
   Future<void> notification(
     JsonRpcNotification notificationData, {
     RelatedTaskMetadata? relatedTask,
-    int? relatedRequestId,
+    RequestId? relatedRequestId,
   }) async {
     _assertStatelessNotificationAllowed(notificationData.method);
     await super.notification(

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -1574,7 +1574,7 @@ abstract class Protocol {
     JsonRpcRequest requestData,
     T Function(Map<String, dynamic> resultJson) resultFactory, [
     RequestOptions? options,
-    int? relatedRequestId,
+    RequestId? relatedRequestId,
   ]) {
     return _requestWithRequestId(
       requestData,
@@ -1961,7 +1961,7 @@ abstract class Protocol {
   Future<void> notification(
     JsonRpcNotification notificationData, {
     RelatedTaskMetadata? relatedTask,
-    int? relatedRequestId,
+    RequestId? relatedRequestId,
   }) {
     return _notificationWithRequestId(
       notificationData,

--- a/test/client/task_client_test.dart
+++ b/test/client/task_client_test.dart
@@ -29,7 +29,7 @@ class MockClient implements McpClient {
     JsonRpcRequest request,
     T Function(Map<String, dynamic> json) parser, [
     RequestOptions? options,
-    int? relatedRequestId,
+    RequestId? relatedRequestId,
   ]) async {
     requests.add(request);
 

--- a/test/shared/protocol_test.dart
+++ b/test/shared/protocol_test.dart
@@ -477,6 +477,47 @@ void main() {
       expect(response.result['value'], 'nested-ok');
     });
 
+    test('public request preserves string relatedRequestId', () async {
+      await protocol.connect(transport);
+
+      final requestFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(id: 0, method: 'test/method'),
+            (json) => TestResult(value: json['value'] as String),
+            const RequestOptions(timeout: Duration(seconds: 1)),
+            'parent-req-1',
+          )
+          .timeout(const Duration(seconds: 5));
+
+      await waitForSentMessages(transport, 1);
+
+      expect(transport.sentMessages[0], isA<JsonRpcRequest>());
+      expect(transport.relatedRequestIds[0], 'parent-req-1');
+
+      final request = transport.sentMessages[0] as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: request.id,
+          result: {'value': 'ok'},
+        ),
+      );
+
+      expect((await requestFuture).value, 'ok');
+    });
+
+    test('public notification preserves finite numeric relatedRequestId',
+        () async {
+      await protocol.connect(transport);
+
+      await protocol.notification(
+        const JsonRpcNotification(method: 'test/notification'),
+        relatedRequestId: 1.5,
+      );
+
+      expect(transport.sentMessages.single, isA<JsonRpcNotification>());
+      expect(transport.relatedRequestIds.single, 1.5);
+    });
+
     test('routes nested cancellation notifications for string request IDs',
         () async {
       await protocol.connect(transport);


### PR DESCRIPTION
## Summary
- widen public Protocol and McpClient relatedRequestId parameters from int? to RequestId?
- preserve string and finite numeric related request IDs through request and notification routing
- add regression coverage for public request/notification routing and update task-client mock overrides

## Validation
- dart format .
- dart analyze
- git diff --check
- dart test
- cd packages/mcp_dart_cli && dart test test/src/conformance_command_test.dart
- cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json

Draft stacked PR for the MCP 2026-07-28 RC work. Base is the prior stack branch, not main.