### PR TITLE
Reject JSON-RPC responses with result and error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,8 @@
   metadata fields.
 - Rejected non-JSON JSON-RPC error `data` values at parse and serialize
   boundaries.
+- Rejected JSON-RPC response envelopes that include both `result` and `error`
+  instead of silently treating them as successful responses.
 - Prevented stateless MCP 2026 clients from sending core request and
   notification methods removed from that protocol revision.
 - Rejected server-initiated JSON-RPC requests received by stateless MCP 2026

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -313,6 +313,9 @@ sealed class JsonRpcMessage {
       throw FormatException('Invalid JSON-RPC version: ${json['jsonrpc']}');
     }
 
+    final hasResult = json.containsKey('result');
+    final hasError = json.containsKey('error');
+
     if (json.containsKey('method')) {
       final method = json['method'] as String;
       final hasId = json.containsKey('id');
@@ -408,7 +411,11 @@ sealed class JsonRpcMessage {
             ),
         };
       }
-    } else if (json.containsKey('result')) {
+    } else if (hasResult && hasError) {
+      throw const FormatException(
+        'Invalid JSON-RPC response: result and error are mutually exclusive',
+      );
+    } else if (hasResult) {
       final id = _parseResultResponseId(json['id']);
       final resultData =
           readJsonObject(json['result'], 'JsonRpcResponse.result');
@@ -419,7 +426,7 @@ sealed class JsonRpcMessage {
       final actualResult = Map<String, dynamic>.from(resultData)
         ..remove('_meta');
       return JsonRpcResponse(id: id, result: actualResult, meta: meta);
-    } else if (json.containsKey('error')) {
+    } else if (hasError) {
       return JsonRpcError.fromJson(json);
     } else {
       throw FormatException('Invalid JSON-RPC message format: $json');

--- a/packages/mcp_dart_cli/lib/src/conformance_runner.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_runner.dart
@@ -98,6 +98,13 @@ class ConformanceRunner {
           ),
           _ConformanceCase(
             suite: _fixtureSuite,
+            name: 'jsonrpc.rejects-result-error-response',
+            description:
+                'Rejects JSON-RPC responses that include both result and error members.',
+            check: _rejectsResultErrorJsonRpcResponse,
+          ),
+          _ConformanceCase(
+            suite: _fixtureSuite,
             name: 'jsonrpc.preserves-string-response-id',
             description:
                 'Parses and serializes successful responses with string JSON-RPC IDs.',
@@ -721,6 +728,20 @@ Future<void> _rejectsMalformedJsonRpcMessage() async {
     () => JsonRpcMessage.fromJson(const <String, dynamic>{
       'jsonrpc': jsonRpcVersion,
       'id': 1,
+    }),
+  );
+}
+
+Future<void> _rejectsResultErrorJsonRpcResponse() async {
+  _expectThrowsFormatException(
+    () => JsonRpcMessage.fromJson(<String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 1,
+      'result': <String, dynamic>{},
+      'error': <String, dynamic>{
+        'code': ErrorCode.internalError.value,
+        'message': 'Internal error',
+      },
     }),
   );
 }

--- a/packages/mcp_dart_cli/test/src/conformance_command_test.dart
+++ b/packages/mcp_dart_cli/test/src/conformance_command_test.dart
@@ -20,6 +20,7 @@ void main() {
         containsAll(<String>[
           'jsonrpc.rejects-invalid-version',
           'jsonrpc.rejects-malformed-message',
+          'jsonrpc.rejects-result-error-response',
           'jsonrpc.preserves-string-response-id',
           'jsonrpc.preserves-numeric-response-id',
           'jsonrpc.preserves-string-progress-token',

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -559,6 +559,22 @@ void main() {
       }
     });
 
+    test('rejects response envelopes with both result and error', () {
+      expect(
+        () => JsonRpcMessage.fromJson({
+          'jsonrpc': '2.0',
+          'id': 1,
+          'result': {'data': 'test'},
+          'error': {'code': -32603, 'message': 'Internal error'},
+        }),
+        throwsA(
+          isA<FormatException>()
+              .having((e) => e.message, 'message', contains('result'))
+              .having((e) => e.message, 'message', contains('error')),
+        ),
+      );
+    });
+
     test('handles error with null id', () {
       final json = {
         'jsonrpc': '2.0',


### PR DESCRIPTION
## Summary
- reject JSON-RPC response envelopes that include both `result` and `error`
- add unit and CLI conformance coverage for the malformed response case
- update the unreleased MCP 2026 RC changelog

## Validation
- `dart format .`
- `dart analyze`
- `git diff --check`
- `dart test test/types_edge_cases_test.dart`
- `(cd packages/mcp_dart_cli && dart test test/src/conformance_command_test.dart && dart run mcp_dart_cli:mcp_dart conformance --suite all --json)`
- `dart test`