### PR TITLE
Validate JSON-RPC method wire values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@
   boundaries.
 - Rejected JSON-RPC response envelopes that include both `result` and `error`
   instead of silently treating them as successful responses.
+- Rejected JSON-RPC request and notification envelopes whose `method` member is
+  not a string, and validated generic request `params` as JSON objects.
 - Prevented stateless MCP 2026 clients from sending core request and
   notification methods removed from that protocol revision.
 - Rejected server-initiated JSON-RPC requests received by stateless MCP 2026

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -201,6 +201,15 @@ RequestId parseRequestId(Object? value, {String fieldName = 'id'}) {
   );
 }
 
+String _parseMethod(Object? value) {
+  if (value is String) {
+    return value;
+  }
+  throw FormatException(
+    'Invalid method: expected string, got ${value.runtimeType}',
+  );
+}
+
 RequestId _parseResultResponseId(Object? value) {
   return parseRequestId(value);
 }
@@ -317,7 +326,7 @@ sealed class JsonRpcMessage {
     final hasError = json.containsKey('error');
 
     if (json.containsKey('method')) {
-      final method = json['method'] as String;
+      final method = _parseMethod(json['method']);
       final hasId = json.containsKey('id');
 
       if (hasId) {
@@ -353,7 +362,10 @@ sealed class JsonRpcMessage {
           _ => JsonRpcRequest(
               id: parseRequestId(json['id']),
               method: method,
-              params: json['params'] as Map<String, dynamic>?,
+              params: readOptionalJsonObject(
+                json['params'],
+                'JsonRpcRequest.params',
+              ),
               meta: extractRequestMeta(json),
             ),
         };

--- a/packages/mcp_dart_cli/lib/src/conformance_runner.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_runner.dart
@@ -98,6 +98,13 @@ class ConformanceRunner {
           ),
           _ConformanceCase(
             suite: _fixtureSuite,
+            name: 'jsonrpc.rejects-non-string-method',
+            description:
+                'Rejects JSON-RPC requests whose method member is not a string.',
+            check: _rejectsNonStringJsonRpcMethod,
+          ),
+          _ConformanceCase(
+            suite: _fixtureSuite,
             name: 'jsonrpc.rejects-result-error-response',
             description:
                 'Rejects JSON-RPC responses that include both result and error members.',
@@ -728,6 +735,16 @@ Future<void> _rejectsMalformedJsonRpcMessage() async {
     () => JsonRpcMessage.fromJson(const <String, dynamic>{
       'jsonrpc': jsonRpcVersion,
       'id': 1,
+    }),
+  );
+}
+
+Future<void> _rejectsNonStringJsonRpcMethod() async {
+  _expectThrowsFormatException(
+    () => JsonRpcMessage.fromJson(const <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 1,
+      'method': 1,
     }),
   );
 }

--- a/packages/mcp_dart_cli/test/src/conformance_command_test.dart
+++ b/packages/mcp_dart_cli/test/src/conformance_command_test.dart
@@ -20,6 +20,7 @@ void main() {
         containsAll(<String>[
           'jsonrpc.rejects-invalid-version',
           'jsonrpc.rejects-malformed-message',
+          'jsonrpc.rejects-non-string-method',
           'jsonrpc.rejects-result-error-response',
           'jsonrpc.preserves-string-response-id',
           'jsonrpc.preserves-numeric-response-id',

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -367,6 +367,47 @@ void main() {
       );
     });
 
+    test('rejects malformed method wire values', () {
+      for (final method in [
+        null,
+        false,
+        1,
+        <String, dynamic>{},
+        <Object>[],
+      ]) {
+        for (final hasId in [true, false]) {
+          expect(
+            () => JsonRpcMessage.fromJson({
+              'jsonrpc': '2.0',
+              if (hasId) 'id': 'request-1',
+              'method': method,
+            }),
+            throwsA(
+              isA<FormatException>()
+                  .having((e) => e.message, 'message', contains('method')),
+            ),
+          );
+        }
+      }
+    });
+
+    test('rejects malformed generic request params wire values', () {
+      for (final params in [false, 1, 'not-params', <Object>[]]) {
+        expect(
+          () => JsonRpcMessage.fromJson({
+            'jsonrpc': '2.0',
+            'id': 'request-1',
+            'method': 'unknown/request',
+            'params': params,
+          }),
+          throwsA(
+            isA<FormatException>()
+                .having((e) => e.message, 'message', contains('params')),
+          ),
+        );
+      }
+    });
+
     test('rejects malformed request id wire values', () {
       for (final id in [
         null,


### PR DESCRIPTION
## Summary
- reject JSON-RPC request and notification envelopes whose `method` is not a string
- validate generic JSON-RPC request `params` with JSON-object parsing instead of a Dart cast
- add unit and CLI conformance coverage for malformed method envelopes
- update the unreleased MCP 2026 RC changelog

## Validation
- `dart format .`
- `dart analyze`
- `git diff --check`
- `dart test test/types_edge_cases_test.dart`
- `(cd packages/mcp_dart_cli && dart test test/src/conformance_command_test.dart && dart run mcp_dart_cli:mcp_dart conformance --suite all --json)`
- `dart test`