### PR TITLE
Validate JSON-RPC error data values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@
   and tool object fields.
 - Rejected non-JSON values in JSON-RPC envelope and remaining typed result
   metadata fields.
+- Rejected non-JSON JSON-RPC error `data` values at parse and serialize
+  boundaries.
 - Prevented stateless MCP 2026 clients from sending core request and
   notification methods removed from that protocol revision.
 - Rejected server-initiated JSON-RPC requests received by stateless MCP 2026

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -583,13 +583,15 @@ class JsonRpcErrorData {
       JsonRpcErrorData(
         code: json['code'] as int,
         message: json['message'] as String,
-        data: json['data'],
+        data: json.containsKey('data')
+            ? readJsonValue(json['data'], 'JsonRpcErrorData.data')
+            : null,
       );
 
   Map<String, dynamic> toJson() => {
         'code': code,
         'message': message,
-        if (data != null) 'data': data,
+        if (data != null) 'data': readJsonValue(data, 'JsonRpcErrorData.data'),
       };
 }
 

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -53,6 +53,33 @@ void main() {
       final restored = JsonRpcErrorData.fromJson(json);
       expect(restored.data['nested']['level'], equals(2));
     });
+
+    test('JsonRpcErrorData rejects non-JSON data values', () {
+      expect(
+        () => const JsonRpcErrorData(
+          code: -32600,
+          message: 'Bad data',
+          data: {'bad': Object()},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const JsonRpcErrorData(
+          code: -32600,
+          message: 'Bad number',
+          data: {'score': double.infinity},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => JsonRpcErrorData.fromJson({
+          'code': -32600,
+          'message': 'Bad data',
+          'data': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
   });
 
   group('JsonRpcCancelledNotification Edge Cases', () {


### PR DESCRIPTION
## Summary
- validate JSON-RPC error `data` as a JSON value when parsing and serializing
- reject non-JSON Dart objects and non-finite numbers before transport encoding
- add edge-case coverage for valid nested data and invalid data values

## Validation
- dart format .
- dart analyze
- git diff --check
- dart test
- cd packages/mcp_dart_cli && dart test test/src/conformance_command_test.dart
- cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json

Draft stacked PR for the MCP 2026-07-28 RC work. Base is the prior stack branch, not main.