### PR TITLE
Restrict elicitation content numbers to integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,8 +91,9 @@
   clamping malformed wire values to zero.
 - Validated MRTR `inputResponses` as `CreateMessageResult`, `ListRootsResult`,
   or `ElicitResult` instead of accepting arbitrary result objects.
-- Allowed finite numeric `ElicitResult.content` values to match the stable and
-  MCP 2026 `string | number | boolean | string[]` schema.
+- Restricted numeric `ElicitResult.content` values to integers, matching the
+  stable and MCP 2026 `string | integer | boolean | string[]` schemas while
+  still accepting whole-number JSON numeric values.
 - Rejected form elicitation schemas that provide legacy `enumNames` without the
   required string `enum`.
 - Rejected `ElicitResult.content` when the result action is `decline` or

--- a/lib/src/types/elicitation.dart
+++ b/lib/src/types/elicitation.dart
@@ -301,10 +301,10 @@ class ElicitResult implements BaseResultData {
   Map<String, dynamic> toJson() {
     final resultAction = action;
     _validateElicitResultContentForAction(resultAction, content);
-    _validateElicitResultContent(content);
+    final normalizedContent = _normalizeElicitResultContent(content);
     return {
       'action': resultAction,
-      if (content != null) 'content': content,
+      if (normalizedContent != null) 'content': normalizedContent,
       if (meta != null) '_meta': readJsonObject(meta, 'ElicitResult._meta'),
     };
   }
@@ -726,39 +726,49 @@ Map<String, dynamic>? _parseElicitResultContent(Object? content) {
     throw const FormatException('ElicitResult.content must be an object.');
   }
   final result = content.cast<String, dynamic>();
-  _validateElicitResultContent(result, formatException: true);
-  return result;
+  return _normalizeElicitResultContent(result, formatException: true);
 }
 
-void _validateElicitResultContent(
+Map<String, dynamic>? _normalizeElicitResultContent(
   Map<String, dynamic>? content, {
   bool formatException = false,
 }) {
   if (content == null) {
-    return;
+    return null;
   }
+  final normalized = <String, dynamic>{};
   for (final entry in content.entries) {
     final value = entry.value;
     if (value is String || value is bool) {
+      normalized[entry.key] = value;
       continue;
     }
-    if (value is num && value.isFinite) {
+    if (value is int) {
+      normalized[entry.key] = value;
+      continue;
+    }
+    if (value is double &&
+        value.isFinite &&
+        value == value.truncateToDouble()) {
+      normalized[entry.key] = value.toInt();
       continue;
     }
     if (value is List && value.every((item) => item is String)) {
+      normalized[entry.key] = List<String>.from(value);
       continue;
     }
     if (formatException) {
       throw FormatException(
-        'ElicitResult.content.${entry.key} must be string, finite number, boolean, or string[]',
+        'ElicitResult.content.${entry.key} must be string, integer, boolean, or string[]',
       );
     }
     throw ArgumentError.value(
       value,
       'content.${entry.key}',
-      'ElicitResult content values must be string, finite number, boolean, or string[]',
+      'ElicitResult content values must be string, integer, boolean, or string[]',
     );
   }
+  return normalized;
 }
 
 void _validateElicitResultContentForAction(

--- a/test/elicitation_test.dart
+++ b/test/elicitation_test.dart
@@ -1116,7 +1116,7 @@ void main() {
         'action': 'accept',
         'content': {
           'text': 'value',
-          'count': 3,
+          'count': 3.0,
           'confirmed': true,
           'selections': ['a', 'b'],
         },
@@ -1143,13 +1143,13 @@ void main() {
         throwsA(isA<FormatException>()),
       );
       expect(
-        ElicitResult.fromJson({
+        () => ElicitResult.fromJson({
           'action': 'accept',
           'content': {
             'ratio': 0.5,
           },
-        }).content?['ratio'],
-        0.5,
+        }),
+        throwsA(isA<FormatException>()),
       );
       expect(
         () => ElicitResult.fromJson({
@@ -1170,13 +1170,22 @@ void main() {
         throwsA(isA<ArgumentError>()),
       );
       expect(
-        const ElicitResult(
+        () => const ElicitResult(
           action: 'accept',
           content: {
             'ratio': 0.5,
           },
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        const ElicitResult(
+          action: 'accept',
+          content: {
+            'count': 3.0,
+          },
         ).toJson()['content'],
-        containsPair('ratio', 0.5),
+        containsPair('count', 3),
       );
       expect(
         () => const ElicitResult(

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -330,17 +330,17 @@ void main() {
         action: 'accept',
         content: {
           'text': 'answer',
-          'confidence': 0.75,
+          'confidence': 75,
           'selection': ['a', 'b'], // List<String>
         },
       );
-      expect(result.content?['confidence'], 0.75);
+      expect(result.content?['confidence'], 75);
       expect(result.content?['selection'], isA<List>());
       expect((result.content?['selection'] as List).first, 'a');
 
       final json = result.toJson();
       final deserialized = ElicitResult.fromJson(json);
-      expect(deserialized.content?['confidence'], 0.75);
+      expect(deserialized.content?['confidence'], 75);
       expect((deserialized.content?['selection'] as List).last, 'b');
     });
 
@@ -1417,6 +1417,24 @@ void main() {
             action: 'accept',
             content: {
               'bad': ['ok', 1],
+            },
+          ).toJson(),
+          throwsA(isA<ArgumentError>()),
+        );
+        expect(
+          () => ElicitResult.fromJson({
+            'action': 'accept',
+            'content': {
+              'fractional': 1.5,
+            },
+          }),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => const ElicitResult(
+            action: 'accept',
+            content: {
+              'fractional': 1.5,
             },
           ).toJson(),
           throwsA(isA<ArgumentError>()),

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -429,9 +429,23 @@ void main() {
         throwsA(isA<FormatException>()),
       );
       expect(
+        () => ElicitResult.fromJson({
+          'action': 'accept',
+          'content': {'score': 1.5},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
         () => const ElicitResult(
           action: 'accept',
           content: {'score': double.nan},
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => const ElicitResult(
+          action: 'accept',
+          content: {'score': 1.5},
         ).toJson(),
         throwsA(isA<ArgumentError>()),
       );


### PR DESCRIPTION
## Summary
- align ElicitResult.content numeric values with the current stable and draft schemas by allowing only integers
- normalize whole-number JSON numeric values to ints while rejecting fractional values
- update stable/draft regression coverage and the changelog note

## Validation
- dart test test/elicitation_test.dart
- dart test test/mcp_2025_11_25_test.dart test/mcp_2026_07_28_test.dart
- dart analyze
- git diff --check
- dart test