### PR TITLE
Validate discovery result types

### DIFF
--- a/lib/src/types/initialization.dart
+++ b/lib/src/types/initialization.dart
@@ -1083,6 +1083,16 @@ class DiscoverResult implements BaseResultData {
   });
 
   factory DiscoverResult.fromJson(Map<String, dynamic> json) {
+    final resultType = readOptionalString(
+      json['resultType'],
+      'DiscoverResult.resultType',
+    );
+    if (resultType != resultTypeComplete) {
+      throw const FormatException(
+        'DiscoverResult.resultType must be complete',
+      );
+    }
+
     final supportedVersions = json['supportedVersions'];
     if (supportedVersions is! List) {
       throw const FormatException(
@@ -1091,7 +1101,6 @@ class DiscoverResult implements BaseResultData {
     }
 
     return DiscoverResult(
-      resultType: json['resultType'] as String? ?? 'complete',
       supportedVersions: supportedVersions.cast<String>(),
       capabilities: ServerCapabilities.fromJson(
         json['capabilities'] as Map<String, dynamic>,
@@ -1105,14 +1114,24 @@ class DiscoverResult implements BaseResultData {
   }
 
   @override
-  Map<String, dynamic> toJson() => {
-        'resultType': resultType,
-        'supportedVersions': supportedVersions,
-        'capabilities': capabilities.toJson(),
-        'serverInfo': serverInfo.toJson(),
-        if (instructions != null) 'instructions': instructions,
-        if (meta != null) '_meta': readJsonObject(meta, 'DiscoverResult._meta'),
-      };
+  Map<String, dynamic> toJson() {
+    if (resultType != resultTypeComplete) {
+      throw ArgumentError.value(
+        resultType,
+        'DiscoverResult.resultType',
+        'must be complete',
+      );
+    }
+
+    return {
+      'resultType': resultType,
+      'supportedVersions': supportedVersions,
+      'capabilities': capabilities.toJson(),
+      'serverInfo': serverInfo.toJson(),
+      if (instructions != null) 'instructions': instructions,
+      if (meta != null) '_meta': readJsonObject(meta, 'DiscoverResult._meta'),
+    };
+  }
 }
 
 /// Notification sent from the client to the server after initialization is finished.

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -573,6 +573,43 @@ void main() {
       );
     });
 
+    test('requires complete resultType on server/discover results', () {
+      final validResult = const DiscoverResult(
+        supportedVersions: [draftProtocolVersion2026_07_28],
+        capabilities: ServerCapabilities(),
+        serverInfo: Implementation(name: 'server', version: '1.0.0'),
+      ).toJson();
+
+      for (final json in [
+        {
+          ...validResult,
+        }..remove('resultType'),
+        {
+          ...validResult,
+          'resultType': resultTypeInputRequired,
+        },
+        {
+          ...validResult,
+          'resultType': 1,
+        },
+      ]) {
+        expect(
+          () => DiscoverResult.fromJson(json),
+          throwsFormatException,
+        );
+      }
+
+      expect(
+        () => const DiscoverResult(
+          resultType: resultTypeInputRequired,
+          supportedVersions: [draftProtocolVersion2026_07_28],
+          capabilities: ServerCapabilities(),
+          serverInfo: Implementation(name: 'server', version: '1.0.0'),
+        ).toJson(),
+        throwsArgumentError,
+      );
+    });
+
     test('requires server/discover request metadata in params', () {
       expect(
         () => JsonRpcServerDiscoverRequest(id: 'discover-1').toJson(),


### PR DESCRIPTION
## Summary
- require `server/discover` results to include `resultType: complete`
- reject missing, non-string, and non-complete discovery result discriminators
- add the same rule to the built-in CLI spec conformance suite

## Spec context
The MCP 2026 draft `DiscoverResult` schema requires `resultType`, and the only valid complete discovery response shape uses `resultType: "complete"`. `server/discover` is draft-only in this SDK, so this tightens that typed boundary without changing stable initialization behavior.

Part of #177.

## Tests
- `dart format lib/src/types/initialization.dart test/mcp_2026_07_28_test.dart packages/mcp_dart_cli/lib/src/conformance_runner.dart packages/mcp_dart_cli/test/src/conformance_command_test.dart`
- `dart test test/mcp_2026_07_28_test.dart`
- `dart pub get` in `packages/mcp_dart_cli`
- `dart test test/src/conformance_command_test.dart` in `packages/mcp_dart_cli`
- `dart analyze`
- `dart analyze` in `packages/mcp_dart_cli`
- `git diff --check`
- `dart test`
- `dart test` in `packages/mcp_dart_cli`
