### PR TITLE
Reject stateless legacy task status notifications

### DIFF
--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -122,6 +122,7 @@ const Set<String> _statelessRemovedRequestMethods = {
 const Set<String> _statelessRemovedNotificationMethods = {
   Method.notificationsInitialized,
   Method.notificationsRootsListChanged,
+  Method.notificationsTasksStatus,
 };
 
 /// An MCP client implementation built on top of a pluggable [Transport].

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -76,6 +76,7 @@ class Server extends Protocol {
   static const Set<String> _statelessRemovedNotificationMethods = {
     Method.notificationsInitialized,
     Method.notificationsRootsListChanged,
+    Method.notificationsTasksStatus,
   };
 
   static const Set<String> _inputRequiredResultMethods = {

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -1541,6 +1541,18 @@ void main() {
             resultParams: const TaskResultRequest(taskId: 'task-1'),
             meta: taskExtensionMeta,
           ),
+        )
+        ..receive(
+          JsonRpcTaskStatusNotification(
+            statusParams: const TaskStatusNotification(
+              taskId: 'task-1',
+              status: TaskStatus.working,
+              ttl: null,
+              createdAt: '2026-07-28T00:00:00Z',
+              lastUpdatedAt: '2026-07-28T00:00:00Z',
+            ),
+            meta: taskExtensionMeta,
+          ),
         );
       await _pump();
 
@@ -2622,6 +2634,20 @@ void main() {
         (
           method: Method.notificationsRootsListChanged,
           call: client.sendRootsListChanged,
+        ),
+        (
+          method: Method.notificationsTasksStatus,
+          call: () => client.notification(
+                JsonRpcTaskStatusNotification(
+                  statusParams: const TaskStatusNotification(
+                    taskId: 'task-1',
+                    status: TaskStatus.working,
+                    ttl: null,
+                    createdAt: '2026-07-28T00:00:00Z',
+                    lastUpdatedAt: '2026-07-28T00:00:00Z',
+                  ),
+                ),
+              ),
         ),
       ];
 


### PR DESCRIPTION
## Summary
- reject legacy `notifications/tasks/status` on MCP 2026 stateless server notification handling
- reject the same legacy notification before stateless clients send it
- cover both server and client regressions in the 2026 RC test suite

## Spec context
- MCP 2026 RC moves tasks to the `io.modelcontextprotocol/tasks` extension
- SEP-2663 defines extension task notifications as `notifications/tasks`; the 2025-11-25 `notifications/tasks/status` shape is legacy and not wire-compatible

## Validation
- `dart format .`
- `git diff --check`
- `dart test test/mcp_2026_07_28_test.dart`
- `dart test test/types/tasks_extension_test.dart test/types/subscriptions_test.dart`
- `dart analyze`
- `dart test`