### PR TITLE
Support task metadata on elicitation requests

### DIFF
--- a/lib/src/types/elicitation.dart
+++ b/lib/src/types/elicitation.dart
@@ -1,5 +1,6 @@
 import '../shared/json_schema/json_schema.dart';
 import 'json_rpc.dart';
+import 'tasks.dart';
 import 'validation.dart';
 
 /// Legacy alias for [JsonSchema] used in elicitation requests.
@@ -40,12 +41,16 @@ class ElicitRequest {
   /// Required for URL mode to correlate with completion notifications.
   final String? elicitationId;
 
+  /// Task metadata for task-augmented execution.
+  final TaskCreation? task;
+
   const ElicitRequest({
     this.mode,
     required this.message,
     this.requestedSchema,
     this.url,
     this.elicitationId,
+    this.task,
   })  : assert(
           mode != ElicitationMode.url || requestedSchema == null,
           'URL elicitation must not include requestedSchema.',
@@ -75,6 +80,7 @@ class ElicitRequest {
   const ElicitRequest.form({
     required this.message,
     required ElicitationInputSchema this.requestedSchema,
+    this.task,
   })  : mode = ElicitationMode.form,
         url = null,
         elicitationId = null;
@@ -84,6 +90,7 @@ class ElicitRequest {
     required this.message,
     required String this.url,
     required String this.elicitationId,
+    this.task,
   })  : mode = ElicitationMode.url,
         requestedSchema = null;
 
@@ -110,6 +117,7 @@ class ElicitRequest {
     final requestedSchemaJson = json['requestedSchema'];
     final url = json['url'];
     final elicitationId = json['elicitationId'];
+    final task = readOptionalJsonObject(json['task'], 'ElicitRequest.task');
 
     if (mode == ElicitationMode.url) {
       if (url is! String) {
@@ -128,6 +136,7 @@ class ElicitRequest {
         message: message,
         url: url,
         elicitationId: elicitationId,
+        task: task == null ? null : TaskCreation.fromJson(task),
       );
     }
 
@@ -148,6 +157,7 @@ class ElicitRequest {
       mode: mode,
       message: message,
       requestedSchema: JsonSchema.fromJson(requestedSchemaJson),
+      task: task == null ? null : TaskCreation.fromJson(task),
     );
   }
 
@@ -188,6 +198,7 @@ class ElicitRequest {
       if (requestedSchema != null) 'requestedSchema': requestedSchema!.toJson(),
       if (url != null) 'url': url,
       if (elicitationId != null) 'elicitationId': elicitationId,
+      if (task != null) 'task': task!.toJson(),
     };
   }
 

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -711,9 +711,10 @@ class InputRequest {
 
   /// Creates an embedded `elicitation/create` input request.
   factory InputRequest.elicit(ElicitRequest params) {
+    final inputParams = params.toJson()..remove('task');
     return InputRequest._(
       method: Method.elicitationCreate,
-      params: params.toJson(),
+      params: inputParams,
     );
   }
 
@@ -746,6 +747,12 @@ class InputRequest {
           json['params'],
           'InputRequest.params',
         );
+        if (params.containsKey('task')) {
+          throw const FormatException(
+            'InputRequest elicitation/create params must not include '
+            'legacy task metadata',
+          );
+        }
         ElicitRequest.fromJson(params);
         return InputRequest._(method: method, params: params);
       case Method.samplingCreateMessage:

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -238,19 +238,23 @@ void main() {
         message: 'test',
         url: 'https://example.com/ui',
         elicitationId: 'ui-123',
+        task: TaskCreationParams(ttl: 7200),
       );
 
       expect(params.url, 'https://example.com/ui');
       expect(params.elicitationId, 'ui-123');
+      expect(params.task?.ttl, 7200);
 
       final json = params.toJson();
       expect(json['mode'], 'url');
       expect(json['url'], 'https://example.com/ui');
       expect(json['elicitationId'], 'ui-123');
+      expect(json['task'], {'ttl': 7200});
 
       final deserialized = ElicitRequestParams.fromJson(json);
       expect(deserialized.url, 'https://example.com/ui');
       expect(deserialized.elicitationId, 'ui-123');
+      expect(deserialized.task?.ttl, 7200);
     });
 
     test('Elicitation URL must be absolute URI', () {

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -725,6 +725,7 @@ void main() {
                 properties: {'name': JsonSchema.string()},
                 required: ['name'],
               ),
+              task: const TaskCreation(ttl: 1000),
             ),
           ),
           'capital_of_france': InputRequest.createMessage(
@@ -756,6 +757,10 @@ void main() {
         Method.elicitationCreate,
       );
       expect(
+        json['inputRequests']['github_login']['params'],
+        isNot(contains('task')),
+      );
+      expect(
         json['inputRequests']['capital_of_france']['method'],
         Method.samplingCreateMessage,
       );
@@ -770,6 +775,10 @@ void main() {
       expect(
         parsed.inputRequests!['github_login']!.elicitParams.message,
         'Please provide your GitHub username',
+      );
+      expect(
+        parsed.inputRequests!['github_login']!.elicitParams.task,
+        isNull,
       );
       expect(
         parsed
@@ -907,6 +916,30 @@ void main() {
             'resultType': resultTypeInputRequired,
             'inputRequests': {
               'unsupported': {'method': Method.toolsCall},
+            },
+          },
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => InputRequiredResult.fromJson(
+          const {
+            'resultType': resultTypeInputRequired,
+            'inputRequests': {
+              'legacy_task_elicit': {
+                'method': Method.elicitationCreate,
+                'params': {
+                  'mode': 'form',
+                  'message': 'Need username',
+                  'requestedSchema': {
+                    'type': 'object',
+                    'properties': {
+                      'name': {'type': 'string'},
+                    },
+                  },
+                  'task': {'ttl': 1000},
+                },
+              },
             },
           },
         ),

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -1069,16 +1069,19 @@ void main() {
           properties: {'name': JsonSchema.string(minLength: 1)},
           required: const ['name'],
         ),
+        task: const TaskCreationParams(ttl: 3600),
       );
 
       final json = params.toJson();
       expect(json['message'], equals("Enter your name"));
       expect(json['requestedSchema']['type'], equals('object'));
       expect(json['requestedSchema']['properties']['name']['type'], 'string');
+      expect(json['task'], {'ttl': 3600});
 
       final restored = ElicitRequestParams.fromJson(json);
       expect(restored.message, equals("Enter your name"));
       expect(restored.requestedSchema!.toJson()['type'], equals('object'));
+      expect(restored.task?.ttl, 3600);
     });
 
     test('JsonRpcElicitRequest serialization and deserialization', () {


### PR DESCRIPTION
## Summary
- add current-spec task metadata support to `ElicitRequest` params
- keep 2026 MRTR embedded `elicitation/create` input requests free of legacy task metadata
- add stable and draft regression coverage for typed round-trip and malformed MRTR input

## Spec context
MCP 2025-11-25 `ElicitRequestFormParams`/`ElicitRequestURLParams` include legacy task augmentation, while the 2026 draft embedded `ElicitRequest` params do not include `task`. This keeps stable/current round-trip support while preserving the 2026 core MRTR shape.

Part of #177.

## Tests
- `dart format .`
- `dart test test/types_test.dart test/mcp_2025_11_25_test.dart test/mcp_2026_07_28_test.dart test/elicitation_test.dart`
- `git diff --check`
- `dart analyze`
- `dart test`
