### PR TITLE
Keep image content theme parse-only

### DIFF
--- a/lib/src/types/content.dart
+++ b/lib/src/types/content.dart
@@ -267,7 +267,6 @@ sealed class Content {
           final ImageContent c => {
               'data': c.data,
               'mimeType': c.mimeType,
-              if (c.theme != null) 'theme': c.theme,
               if (c.annotations != null) 'annotations': c.annotations!.toJson(),
               if (c.meta != null)
                 '_meta': readJsonObject(c.meta, 'ImageContent._meta'),
@@ -346,6 +345,10 @@ class ImageContent extends Content {
   final String mimeType;
 
   /// Optional theme hint for legacy icon usage (`light` | `dark`).
+  ///
+  /// This field is parsed for backwards compatibility with older icon-shaped
+  /// payloads. MCP ImageContent content blocks do not serialize `theme`; use
+  /// [McpIcon.theme] for advertised icons.
   final String? theme;
 
   /// Optional annotations for the content block.

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -494,7 +494,7 @@ void main() {
       expect(deserialized.mimeType, equals('image/png'));
     });
 
-    test('ImageContent supports optional theme', () {
+    test('ImageContent parses legacy theme without serializing it', () {
       final content = const ImageContent(
         data: 'base64data',
         mimeType: 'image/png',
@@ -502,9 +502,12 @@ void main() {
       );
 
       final json = content.toJson();
-      expect(json['theme'], equals('dark'));
+      expect(json, isNot(contains('theme')));
 
-      final deserialized = ImageContent.fromJson(json);
+      final deserialized = ImageContent.fromJson({
+        ...json,
+        'theme': 'dark',
+      });
       expect(deserialized.theme, equals('dark'));
     });
 


### PR DESCRIPTION
## Summary
- stop serializing legacy `ImageContent.theme` on normal image content blocks
- keep parsing legacy `theme` values so old icon-shaped payloads remain readable
- leave spec-compliant `McpIcon.theme` behavior unchanged for advertised icons

## Spec context
Both current MCP 2025-11-25 and the draft schema define `ImageContent` with `_meta`, `annotations`, `data`, `mimeType`, and `type`; neither schema includes `theme` on image content blocks. The `theme` field belongs on `Icon`/`McpIcon` metadata, so this makes the content serializer spec-shaped without breaking legacy parsing.

Part of #177.

## Tests
- `dart format lib/src/types/content.dart test/types_test.dart`
- `dart test test/types_test.dart test/mcp_2025_11_25_test.dart test/mcp_2026_07_28_test.dart`
- `git diff --check`
- `dart analyze`
- `dart test`
