### PR TITLE
Accept whole-number integer wire values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@
 - Retried `server/discover` with an advertised compatible stateless protocol
   version after `UnsupportedProtocolVersionError` instead of falling back to
   legacy initialization.
+- Accepted whole-number JSON numeric values for integer wire fields such as
+  resource link sizes, completion totals, sampling `maxTokens`, task TTLs, and
+  JSON Schema length/item bounds while continuing to reject fractional values.
 - Added client-side `subscriptions/listen` handles that correlate stream
   notifications by `io.modelcontextprotocol/subscriptionId`, validate the
   acknowledgment, and cancel long-lived streams with `notifications/cancelled`.

--- a/lib/src/shared/json_schema/json_schema.dart
+++ b/lib/src/shared/json_schema/json_schema.dart
@@ -1,5 +1,18 @@
 const _jsonSchemaAnnotationKeys = {'title', 'description', 'default'};
 
+int? _readOptionalInteger(Object? value, String field) {
+  if (value == null) {
+    return null;
+  }
+  if (value is int) {
+    return value;
+  }
+  if (value is double && value.isFinite && value == value.truncateToDouble()) {
+    return value.toInt();
+  }
+  throw FormatException('$field must be an integer');
+}
+
 /// A builder for creating JSON Schemas in a type-safe way.
 sealed class JsonSchema {
   final String? title;
@@ -496,8 +509,14 @@ class JsonString extends JsonSchema {
   factory JsonString.fromJson(Map<String, dynamic> json) {
     final rawMcpHeader = json['x-mcp-header'];
     return JsonString._(
-      minLength: json['minLength'] as int?,
-      maxLength: json['maxLength'] as int?,
+      minLength: _readOptionalInteger(
+        json['minLength'],
+        'JsonString.minLength',
+      ),
+      maxLength: _readOptionalInteger(
+        json['maxLength'],
+        'JsonString.maxLength',
+      ),
       pattern: json['pattern'] as String?,
       format: json['format'] as String?,
       enumValues: (json['enum'] as List?)?.cast<String>() ??
@@ -832,8 +851,14 @@ class JsonArray extends JsonSchema {
       items: json['items'] != null
           ? JsonSchema.fromJson(json['items'] as Map<String, dynamic>)
           : null,
-      minItems: json['minItems'] as int?,
-      maxItems: json['maxItems'] as int?,
+      minItems: _readOptionalInteger(
+        json['minItems'],
+        'JsonArray.minItems',
+      ),
+      maxItems: _readOptionalInteger(
+        json['maxItems'],
+        'JsonArray.maxItems',
+      ),
       uniqueItems: json['uniqueItems'] as bool?,
       title: json['title'] as String?,
       description: json['description'] as String?,

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:mcp_dart/src/shared/logging.dart';
 import 'package:mcp_dart/src/shared/task_interfaces.dart';
 import 'package:mcp_dart/src/types.dart';
+import 'package:mcp_dart/src/types/validation.dart';
 import 'package:meta/meta.dart';
 
 import 'transport.dart';
@@ -1275,8 +1276,10 @@ abstract class Protocol {
               this,
             )
           : null,
-      taskRequestedTtl:
-          (request.params?['task'] as Map<String, dynamic>?)?['ttl'] as int?,
+      taskRequestedTtl: readOptionalInteger(
+        (request.params?['task'] as Map<String, dynamic>?)?['ttl'],
+        'RequestOptions.task.ttl',
+      ),
       sendNotification: (notification, {relatedTask}) {
         var outgoingNotification = notification;
         if (subscriptionState != null) {

--- a/lib/src/types/completion.dart
+++ b/lib/src/types/completion.dart
@@ -204,7 +204,7 @@ class CompletionResultData {
     }
     return CompletionResultData(
       values: values.cast<String>(),
-      total: json['total'] as int?,
+      total: readOptionalInteger(json['total'], 'CompletionResultData.total'),
       hasMore: json['hasMore'] as bool?,
     );
   }

--- a/lib/src/types/content.dart
+++ b/lib/src/types/content.dart
@@ -574,7 +574,7 @@ class ResourceLink extends Content {
       title: json['title'] as String?,
       description: json['description'] as String?,
       mimeType: json['mimeType'] as String?,
-      size: json['size'] as int?,
+      size: readOptionalInteger(json['size'], 'ResourceLink.size'),
       icons: (json['icons'] as List<dynamic>?)
           ?.map((icon) => McpIcon.fromJson(_asJsonObject(icon)))
           .toList(),

--- a/lib/src/types/sampling.dart
+++ b/lib/src/types/sampling.dart
@@ -664,7 +664,10 @@ class CreateMessageRequest {
         json['temperature'],
         'CreateMessageRequest.temperature',
       ),
-      maxTokens: json['maxTokens'] as int,
+      maxTokens: readInteger(
+        json['maxTokens'],
+        'CreateMessageRequest.maxTokens',
+      ),
       stopSequences: (json['stopSequences'] as List<dynamic>?)?.cast<String>(),
       metadata: _asJsonObjectOrNull(
         json['metadata'],

--- a/lib/src/types/tasks.dart
+++ b/lib/src/types/tasks.dart
@@ -178,6 +178,9 @@ int? _readTaskInt(
   if (value == null || value is int) {
     return value as int?;
   }
+  if (value is double && value.isFinite && value == value.truncateToDouble()) {
+    return value.toInt();
+  }
 
   throw FormatException('$owner.$field must be an integer or null');
 }
@@ -442,7 +445,7 @@ class TaskCreation {
   const TaskCreation({this.ttl});
 
   factory TaskCreation.fromJson(Map<String, dynamic> json) =>
-      TaskCreation(ttl: json['ttl'] as int?);
+      TaskCreation(ttl: readOptionalInteger(json['ttl'], 'TaskCreation.ttl'));
 
   Map<String, dynamic> toJson() => {
         if (ttl != null) 'ttl': ttl,

--- a/lib/src/types/validation.dart
+++ b/lib/src/types/validation.dart
@@ -63,6 +63,14 @@ int? readOptionalInteger(Object? value, String field) {
   throw FormatException('$field must be an integer');
 }
 
+int readInteger(Object? value, String field) {
+  final integer = readOptionalInteger(value, field);
+  if (integer == null) {
+    throw FormatException('$field is required');
+  }
+  return integer;
+}
+
 String? readOptionalString(Object? value, String field) {
   if (value == null) {
     return null;

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -743,6 +743,17 @@ void main() {
         expect(deserialized.ttl, 3600);
       });
 
+      test('TaskCreationParams accepts whole-number JSON ttl values', () {
+        final deserialized = TaskCreationParams.fromJson({'ttl': 3600.0});
+        expect(deserialized.ttl, 3600);
+        expect(deserialized.toJson()['ttl'], 3600);
+
+        expect(
+          () => TaskCreationParams.fromJson({'ttl': 3600.5}),
+          throwsA(isA<FormatException>()),
+        );
+      });
+
       test('TaskCreationParams without ttl', () {
         final params = const TaskCreationParams();
         expect(params.ttl, isNull);
@@ -1041,6 +1052,22 @@ void main() {
         final json = task.toJson();
         expect(json, containsPair('ttl', null));
         expect(json, isNot(contains('pollInterval')));
+      });
+
+      test('Task accepts whole-number JSON ttl and poll interval values', () {
+        final task = Task.fromJson({
+          'taskId': 'numeric-task',
+          'status': 'working',
+          'ttl': 3600.0,
+          'pollInterval': 500.0,
+          'createdAt': '2025-01-15T10:00:00Z',
+          'lastUpdatedAt': '2025-01-15T10:01:00Z',
+        });
+
+        expect(task.ttl, 3600);
+        expect(task.pollInterval, 500);
+        expect(task.toJson(), containsPair('ttl', 3600));
+        expect(task.toJson(), containsPair('pollInterval', 500));
       });
 
       test('Task rejects missing MCP-required fields', () {
@@ -1430,6 +1457,19 @@ void main() {
         expect(
           () => CompletionResultData.fromJson({
             'values': List.generate(101, (index) => '$index'),
+          }),
+          throwsA(isA<FormatException>()),
+        );
+        final completion = CompletionResultData.fromJson({
+          'values': ['a'],
+          'total': 10.0,
+        });
+        expect(completion.total, 10);
+        expect(completion.toJson()['total'], 10);
+        expect(
+          () => CompletionResultData.fromJson({
+            'values': ['a'],
+            'total': 10.5,
           }),
           throwsA(isA<FormatException>()),
         );

--- a/test/shared/json_schema_from_json_test.dart
+++ b/test/shared/json_schema_from_json_test.dart
@@ -22,6 +22,32 @@ void main() {
       expect(s.enumValues, ['a', 'b']);
     });
 
+    test('accepts whole-number numeric string schema bounds', () {
+      final schema = JsonSchema.fromJson({
+        'type': 'string',
+        'minLength': 5.0,
+        'maxLength': 10.0,
+      });
+
+      expect(schema, isA<JsonString>());
+      final stringSchema = schema as JsonString;
+      expect(stringSchema.minLength, 5);
+      expect(stringSchema.maxLength, 10);
+      expect(stringSchema.toJson(), {
+        'minLength': 5,
+        'maxLength': 10,
+        'type': 'string',
+      });
+
+      expect(
+        () => JsonSchema.fromJson({
+          'type': 'string',
+          'minLength': 1.5,
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
     test('preserves mixed typed enum schemas conjunctively', () {
       final json = {
         'type': 'string',
@@ -192,6 +218,32 @@ void main() {
       expect(s.minItems, 1);
       expect(s.maxItems, 5);
       expect(s.uniqueItems, true);
+    });
+
+    test('accepts whole-number numeric array schema bounds', () {
+      final schema = JsonSchema.fromJson({
+        'type': 'array',
+        'minItems': 1.0,
+        'maxItems': 5.0,
+      });
+
+      expect(schema, isA<JsonArray>());
+      final arraySchema = schema as JsonArray;
+      expect(arraySchema.minItems, 1);
+      expect(arraySchema.maxItems, 5);
+      expect(arraySchema.toJson(), {
+        'minItems': 1,
+        'maxItems': 5,
+        'type': 'array',
+      });
+
+      expect(
+        () => JsonSchema.fromJson({
+          'type': 'array',
+          'minItems': 1.5,
+        }),
+        throwsA(isA<FormatException>()),
+      );
     });
 
     test('parses object schema', () {

--- a/test/shared/protocol_test.dart
+++ b/test/shared/protocol_test.dart
@@ -751,6 +751,43 @@ void main() {
       expect((await requestFuture).task.taskId, 'shape-task');
     });
 
+    test('handler extra accepts whole-number JSON task ttl values', () async {
+      await protocol.connect(transport);
+
+      final observedTtl = Completer<int?>();
+      protocol.setRequestHandler<JsonRpcRequest>(
+        'test/task-ttl',
+        (request, extra) async {
+          observedTtl.complete(extra.taskRequestedTtl);
+          return TestResult(value: 'ok');
+        },
+        (id, params, meta) => JsonRpcRequest(
+          id: id,
+          method: 'test/task-ttl',
+          params: params,
+          meta: meta,
+        ),
+      );
+
+      transport.receiveMessage(
+        const JsonRpcRequest(
+          id: 99,
+          method: 'test/task-ttl',
+          params: {
+            'task': {'ttl': 1234.0},
+          },
+        ),
+      );
+
+      await waitForSentMessages(transport, 1);
+      expect(
+        await observedTtl.future.timeout(const Duration(seconds: 5)),
+        1234,
+      );
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      expect(response.result, {'value': 'ok'});
+    });
+
     test('progress notifications reset timeout for custom tokens', () async {
       await protocol.connect(transport);
 

--- a/test/types/sampling_test.dart
+++ b/test/types/sampling_test.dart
@@ -494,6 +494,37 @@ void main() {
       expect(params.includeContext, equals(IncludeContext.allServers));
     });
 
+    test('accepts whole-number JSON maxTokens values', () {
+      final messages = [
+        {
+          'role': 'user',
+          'content': {'type': 'text', 'text': 'Hello'},
+        },
+      ];
+
+      final params = CreateMessageRequestParams.fromJson({
+        'messages': messages,
+        'maxTokens': 100.0,
+      });
+
+      expect(params.maxTokens, 100);
+      expect(params.toJson()['maxTokens'], 100);
+
+      expect(
+        () => CreateMessageRequestParams.fromJson({
+          'messages': messages,
+          'maxTokens': 100.5,
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => CreateMessageRequestParams.fromJson({
+          'messages': messages,
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
     test('rejects non-finite temperature values', () {
       final messages = [
         {

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -784,6 +784,28 @@ void main() {
       expect((content as ResourceLink).uri, equals('file:///docs/spec.md'));
     });
 
+    test('ResourceLink accepts whole-number JSON size values', () {
+      final link = ResourceLink.fromJson({
+        'type': 'resource_link',
+        'uri': 'file:///docs/spec.md',
+        'name': 'spec',
+        'size': 123.0,
+      });
+
+      expect(link.size, 123);
+      expect(link.toJson()['size'], 123);
+
+      expect(
+        () => ResourceLink.fromJson({
+          'type': 'resource_link',
+          'uri': 'file:///docs/spec.md',
+          'name': 'spec',
+          'size': 123.5,
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
     test('EmbeddedResource supports annotations and meta', () {
       final content = const EmbeddedResource(
         resource: TextResourceContents(


### PR DESCRIPTION
## Summary
- accept whole-number JSON numeric values for remaining integer wire fields
- cover resource link size, completion total, sampling maxTokens, task TTLs, protocol handler TTLs, and JSON Schema string/array bounds
- document the compatibility tightening in the 2026 RC changelog

## Validation
- dart analyze
- git diff --check
- dart test test/types_test.dart test/shared/json_schema_from_json_test.dart test/types/sampling_test.dart test/mcp_2025_11_25_test.dart test/shared/protocol_test.dart
- dart test test/mcp_2026_07_28_test.dart
- dart test