### PR TITLE
Validate JSON-RPC error response ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@
   not a string, and validated generic request `params` as JSON objects.
 - Rejected malformed JSON-RPC `error` objects with missing or invalid `code` or
   `message` fields instead of surfacing Dart cast errors.
+- Rejected JSON-RPC error responses that include an explicit `id: null` member
+  while continuing to allow omitted IDs for malformed-request error cases.
 - Rejected JSON-RPC request and notification envelopes that include an explicit
   `params: null` member, since `params` must be an object when present.
 - Prevented stateless MCP 2026 clients from sending core request and

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -231,7 +231,7 @@ RequestId _parseResultResponseId(Object? value) {
 }
 
 RequestId? _parseErrorResponseId(Map<String, dynamic> json) {
-  if (!json.containsKey('id') || json['id'] == null) {
+  if (!json.containsKey('id')) {
     return null;
   }
   return parseRequestId(json['id']);

--- a/packages/mcp_dart_cli/lib/src/conformance_runner.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_runner.dart
@@ -119,6 +119,13 @@ class ConformanceRunner {
           ),
           _ConformanceCase(
             suite: _fixtureSuite,
+            name: 'jsonrpc.rejects-null-error-response-id',
+            description:
+                'Rejects JSON-RPC error responses whose id member is explicitly null.',
+            check: _rejectsNullJsonRpcErrorResponseId,
+          ),
+          _ConformanceCase(
+            suite: _fixtureSuite,
             name: 'jsonrpc.rejects-null-params-member',
             description:
                 'Rejects JSON-RPC request and notification envelopes whose params member is null.',
@@ -784,6 +791,19 @@ Future<void> _rejectsMalformedJsonRpcErrorObject() async {
       'id': 1,
       'error': <String, dynamic>{
         'code': 'not-a-number',
+        'message': 'Invalid request',
+      },
+    }),
+  );
+}
+
+Future<void> _rejectsNullJsonRpcErrorResponseId() async {
+  _expectThrowsFormatException(
+    () => JsonRpcMessage.fromJson(const <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': null,
+      'error': <String, dynamic>{
+        'code': -32600,
         'message': 'Invalid request',
       },
     }),

--- a/packages/mcp_dart_cli/test/src/conformance_command_test.dart
+++ b/packages/mcp_dart_cli/test/src/conformance_command_test.dart
@@ -23,6 +23,7 @@ void main() {
           'jsonrpc.rejects-non-string-method',
           'jsonrpc.rejects-result-error-response',
           'jsonrpc.rejects-malformed-error-object',
+          'jsonrpc.rejects-null-error-response-id',
           'jsonrpc.rejects-null-params-member',
           'jsonrpc.preserves-string-response-id',
           'jsonrpc.preserves-numeric-response-id',

--- a/test/server/stdio_test.dart
+++ b/test/server/stdio_test.dart
@@ -408,6 +408,17 @@ void main() {
           field: 'id',
           message: {
             'jsonrpc': '2.0',
+            'id': null,
+            'error': {
+              'code': -32600,
+              'message': 'Invalid request',
+            },
+          },
+        ),
+        (
+          field: 'id',
+          message: {
+            'jsonrpc': '2.0',
             'id': <Object>[],
             'error': {
               'code': -32600,

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -700,10 +700,9 @@ void main() {
       );
     });
 
-    test('handles error with null id', () {
+    test('handles error with omitted id', () {
       final json = {
         'jsonrpc': '2.0',
-        'id': null,
         'error': {'code': -32600, 'message': 'Error'},
       };
 
@@ -714,6 +713,7 @@ void main() {
 
     test('rejects malformed error id wire values', () {
       for (final id in [
+        null,
         false,
         double.nan,
         double.infinity,


### PR DESCRIPTION
## Summary
- Reject JSON-RPC error responses when `id` is explicitly null
- Keep omitted error-response IDs valid for malformed-request cases where the request ID could not be read
- Add edge-case, stdio raw-input, and CLI conformance coverage

## Validation
- `dart format .`
- `dart analyze`
- `git diff --check`
- `dart test test/types_edge_cases_test.dart test/server/stdio_test.dart`
- `(cd packages/mcp_dart_cli && dart test test/src/conformance_command_test.dart && dart run mcp_dart_cli:mcp_dart conformance --suite all --json)`
- `dart test`

Draft stacked PR for RC spec work. Do not merge/release to main until the spec is finalized.