### PR TITLE
Allow finite numeric elicitation content values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,8 +88,8 @@
   clamping malformed wire values to zero.
 - Validated MRTR `inputResponses` as `CreateMessageResult`, `ListRootsResult`,
   or `ElicitResult` instead of accepting arbitrary result objects.
-- Rejected non-integer numeric `ElicitResult.content` values to match the
-  stable and MCP 2026 schemas.
+- Allowed finite numeric `ElicitResult.content` values to match the stable and
+  MCP 2026 `string | number | boolean | string[]` schema.
 - Rejected form elicitation schemas that provide legacy `enumNames` without the
   required string `enum`.
 - Rejected `ElicitResult.content` when the result action is `decline` or

--- a/lib/src/types/elicitation.dart
+++ b/lib/src/types/elicitation.dart
@@ -634,7 +634,10 @@ void _validateElicitResultContent(
   }
   for (final entry in content.entries) {
     final value = entry.value;
-    if (value is String || value is int || value is bool) {
+    if (value is String || value is bool) {
+      continue;
+    }
+    if (value is num && value.isFinite) {
       continue;
     }
     if (value is List && value.every((item) => item is String)) {
@@ -642,13 +645,13 @@ void _validateElicitResultContent(
     }
     if (formatException) {
       throw FormatException(
-        'ElicitResult.content.${entry.key} must be string, integer, boolean, or string[]',
+        'ElicitResult.content.${entry.key} must be string, finite number, boolean, or string[]',
       );
     }
     throw ArgumentError.value(
       value,
       'content.${entry.key}',
-      'ElicitResult content values must be string, integer, boolean, or string[]',
+      'ElicitResult content values must be string, finite number, boolean, or string[]',
     );
   }
 }

--- a/test/elicitation_test.dart
+++ b/test/elicitation_test.dart
@@ -1060,13 +1060,13 @@ void main() {
         throwsA(isA<FormatException>()),
       );
       expect(
-        () => ElicitResult.fromJson({
+        ElicitResult.fromJson({
           'action': 'accept',
           'content': {
             'ratio': 0.5,
           },
-        }),
-        throwsA(isA<FormatException>()),
+        }).content?['ratio'],
+        0.5,
       );
       expect(
         () => ElicitResult.fromJson({
@@ -1087,13 +1087,13 @@ void main() {
         throwsA(isA<ArgumentError>()),
       );
       expect(
-        () => const ElicitResult(
+        const ElicitResult(
           action: 'accept',
           content: {
             'ratio': 0.5,
           },
-        ).toJson(),
-        throwsA(isA<ArgumentError>()),
+        ).toJson()['content'],
+        containsPair('ratio', 0.5),
       );
       expect(
         () => const ElicitResult(

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -326,14 +326,17 @@ void main() {
         action: 'accept',
         content: {
           'text': 'answer',
+          'confidence': 0.75,
           'selection': ['a', 'b'], // List<String>
         },
       );
+      expect(result.content?['confidence'], 0.75);
       expect(result.content?['selection'], isA<List>());
       expect((result.content?['selection'] as List).first, 'a');
 
       final json = result.toJson();
       final deserialized = ElicitResult.fromJson(json);
+      expect(deserialized.content?['confidence'], 0.75);
       expect((deserialized.content?['selection'] as List).last, 'b');
     });
 

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -390,6 +390,20 @@ void main() {
         }),
         throwsA(isA<FormatException>()),
       );
+      expect(
+        () => ElicitResult.fromJson({
+          'action': 'accept',
+          'content': {'score': double.infinity},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ElicitResult(
+          action: 'accept',
+          content: {'score': double.nan},
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
     });
 
     test('rejects non-JSON sampling object values', () {


### PR DESCRIPTION
## Summary
- allow finite numeric `ElicitResult.content` values, matching the stable and MCP 2026 `string | number | boolean | string[]` schema
- keep non-finite numeric values rejected at parse/serialize boundaries
- update stable, RC, and elicitation regression tests that previously assumed integer-only content

## Validation
- dart format .
- dart analyze
- git diff --check
- dart test
- cd packages/mcp_dart_cli && dart test test/src/conformance_command_test.dart
- cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json

Draft stacked PR for the MCP 2026-07-28 RC work. Base is the prior stack branch, not main.