### PR TITLE
Accept numeric integer schema bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,9 @@
   dispatch finite numeric progress tokens end-to-end.
 - Widened protocol `relatedRequestId` API parameters to preserve string and
   finite numeric JSON-RPC request IDs through request and notification routing.
+- Accepted numeric `minimum`, `maximum`, `exclusiveMinimum`,
+  `exclusiveMaximum`, `multipleOf`, and `default` values on JSON Schema
+  `integer` schemas, matching the stable and MCP 2026 schema definitions.
 
 ## 2.2.0
 

--- a/lib/src/shared/json_schema/json_schema.dart
+++ b/lib/src/shared/json_schema/json_schema.dart
@@ -8,7 +8,7 @@ sealed class JsonSchema {
   /// The default value for this schema.
   ///
   /// The type of this value depends on the schema type (e.g., [String] for [JsonString],
-  /// [int] for [JsonInteger], etc.).
+  /// [num] for [JsonNumber] and [JsonInteger], etc.).
   dynamic get defaultValue;
 
   const JsonSchema({this.title, this.description});
@@ -255,14 +255,14 @@ sealed class JsonSchema {
 
   /// Creates an integer schema.
   static JsonInteger integer({
-    int? minimum,
-    int? maximum,
-    int? exclusiveMinimum,
-    int? exclusiveMaximum,
-    int? multipleOf,
+    num? minimum,
+    num? maximum,
+    num? exclusiveMinimum,
+    num? exclusiveMaximum,
+    num? multipleOf,
     String? title,
     String? description,
-    int? defaultValue,
+    num? defaultValue,
     String? mcpHeader,
   }) {
     return JsonInteger(
@@ -619,11 +619,11 @@ class JsonInteger extends JsonSchema {
   final bool _hasDefault;
   final bool _hasMcpHeader;
   final Object? _rawMcpHeader;
-  final int? minimum;
-  final int? maximum;
-  final int? exclusiveMinimum;
-  final int? exclusiveMaximum;
-  final int? multipleOf;
+  final num? minimum;
+  final num? maximum;
+  final num? exclusiveMinimum;
+  final num? exclusiveMaximum;
+  final num? multipleOf;
 
   /// MCP `x-mcp-header` extension for mirroring this parameter into HTTP.
   final String? mcpHeader;
@@ -660,19 +660,19 @@ class JsonInteger extends JsonSchema {
         _rawMcpHeader = rawMcpHeader;
 
   @override
-  final int? defaultValue;
+  final num? defaultValue;
 
   factory JsonInteger.fromJson(Map<String, dynamic> json) {
     final rawMcpHeader = json['x-mcp-header'];
     return JsonInteger._(
-      minimum: json['minimum'] as int?,
-      maximum: json['maximum'] as int?,
-      exclusiveMinimum: json['exclusiveMinimum'] as int?,
-      exclusiveMaximum: json['exclusiveMaximum'] as int?,
-      multipleOf: json['multipleOf'] as int?,
+      minimum: json['minimum'] as num?,
+      maximum: json['maximum'] as num?,
+      exclusiveMinimum: json['exclusiveMinimum'] as num?,
+      exclusiveMaximum: json['exclusiveMaximum'] as num?,
+      multipleOf: json['multipleOf'] as num?,
       title: json['title'] as String?,
       description: json['description'] as String?,
-      defaultValue: json['default'] as int?,
+      defaultValue: json['default'] as num?,
       mcpHeader: rawMcpHeader is String ? rawMcpHeader : null,
       rawMcpHeader: rawMcpHeader,
       hasDefault: json.containsKey('default'),

--- a/lib/src/shared/json_schema/json_schema_validator.dart
+++ b/lib/src/shared/json_schema/json_schema_validator.dart
@@ -188,7 +188,7 @@ extension JsonSchemaValidation on JsonSchema {
     }
 
     if (schema.multipleOf != null) {
-      if ((data % schema.multipleOf!).abs() > 0) {
+      if ((data % schema.multipleOf!).abs() > 1e-10) {
         throw JsonSchemaValidationException(
           'Value must be multiple of ${schema.multipleOf}',
           path,

--- a/test/shared/json_schema_from_json_test.dart
+++ b/test/shared/json_schema_from_json_test.dart
@@ -146,20 +146,23 @@ void main() {
     test('parses integer schema', () {
       final json = {
         'type': 'integer',
-        'minimum': 1,
-        'maximum': 10,
-        'exclusiveMinimum': 0,
-        'exclusiveMaximum': 11,
-        'multipleOf': 2,
+        'minimum': 1.5,
+        'maximum': 10.5,
+        'exclusiveMinimum': 0.5,
+        'exclusiveMaximum': 11.5,
+        'multipleOf': 0.5,
+        'default': 2.0,
       };
       final schema = JsonSchema.fromJson(json);
       expect(schema, isA<JsonInteger>());
       final s = schema as JsonInteger;
-      expect(s.minimum, 1);
-      expect(s.maximum, 10);
-      expect(s.exclusiveMinimum, 0);
-      expect(s.exclusiveMaximum, 11);
-      expect(s.multipleOf, 2);
+      expect(s.minimum, 1.5);
+      expect(s.maximum, 10.5);
+      expect(s.exclusiveMinimum, 0.5);
+      expect(s.exclusiveMaximum, 11.5);
+      expect(s.multipleOf, 0.5);
+      expect(s.defaultValue, 2.0);
+      expect(s.toJson(), json);
     });
 
     test('parses boolean schema', () {

--- a/test/shared/json_schema_validator_test.dart
+++ b/test/shared/json_schema_validator_test.dart
@@ -160,7 +160,7 @@ void main() {
       });
 
       test('validates exclusiveMinimum', () {
-        final schema = JsonSchema.integer(exclusiveMinimum: 5);
+        final schema = JsonSchema.integer(exclusiveMinimum: 5.5);
         schema.validate(6);
         expect(
           () => schema.validate(5),
@@ -169,19 +169,21 @@ void main() {
       });
 
       test('validates exclusiveMaximum', () {
-        final schema = JsonSchema.integer(exclusiveMaximum: 10);
+        final schema = JsonSchema.integer(exclusiveMaximum: 10.5);
         schema.validate(9);
+        schema.validate(10);
         expect(
-          () => schema.validate(10),
+          () => schema.validate(11),
           throwsA(isA<JsonSchemaValidationException>()),
         );
       });
 
       test('validates multipleOf', () {
-        final schema = JsonSchema.integer(multipleOf: 3);
-        schema.validate(9);
+        final schema = JsonSchema.integer(multipleOf: 1.5);
+        schema.validate(3);
+        schema.validate(6);
         expect(
-          () => schema.validate(10),
+          () => schema.validate(4),
           throwsA(isA<JsonSchemaValidationException>()),
         );
       });


### PR DESCRIPTION
## Summary
- widen JsonInteger numeric keywords and default values from int-only to num
- preserve fractional integer schema bounds/defaults during JSON schema parsing and serialization
- keep integer instance validation strict while allowing fractional multipleOf constraints

## Spec evidence
- Official draft and 2025-11-25 JSON schemas define RequestId/ProgressToken as integer, but NumberSchema numeric keywords for integer schemas use JSON number values.
- Draft changelog notes schema JSON now reflects minimum/maximum/default as numbers rather than only integers.

## Validation
- dart format lib/src/shared/json_schema/json_schema.dart lib/src/shared/json_schema/json_schema_validator.dart test/shared/json_schema_from_json_test.dart test/shared/json_schema_validator_test.dart
- dart test test/shared/json_schema_from_json_test.dart test/shared/json_schema_validator_test.dart
- dart analyze
- git diff --check
- dart test
- (packages/mcp_dart_cli) dart run bin/mcp_dart.dart conformance --suite all --json