### PR TITLE
Require metadata on server discover requests

### DIFF
--- a/lib/src/types/initialization.dart
+++ b/lib/src/types/initialization.dart
@@ -600,10 +600,43 @@ class JsonRpcServerDiscoverRequest extends JsonRpcRequest {
   }) : super(method: Method.serverDiscover);
 
   factory JsonRpcServerDiscoverRequest.fromJson(Map<String, dynamic> json) {
+    final params = readJsonObject(
+      json['params'],
+      'JsonRpcServerDiscoverRequest.params',
+    );
+    final meta = validateRequestMeta(
+      readJsonObject(
+        params['_meta'],
+        'JsonRpcServerDiscoverRequest.params._meta',
+      ),
+      validateKeys: true,
+    )!;
+
     return JsonRpcServerDiscoverRequest(
       id: parseRequestId(json['id']),
-      meta: extractRequestMeta(json),
+      meta: meta,
     );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    final meta = this.meta;
+    if (meta == null) {
+      throw const FormatException(
+        'JsonRpcServerDiscoverRequest.params._meta is required',
+      );
+    }
+    return {
+      'jsonrpc': jsonrpc,
+      'id': parseRequestId(id, fieldName: 'JsonRpcServerDiscoverRequest.id'),
+      'method': method,
+      'params': <String, dynamic>{
+        '_meta': readJsonObject(
+          validateRequestMeta(meta, validateKeys: true),
+          'JsonRpcServerDiscoverRequest.params._meta',
+        ),
+      },
+    };
   }
 }
 

--- a/packages/mcp_dart_cli/lib/src/conformance_runner.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_runner.dart
@@ -7,6 +7,12 @@ const String _fixtureSuite = 'fixture';
 const String _specSuite = 'spec';
 const String _allSuites = 'all';
 const String _serverDiscoverMethod = 'server/discover';
