### PR TITLE
Validate JSON-RPC params member wire values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@
   not a string, and validated generic request `params` as JSON objects.
 - Rejected malformed JSON-RPC `error` objects with missing or invalid `code` or
   `message` fields instead of surfacing Dart cast errors.
+- Rejected JSON-RPC request and notification envelopes that include an explicit
+  `params: null` member, since `params` must be an object when present.
 - Prevented stateless MCP 2026 clients from sending core request and
   notification methods removed from that protocol revision.
 - Rejected server-initiated JSON-RPC requests received by stateless MCP 2026

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -237,6 +237,16 @@ RequestId? _parseErrorResponseId(Map<String, dynamic> json) {
   return parseRequestId(json['id']);
 }
 
+Map<String, dynamic>? _parseOptionalParamsObject(
+  Map<String, dynamic> json,
+  String fieldName,
+) {
+  if (!json.containsKey('params')) {
+    return null;
+  }
+  return readJsonObject(json['params'], fieldName);
+}
+
 Object _requestIdToJson(RequestId id, String fieldName) {
   return parseRequestId(id, fieldName: fieldName);
 }
@@ -344,6 +354,10 @@ sealed class JsonRpcMessage {
     if (json.containsKey('method')) {
       final method = _parseMethod(json['method']);
       final hasId = json.containsKey('id');
+      final params = _parseOptionalParamsObject(
+        json,
+        hasId ? 'JsonRpcRequest.params' : 'JsonRpcNotification.params',
+      );
 
       if (hasId) {
         return switch (method) {
@@ -378,10 +392,7 @@ sealed class JsonRpcMessage {
           _ => JsonRpcRequest(
               id: parseRequestId(json['id']),
               method: method,
-              params: readOptionalJsonObject(
-                json['params'],
-                'JsonRpcRequest.params',
-              ),
+              params: params,
               meta: extractRequestMeta(json),
             ),
         };
@@ -421,19 +432,13 @@ sealed class JsonRpcMessage {
             JsonRpcElicitationCompleteNotification.fromJson(json),
           _ => JsonRpcNotification(
               method: method,
-              params: readOptionalJsonObject(
-                json['params'],
-                'JsonRpcNotification.params',
-              ),
+              params: params,
               meta: readOptionalJsonObject(
                     json['_meta'],
                     'JsonRpcNotification._meta',
                   ) ??
                   readOptionalJsonObject(
-                    readOptionalJsonObject(
-                      json['params'],
-                      'JsonRpcNotification.params',
-                    )?['_meta'],
+                    params?['_meta'],
                     'JsonRpcNotification._meta',
                   ),
             ),

--- a/packages/mcp_dart_cli/lib/src/conformance_runner.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_runner.dart
@@ -119,6 +119,13 @@ class ConformanceRunner {
           ),
           _ConformanceCase(
             suite: _fixtureSuite,
+            name: 'jsonrpc.rejects-null-params-member',
+            description:
+                'Rejects JSON-RPC request and notification envelopes whose params member is null.',
+            check: _rejectsNullJsonRpcParamsMember,
+          ),
+          _ConformanceCase(
+            suite: _fixtureSuite,
             name: 'jsonrpc.preserves-string-response-id',
             description:
                 'Parses and serializes successful responses with string JSON-RPC IDs.',
@@ -781,6 +788,24 @@ Future<void> _rejectsMalformedJsonRpcErrorObject() async {
       },
     }),
   );
+}
+
+Future<void> _rejectsNullJsonRpcParamsMember() async {
+  for (final message in const [
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 1,
+      'method': Method.ping,
+      'params': null,
+    },
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'method': Method.notificationsInitialized,
+      'params': null,
+    },
+  ]) {
+    _expectThrowsFormatException(() => JsonRpcMessage.fromJson(message));
+  }
 }
 
 Future<void> _preservesStringResponseId() async {

--- a/packages/mcp_dart_cli/test/src/conformance_command_test.dart
+++ b/packages/mcp_dart_cli/test/src/conformance_command_test.dart
@@ -23,6 +23,7 @@ void main() {
           'jsonrpc.rejects-non-string-method',
           'jsonrpc.rejects-result-error-response',
           'jsonrpc.rejects-malformed-error-object',
+          'jsonrpc.rejects-null-params-member',
           'jsonrpc.preserves-string-response-id',
           'jsonrpc.preserves-numeric-response-id',
           'jsonrpc.preserves-string-progress-token',

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -452,7 +452,7 @@ void main() {
     });
 
     test('rejects malformed generic request params wire values', () {
-      for (final params in [false, 1, 'not-params', <Object>[]]) {
+      for (final params in [null, false, 1, 'not-params', <Object>[]]) {
         expect(
           () => JsonRpcMessage.fromJson({
             'jsonrpc': '2.0',
@@ -460,6 +460,30 @@ void main() {
             'method': 'unknown/request',
             'params': params,
           }),
+          throwsA(
+            isA<FormatException>()
+                .having((e) => e.message, 'message', contains('params')),
+          ),
+        );
+      }
+    });
+
+    test('rejects explicit null params on typed request and notification', () {
+      for (final json in [
+        {
+          'jsonrpc': '2.0',
+          'id': 'request-1',
+          'method': Method.ping,
+          'params': null,
+        },
+        {
+          'jsonrpc': '2.0',
+          'method': Method.notificationsInitialized,
+          'params': null,
+        },
+      ]) {
+        expect(
+          () => JsonRpcMessage.fromJson(json),
           throwsA(
             isA<FormatException>()
                 .having((e) => e.message, 'message', contains('params')),


### PR DESCRIPTION
## Summary
- Reject JSON-RPC request and notification envelopes when `params` is explicitly null
- Pre-validate `params` as an object before dispatching to typed request/notification parsers
- Add edge-case coverage plus a CLI conformance fixture for null params

## Validation
- `dart format .`
- `dart analyze`
- `git diff --check`
- `dart test test/types_edge_cases_test.dart`
- `(cd packages/mcp_dart_cli && dart test test/src/conformance_command_test.dart && dart run mcp_dart_cli:mcp_dart conformance --suite all --json)`
- `dart test`

Draft stacked PR for RC spec work. Do not merge/release to main until the spec is finalized.