### PR TITLE
Match MRTR sampling input response shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,8 +119,9 @@
   `params._meta` metadata for direct JSON-RPC transport sends.
 - Allowed Streamable MCP server CORS preflights for 2026 stateless routing and
   tool parameter headers, including requested `Mcp-Param-*` headers.
-- Serialized MRTR `ElicitResult` and `ListRootsResult` input responses with the
-  MCP 2026 embedded client-result shapes that omit common Result `_meta`.
+- Serialized MRTR `CreateMessageResult`, `ElicitResult`, and `ListRootsResult`
+  input responses with the MCP 2026 embedded client-result shapes that omit
+  common Result `_meta`.
 - Accepted finite numeric JSON-RPC request IDs and progress tokens, matching
   the stable and MCP 2026 `string | number` schema while continuing to reject
   non-finite numbers.

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -821,7 +821,9 @@ class InputResponse {
 
 Map<String, dynamic> _inputResponseJsonForResult(BaseResultData result) {
   final json = Map<String, dynamic>.from(result.toJson());
-  if (result is ElicitResult || result is ListRootsResult) {
+  if (result is CreateMessageResult ||
+      result is ElicitResult ||
+      result is ListRootsResult) {
     json.remove('_meta');
   }
   _validateInputResponse(json);
@@ -830,6 +832,7 @@ Map<String, dynamic> _inputResponseJsonForResult(BaseResultData result) {
 
 void _validateInputResponse(Map<String, dynamic> json) {
   if (_canParseInputResponse(CreateMessageResult.fromJson, json)) {
+    _rejectInputResponseMeta(json, 'CreateMessageResult');
     return;
   }
 

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -723,9 +723,10 @@ void main() {
         isNot(contains('_meta')),
       );
       expect(toolJson['inputResponses']['roots'], isNot(contains('_meta')));
-      expect(toolJson['inputResponses']['capital_of_france']['_meta'], {
-        'preserved': true,
-      });
+      expect(
+        toolJson['inputResponses']['capital_of_france'],
+        isNot(contains('_meta')),
+      );
       expect(toolJson['requestState'], 'opaque-state');
 
       final parsedToolRequest = CallToolRequest.fromJson(toolJson);
@@ -872,6 +873,15 @@ void main() {
       expect(
         () => const InputResponse.raw({
           'action': 'accept',
+          '_meta': {'trace': 'not-in-draft-client-result'},
+        }).toJson(),
+        throwsFormatException,
+      );
+      expect(
+        () => const InputResponse.raw({
+          'model': 'model',
+          'role': 'assistant',
+          'content': {'type': 'text', 'text': 'Paris'},
           '_meta': {'trace': 'not-in-draft-client-result'},
         }).toJson(),
         throwsFormatException,


### PR DESCRIPTION
## Summary
- strip top-level `_meta` from embedded `CreateMessageResult` MRTR input responses for MCP 2026
- reject raw sampling input responses that include common Result `_meta`
- update RC MRTR retry-shape tests and changelog coverage

## Validation
- dart format .
- dart analyze
- git diff --check
- dart test
- cd packages/mcp_dart_cli && dart test test/src/conformance_command_test.dart
- cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json

Draft stacked PR for the MCP 2026-07-28 RC work. Base is the prior stack branch, not main.