+const String _draftProtocolVersion2026_07_28 = '2026-07-28';
+const String _protocolVersionMetaKey =
+    'io.modelcontextprotocol/protocolVersion';
+const String _clientInfoMetaKey = 'io.modelcontextprotocol/clientInfo';
+const String _clientCapabilitiesMetaKey =
+    'io.modelcontextprotocol/clientCapabilities';
 
 const List<String> conformanceSuiteNames = <String>[
   _fixtureSuite,
@@ -562,7 +568,7 @@ Future<void> _rejectsPreInitializeRequest() async {
 }
 
 Future<void> _serverDiscoverRequiresRequestMeta() async {
-  for (final message in const [
+  for (final message in [
     <String, dynamic>{
       'jsonrpc': jsonRpcVersion,
       'id': 'discover-1',
@@ -573,7 +579,7 @@ Future<void> _serverDiscoverRequiresRequestMeta() async {
       'id': 'discover-1',
       'method': _serverDiscoverMethod,
       '_meta': <String, dynamic>{
-        McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
+        _protocolVersionMetaKey: _draftProtocolVersion2026_07_28,
       },
     },
     <String, dynamic>{
@@ -586,29 +592,28 @@ Future<void> _serverDiscoverRequiresRequestMeta() async {
     _expectThrowsFormatException(() => JsonRpcMessage.fromJson(message));
   }
 
-  _expectThrowsFormatException(
-    () => JsonRpcServerDiscoverRequest(id: 'discover-1').toJson(),
-  );
-
   final parsed = JsonRpcMessage.fromJson(<String, dynamic>{
     'jsonrpc': jsonRpcVersion,
     'id': 'discover-1',
     'method': _serverDiscoverMethod,
     'params': <String, dynamic>{
-      '_meta': buildProtocolRequestMeta(
-        protocolVersion: draftProtocolVersion2026_07_28,
-        clientInfo: const Implementation(name: 'client', version: '1.0.0'),
-        clientCapabilities: const ClientCapabilities(),
-      ),
+      '_meta': <String, dynamic>{
+        _protocolVersionMetaKey: _draftProtocolVersion2026_07_28,
+        _clientInfoMetaKey: <String, dynamic>{
+          'name': 'client',
+          'version': '1.0.0',
+        },
+        _clientCapabilitiesMetaKey: <String, dynamic>{},
+      },
     },
   });
-  if (parsed is! JsonRpcServerDiscoverRequest) {
+  if (parsed is! JsonRpcRequest) {
     throw StateError(
-      'Expected JsonRpcServerDiscoverRequest, got ${parsed.runtimeType}.',
+      'Expected JsonRpcRequest, got ${parsed.runtimeType}.',
     );
   }
-  if (parsed.meta?[McpMetaKey.protocolVersion] !=
-      draftProtocolVersion2026_07_28) {
+  if (parsed.meta?[_protocolVersionMetaKey] !=
+      _draftProtocolVersion2026_07_28) {
     throw StateError('Expected server/discover metadata to be preserved.');
   }
 }

--- a/packages/mcp_dart_cli/lib/src/conformance_runner.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_runner.dart
@@ -6,6 +6,7 @@ import 'package:mcp_dart/mcp_dart.dart';
 const String _fixtureSuite = 'fixture';
 const String _specSuite = 'spec';
 const String _allSuites = 'all';
+const String _serverDiscoverMethod = 'server/discover';
 
 const List<String> conformanceSuiteNames = <String>[
   _fixtureSuite,
@@ -565,12 +566,12 @@ Future<void> _serverDiscoverRequiresRequestMeta() async {
     <String, dynamic>{
       'jsonrpc': jsonRpcVersion,
       'id': 'discover-1',
-      'method': Method.serverDiscover,
+      'method': _serverDiscoverMethod,
     },
     <String, dynamic>{
       'jsonrpc': jsonRpcVersion,
       'id': 'discover-1',
-      'method': Method.serverDiscover,
+      'method': _serverDiscoverMethod,
       '_meta': <String, dynamic>{
         McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
       },
@@ -578,7 +579,7 @@ Future<void> _serverDiscoverRequiresRequestMeta() async {
     <String, dynamic>{
       'jsonrpc': jsonRpcVersion,
       'id': 'discover-1',
-      'method': Method.serverDiscover,
+      'method': _serverDiscoverMethod,
       'params': <String, dynamic>{},
     },
   ]) {
@@ -592,7 +593,7 @@ Future<void> _serverDiscoverRequiresRequestMeta() async {
   final parsed = JsonRpcMessage.fromJson(<String, dynamic>{
     'jsonrpc': jsonRpcVersion,
     'id': 'discover-1',
-    'method': Method.serverDiscover,
+    'method': _serverDiscoverMethod,
     'params': <String, dynamic>{
       '_meta': buildProtocolRequestMeta(
         protocolVersion: draftProtocolVersion2026_07_28,

--- a/packages/mcp_dart_cli/lib/src/conformance_runner.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_runner.dart
@@ -184,6 +184,13 @@ class ConformanceRunner {
           ),
           _ConformanceCase(
             suite: _specSuite,
+            name: 'server-discover.requires-request-meta',
+            description:
+                'Rejects server/discover requests that omit params._meta request metadata.',
+            check: _serverDiscoverRequiresRequestMeta,
+          ),
+          _ConformanceCase(
+            suite: _specSuite,
             name: 'capabilities.rejects-unnegotiated-sampling-tools',
             description:
                 'Rejects sampling/createMessage tool-use when sampling.tools was not negotiated.',
@@ -551,6 +558,58 @@ Future<void> _rejectsPreInitializeRequest() async {
     messageContains: 'before initialize',
   );
   await server.close();
+}
+
+Future<void> _serverDiscoverRequiresRequestMeta() async {
+  for (final message in const [
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 'discover-1',
+      'method': Method.serverDiscover,
+    },
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 'discover-1',
+      'method': Method.serverDiscover,
+      '_meta': <String, dynamic>{
+        McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
+      },
+    },
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 'discover-1',
+      'method': Method.serverDiscover,
+      'params': <String, dynamic>{},
+    },
+  ]) {
+    _expectThrowsFormatException(() => JsonRpcMessage.fromJson(message));
+  }
+
+  _expectThrowsFormatException(
+    () => JsonRpcServerDiscoverRequest(id: 'discover-1').toJson(),
+  );
+
+  final parsed = JsonRpcMessage.fromJson(<String, dynamic>{
+    'jsonrpc': jsonRpcVersion,
+    'id': 'discover-1',
+    'method': Method.serverDiscover,
+    'params': <String, dynamic>{
+      '_meta': buildProtocolRequestMeta(
+        protocolVersion: draftProtocolVersion2026_07_28,
+        clientInfo: const Implementation(name: 'client', version: '1.0.0'),
+        clientCapabilities: const ClientCapabilities(),
+      ),
+    },
+  });
+  if (parsed is! JsonRpcServerDiscoverRequest) {
+    throw StateError(
+      'Expected JsonRpcServerDiscoverRequest, got ${parsed.runtimeType}.',
+    );
+  }
+  if (parsed.meta?[McpMetaKey.protocolVersion] !=
+      draftProtocolVersion2026_07_28) {
+    throw StateError('Expected server/discover metadata to be preserved.');
+  }
 }
 
 Future<void> _rejectsUnnegotiatedSamplingTools() async {

--- a/packages/mcp_dart_cli/test/src/conformance_command_test.dart
+++ b/packages/mcp_dart_cli/test/src/conformance_command_test.dart
@@ -44,6 +44,7 @@ void main() {
         result.caseNames,
         containsAll(<String>[
           'lifecycle.rejects-pre-initialize-request',
+          'server-discover.requires-request-meta',
           'capabilities.rejects-unnegotiated-sampling-tools',
           'elicitation.rejects-invalid-form-url-union',
           'tasks.strips-unnegotiated-related-task-metadata',

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -542,6 +542,63 @@ void main() {
       );
     });
 
+    test('requires server/discover request metadata in params', () {
+      expect(
+        () => JsonRpcServerDiscoverRequest(id: 'discover-1').toJson(),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('params._meta'),
+          ),
+        ),
+      );
+
+      for (final message in [
+        {
+          'jsonrpc': jsonRpcVersion,
+          'id': 'discover-1',
+          'method': Method.serverDiscover,
+        },
+        {
+          'jsonrpc': jsonRpcVersion,
+          'id': 'discover-1',
+          'method': Method.serverDiscover,
+          '_meta': _clientMeta(),
+        },
+        {
+          'jsonrpc': jsonRpcVersion,
+          'id': 'discover-1',
+          'method': Method.serverDiscover,
+          'params': <String, dynamic>{},
+        },
+      ]) {
+        expect(
+          () => JsonRpcMessage.fromJson(message),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              anyOf(contains('params'), contains('params._meta')),
+            ),
+          ),
+        );
+      }
+
+      final parsed = JsonRpcMessage.fromJson({
+        'jsonrpc': jsonRpcVersion,
+        'id': 'discover-1',
+        'method': Method.serverDiscover,
+        'params': {'_meta': _clientMeta()},
+      });
+      expect(parsed, isA<JsonRpcServerDiscoverRequest>());
+      expect(
+        (parsed as JsonRpcServerDiscoverRequest)
+            .meta?[McpMetaKey.protocolVersion],
+        draftProtocolVersion2026_07_28,
+      );
+    });
+
     test('serializes cacheable result hints without changing legacy defaults',
         () {
       final toolsJson = const ListToolsResult(


### PR DESCRIPTION
## Summary
- require `server/discover` requests to carry nested `params._meta` request metadata when parsing or serializing
- reject top-level-only or missing metadata for the 2026 discover request shape
- add a CLI conformance case for the `server/discover` request metadata requirement

## Verification
- dart format lib/src/types/initialization.dart test/mcp_2026_07_28_test.dart packages/mcp_dart_cli/lib/src/conformance_runner.dart packages/mcp_dart_cli/test/src/conformance_command_test.dart
- dart test test/mcp_2026_07_28_test.dart
- (cd packages/mcp_dart_cli && dart test test/src/conformance_command_test.dart)
- (cd packages/mcp_dart_cli && dart run mcp_dart_cli:mcp_dart conformance --suite all --json)
- dart analyze
- git diff --check
- (cd packages/mcp_dart_cli && dart analyze)
- dart test
- (cd packages/mcp_dart_cli && dart test)

Spec note: the current draft schema requires `server/discover` to include `params`, and common request params require `_meta`. This remains draft-stack work while `2026-07-28` is RC.
