### PR TITLE
Prefer nested request metadata

### DIFF
--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -328,12 +328,12 @@ Map<String, dynamic>? _parseRequestMeta(Object? value) {
   return validateRequestMeta(readJsonObject(value, '_meta'));
 }
 
-/// Extracts request metadata from either top-level or params-nested `_meta`.
+/// Extracts request metadata, preferring spec-defined params-nested `_meta`.
 Map<String, dynamic>? extractRequestMeta(Map<String, dynamic> json) {
   final topLevelMeta = _parseRequestMeta(json['_meta']);
   final params = json['params'];
   final paramsMeta = params is Map ? _parseRequestMeta(params['_meta']) : null;
-  return topLevelMeta ?? paramsMeta;
+  return paramsMeta ?? topLevelMeta;
 }
 
 /// Base class for all JSON-RPC messages (requests, notifications, responses, errors).
@@ -435,14 +435,7 @@ sealed class JsonRpcMessage {
           _ => JsonRpcNotification(
               method: method,
               params: params,
-              meta: readOptionalJsonObject(
-                    json['_meta'],
-                    'JsonRpcNotification._meta',
-                  ) ??
-                  readOptionalJsonObject(
-                    params?['_meta'],
-                    'JsonRpcNotification._meta',
-                  ),
+              meta: extractRequestMeta(json),
             ),
         };
       }

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -1226,6 +1226,26 @@ void main() {
         );
       });
 
+      test('request parsing prefers params metadata over top-level metadata',
+          () {
+        final parsed = JsonRpcMessage.fromJson(
+          const {
+            'jsonrpc': jsonRpcVersion,
+            'id': 'tools',
+            'method': Method.toolsList,
+            '_meta': {'progressToken': 'top-level'},
+            'params': {
+              '_meta': {'progressToken': 'params-nested'},
+            },
+          },
+        );
+
+        expect(parsed, isA<JsonRpcListToolsRequest>());
+        final request = parsed as JsonRpcListToolsRequest;
+        expect(request.meta, {'progressToken': 'params-nested'});
+        expect(request.progressToken, 'params-nested');
+      });
+
       test('server capabilities omit non-stable fields while parsing legacy',
           () {
         final capabilities = const ServerCapabilities(

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -322,6 +322,31 @@ void main() {
       }
     });
 
+    test('request parsing does not let top-level metadata override params', () {
+      final parsed = JsonRpcMessage.fromJson({
+        'jsonrpc': jsonRpcVersion,
+        'id': 'tools',
+        'method': Method.toolsList,
+        '_meta': {
+          McpMetaKey.protocolVersion: latestProtocolVersion,
+        },
+        'params': {
+          '_meta': _clientMeta(),
+        },
+      });
+
+      expect(parsed, isA<JsonRpcListToolsRequest>());
+      final request = parsed as JsonRpcListToolsRequest;
+      expect(
+        request.meta?[McpMetaKey.protocolVersion],
+        draftProtocolVersion2026_07_28,
+      );
+      expect(request.meta?[McpMetaKey.clientInfo], {
+        'name': 'client',
+        'version': '1.0.0',
+      });
+    });
+
     test('preserves integer request ids and progress tokens', () {
       final message = JsonRpcMessage.fromJson(
         const {


### PR DESCRIPTION
## Summary
- prefer spec-defined `params._meta` over non-spec top-level `_meta` when parsing request and notification metadata
- keep top-level `_meta` as a compatibility fallback when nested metadata is absent
- add stable 2025-11-25 and draft 2026-07-28 regression coverage for metadata precedence

## Spec notes
- The current stable schema (`2025-11-25`) defines request metadata under request params.
- The draft `2026-07-28` schema requires request metadata under `params._meta`, including protocol-version metadata for stateless requests.
- This PR prevents top-level extras from overriding the spec-shaped nested metadata while preserving fallback parsing for older/non-conforming peers.

Sources:
- https://github.com/modelcontextprotocol/modelcontextprotocol/releases
- https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/2025-11-25/schema.json
- https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/draft/schema.json

## Verification
- dart format lib/src/types/json_rpc.dart test/mcp_2025_11_25_test.dart test/mcp_2026_07_28_test.dart
- dart test test/mcp_2025_11_25_test.dart test/mcp_2026_07_28_test.dart
- dart analyze
- dart test
- (cd packages/mcp_dart_cli && dart analyze && dart test)
- git diff --check
