### PR TITLE
Prefer nested metadata for stateless routing

### DIFF
--- a/lib/src/server/streamable_mcp_server.dart
+++ b/lib/src/server/streamable_mcp_server.dart
@@ -707,14 +707,6 @@ class StreamableMcpServer {
   }
 
   String? _bodyProtocolVersion(Map<String, dynamic> body) {
-    final topLevelMeta = body['_meta'];
-    if (topLevelMeta is Map) {
-      final version = topLevelMeta[McpMetaKey.protocolVersion];
-      if (version is String) {
-        return version;
-      }
-    }
-
     final params = body['params'];
     if (params is Map) {
       final meta = params['_meta'];
@@ -723,6 +715,14 @@ class StreamableMcpServer {
         if (version is String) {
           return version;
         }
+      }
+    }
+
+    final topLevelMeta = body['_meta'];
+    if (topLevelMeta is Map) {
+      final version = topLevelMeta[McpMetaKey.protocolVersion];
+      if (version is String) {
+        return version;
       }
     }
 

--- a/test/server/streamable_mcp_server_test.dart
+++ b/test/server/streamable_mcp_server_test.dart
@@ -428,6 +428,30 @@ void main() {
       );
     });
 
+    test('keeps top-level metadata as stateless detection fallback', () async {
+      final response = await http.post(
+        Uri.parse(baseUrl),
+        body: jsonEncode(
+          const JsonRpcListToolsRequest(id: 12).toJson()
+            ..['_meta'] = const {
+              McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
+            },
+        ),
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json, text/event-stream',
+          'Mcp-Method': Method.toolsList,
+        },
+      );
+
+      expect(response.statusCode, HttpStatus.badRequest);
+      final body = jsonDecode(response.body) as Map<String, dynamic>;
+      expect(
+        body['error']['message'],
+        contains('MCP-Protocol-Version header is required'),
+      );
+    });
+
     test('routes 2026 stateless non-POST methods without a session ID',
         () async {
       final client = HttpClient();

--- a/test/server/streamable_mcp_server_test.dart
+++ b/test/server/streamable_mcp_server_test.dart
@@ -362,6 +362,51 @@ void main() {
       expect(messages.single['result']['tools'][0]['name'], 'echo');
     });
 
+    test('detects stateless requests from nested metadata before top-level',
+        () async {
+      await server.stop();
+      server = StreamableMcpServer(
+        serverFactory: (sessionId) {
+          final mcpServer = McpServer(
+            const Implementation(name: 'StatelessServer', version: '1.0.0'),
+          );
+          mcpServer.registerTool(
+            'echo',
+            inputSchema: const ToolInputSchema(),
+            callback: (args, extra) async => const CallToolResult(content: []),
+          );
+          return mcpServer;
+        },
+        host: host,
+        port: port,
+      );
+      await server.start();
+
+      final request = JsonRpcListToolsRequest(
+        id: 11,
+        meta: statelessMeta(),
+      ).toJson()
+        ..['_meta'] = const {
+          McpMetaKey.protocolVersion: latestProtocolVersion,
+        };
+
+      final response = await http.post(
+        Uri.parse(baseUrl),
+        body: jsonEncode(request),
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json, text/event-stream',
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+          'Mcp-Method': Method.toolsList,
+        },
+      );
+
+      expect(response.statusCode, HttpStatus.ok);
+      expect(response.headers['mcp-session-id'], isNull);
+      final messages = _decodeSseJsonMessages(response.body);
+      expect(messages.single['result']['tools'][0]['name'], 'echo');
+    });
+
     test('detects 2026 stateless requests from body metadata', () async {
       final response = await http.post(
         Uri.parse(baseUrl),


### PR DESCRIPTION
## Summary
- prefer `params._meta` over top-level `_meta` when detecting stateless protocol versions from raw Streamable MCP request bodies
- keep top-level metadata as a fallback for compatibility when nested metadata is absent
- add a transport-level regression for conflicting top-level and nested protocol metadata

## Spec notes
- The current stable schema (`2025-11-25`) defines request metadata under request params.
- The draft `2026-07-28` schema requires request metadata under `params._meta` for stateless requests.
- This aligns the Streamable MCP routing detector with the JSON-RPC parser precedence from the previous stacked PR.

Sources:
- https://github.com/modelcontextprotocol/modelcontextprotocol/releases
- https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/2025-11-25/schema.json
- https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/draft/schema.json

## Verification
- dart format lib/src/server/streamable_mcp_server.dart test/server/streamable_mcp_server_test.dart
- dart test test/server/streamable_mcp_server_test.dart
- dart analyze
- dart test
- (cd packages/mcp_dart_cli && dart analyze && dart test)
- git diff --check
