### PR TITLE
Align MRTR sampling input request shape

### DIFF
--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -719,9 +719,10 @@ class InputRequest {
 
   /// Creates an embedded `sampling/createMessage` input request.
   factory InputRequest.createMessage(CreateMessageRequest params) {
+    final inputParams = params.toJson()..remove('task');
     return InputRequest._(
       method: Method.samplingCreateMessage,
-      params: params.toJson(),
+      params: inputParams,
     );
   }
 
@@ -752,6 +753,12 @@ class InputRequest {
           json['params'],
           'InputRequest.params',
         );
+        if (params.containsKey('task')) {
+          throw const FormatException(
+            'InputRequest sampling/createMessage params must not include '
+            'legacy task metadata',
+          );
+        }
         CreateMessageRequest.fromJson(params);
         return InputRequest._(method: method, params: params);
       case Method.rootsList:

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -737,6 +737,7 @@ void main() {
                   ),
                 ),
               ],
+              task: TaskCreation(ttl: 1000),
               maxTokens: 100,
             ),
           ),
@@ -758,6 +759,10 @@ void main() {
         json['inputRequests']['capital_of_france']['method'],
         Method.samplingCreateMessage,
       );
+      expect(
+        json['inputRequests']['capital_of_france']['params'],
+        isNot(contains('task')),
+      );
       expect(json['inputRequests']['roots'], {'method': Method.rootsList});
 
       final parsed = InputRequiredResult.fromJson(json);
@@ -770,6 +775,10 @@ void main() {
         parsed
             .inputRequests!['capital_of_france']!.createMessageParams.maxTokens,
         100,
+      );
+      expect(
+        parsed.inputRequests!['capital_of_france']!.createMessageParams.task,
+        isNull,
       );
     });
 
@@ -898,6 +907,32 @@ void main() {
             'resultType': resultTypeInputRequired,
             'inputRequests': {
               'unsupported': {'method': Method.toolsCall},
+            },
+          },
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => InputRequiredResult.fromJson(
+          const {
+            'resultType': resultTypeInputRequired,
+            'inputRequests': {
+              'legacy_task_sampling': {
+                'method': Method.samplingCreateMessage,
+                'params': {
+                  'messages': [
+                    {
+                      'role': 'user',
+                      'content': {
+                        'type': 'text',
+                        'text': 'Continue?',
+                      },
+                    },
+                  ],
+                  'maxTokens': 1,
+                  'task': {'ttl': 1000},
+                },
+              },
             },
           },
         ),


### PR DESCRIPTION
## Summary
- omit legacy `task` metadata from embedded MRTR `sampling/createMessage` input requests
- reject incoming embedded `sampling/createMessage` params that still carry legacy task metadata
- add 2026 RC regression coverage for serialization and malformed MRTR parsing

## Spec context
- The draft `CreateMessageRequestParams` schema includes sampling fields such as `messages`, `maxTokens`, `includeContext`, `metadata`, `modelPreferences`, `toolChoice`, and `tools`, but no legacy `task` member: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/draft/schema.json
- This preserves `CreateMessageRequest.toJson()` for legacy JSON-RPC sampling requests while making the embedded MRTR shape match the 2026 core schema.

Part of #177.

## Tests
- `dart format lib/src/types/json_rpc.dart test/mcp_2026_07_28_test.dart`
- `dart test test/mcp_2026_07_28_test.dart`
- `git diff --check`
- `dart analyze`
- `dart test`
