### PR TITLE
Validate icon source URIs

### DIFF
--- a/lib/src/types/content.dart
+++ b/lib/src/types/content.dart
@@ -28,6 +28,24 @@ String _readRequiredString(Object? value, String field) {
   throw FormatException('$field must be a string');
 }
 
+bool _isAbsoluteUri(String value) {
+  return Uri.tryParse(value)?.hasScheme ?? false;
+}
+
+String _readRequiredAbsoluteUriString(Object? value, String field) {
+  final result = _readRequiredString(value, field);
+  if (!_isAbsoluteUri(result)) {
+    throw FormatException('$field must be an absolute URI');
+  }
+  return result;
+}
+
+void _validateAbsoluteUriString(String value, String field) {
+  if (!_isAbsoluteUri(value)) {
+    throw ArgumentError.value(value, field, 'must be an absolute URI');
+  }
+}
+
 String? _readOptionalPresentString(
   Map<String, dynamic> json,
   String key,
@@ -266,7 +284,7 @@ class McpIcon {
     };
 
     return McpIcon(
-      src: _readRequiredString(json['src'], 'McpIcon.src'),
+      src: _readRequiredAbsoluteUriString(json['src'], 'McpIcon.src'),
       mimeType: _readOptionalPresentString(
         json,
         'mimeType',
@@ -277,12 +295,16 @@ class McpIcon {
     );
   }
 
-  Map<String, dynamic> toJson() => {
-        'src': src,
-        if (mimeType != null) 'mimeType': mimeType,
-        if (sizes != null) 'sizes': sizes,
-        if (theme != null) 'theme': theme!.name,
-      };
+  Map<String, dynamic> toJson() {
+    _validateAbsoluteUriString(src, 'McpIcon.src');
+
+    return {
+      'src': src,
+      if (mimeType != null) 'mimeType': mimeType,
+      if (sizes != null) 'sizes': sizes,
+      if (theme != null) 'theme': theme!.name,
+    };
+  }
 }
 
 /// Base class for content parts within prompts or tool results.

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -529,6 +529,11 @@ void main() {
         'sizes': ['48x48', 'any'],
         'theme': 'dark',
       });
+
+      final dataIcon = McpIcon.fromJson({
+        'src': 'data:image/png;base64,aWNvbg==',
+      });
+      expect(dataIcon.src, equals('data:image/png;base64,aWNvbg=='));
     });
 
     test('McpIcon rejects malformed stable wire fields', () {
@@ -540,6 +545,8 @@ void main() {
 
       expectInvalid({});
       expectInvalid({'src': 1});
+      expectInvalid({'src': 'icon.png'});
+      expectInvalid({'src': '://not-a-uri'});
       expectInvalid({'src': 'https://example.com/icon.png', 'mimeType': null});
       expectInvalid({'src': 'https://example.com/icon.png', 'mimeType': 1});
       expectInvalid({'src': 'https://example.com/icon.png', 'sizes': null});
@@ -551,6 +558,17 @@ void main() {
       expectInvalid({'src': 'https://example.com/icon.png', 'theme': null});
       expectInvalid({'src': 'https://example.com/icon.png', 'theme': 1});
       expectInvalid({'src': 'https://example.com/icon.png', 'theme': 'sepia'});
+    });
+
+    test('McpIcon validates src URI during serialization', () {
+      expect(
+        () => const McpIcon(src: 'icon.png').toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        const McpIcon(src: 'data:image/png;base64,aWNvbg==').toJson()['src'],
+        equals('data:image/png;base64,aWNvbg=='),
+      );
     });
 
     test('Implementation icon parsing rejects invalid themes', () {


### PR DESCRIPTION
## Summary
- enforce `Icon.src` as an absolute URI while parsing icon wire JSON
- validate constructed `McpIcon` values during serialization
- cover data URI support and malformed/relative source rejection

## Validation
- `dart format lib/src/types/content.dart test/types_test.dart`
- `dart analyze`
- `dart test test/types_test.dart`
- `dart test test/mcp_2025_11_25_test.dart`
- `dart test test/mcp_2026_07_28_test.dart`
- `git diff --check`
- `dart test`
