### PR TITLE
Validate role wire fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,8 @@
   content to match stable and MCP 2026 `format: byte` schemas.
 - Rejected malformed shared annotation fields, including non-role audiences,
   out-of-range priorities, and non-string `lastModified` values.
+- Rejected malformed `Role` values in prompt and sampling messages instead of
+  allowing raw enum lookup failures.
 - Rejected non-finite numeric values for progress, annotation priority, model
   priority, and sampling temperature fields so SDK-built payloads remain valid
   JSON numbers.

--- a/lib/src/types/prompts.dart
+++ b/lib/src/types/prompts.dart
@@ -295,7 +295,9 @@ class PromptMessage {
 
   factory PromptMessage.fromJson(Map<String, dynamic> json) {
     return PromptMessage(
-      role: PromptMessageRole.values.byName(json['role'] as String),
+      role: PromptMessageRole.values.byName(
+        readRequiredRoleString(json['role'], 'PromptMessage.role'),
+      ),
       content: Content.fromJson(json['content'] as Map<String, dynamic>),
     );
   }

--- a/lib/src/types/sampling.dart
+++ b/lib/src/types/sampling.dart
@@ -560,7 +560,9 @@ class SamplingMessage {
 
   factory SamplingMessage.fromJson(Map<String, dynamic> json) {
     return SamplingMessage(
-      role: SamplingMessageRole.values.byName(json['role'] as String),
+      role: SamplingMessageRole.values.byName(
+        readRequiredRoleString(json['role'], 'SamplingMessage.role'),
+      ),
       content: _parseSamplingMessageContent(json['content']),
       meta: _asJsonObjectOrNull(json['_meta'], 'SamplingMessage._meta'),
     );
@@ -818,7 +820,9 @@ class CreateMessageResult implements BaseResultData {
     return CreateMessageResult(
       model: json['model'] as String,
       stopReason: reason,
-      role: SamplingMessageRole.values.byName(json['role'] as String),
+      role: SamplingMessageRole.values.byName(
+        readRequiredRoleString(json['role'], 'CreateMessageResult.role'),
+      ),
       content: _parseSamplingMessageContent(json['content']),
       meta: meta,
     );

--- a/lib/src/types/validation.dart
+++ b/lib/src/types/validation.dart
@@ -85,6 +85,18 @@ void validateBase64String(String value, String field) {
   }
 }
 
+bool isRoleString(String value) {
+  return value == 'user' || value == 'assistant';
+}
+
+String readRequiredRoleString(Object? value, String field) {
+  final result = readRequiredString(value, field);
+  if (!isRoleString(result)) {
+    throw FormatException('$field must be "user" or "assistant"');
+  }
+  return result;
+}
+
 List<String>? readOptionalAnnotationAudience(Object? value, String field) {
   if (value == null) {
     return null;
@@ -93,11 +105,7 @@ List<String>? readOptionalAnnotationAudience(Object? value, String field) {
     throw FormatException('$field must be a list of roles');
   }
   return [
-    for (final item in value)
-      if (item is String && (item == 'user' || item == 'assistant'))
-        item
-      else
-        throw FormatException('$field items must be "user" or "assistant"'),
+    for (final item in value) readRequiredRoleString(item, '$field items'),
   ];
 }
 
@@ -106,7 +114,7 @@ void validateAnnotationAudience(List<String>? value, String field) {
     return;
   }
   for (final item in value) {
-    if (item != 'user' && item != 'assistant') {
+    if (!isRoleString(item)) {
       throw ArgumentError.value(
         item,
         field,

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -1533,6 +1533,28 @@ void main() {
           () => ModelPreferences.fromJson({'costPriority': -1}),
           throwsA(isA<FormatException>()),
         );
+        expect(
+          () => SamplingMessage.fromJson({
+            'role': 'system',
+            'content': {'type': 'text', 'text': 'Hello'},
+          }),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => CreateMessageResult.fromJson({
+            'role': 'system',
+            'content': {'type': 'text', 'text': 'Hello'},
+            'model': 'model',
+          }),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => PromptMessage.fromJson({
+            'role': 'system',
+            'content': {'type': 'text', 'text': 'Hello'},
+          }),
+          throwsA(isA<FormatException>()),
+        );
       });
 
       test('bare task containers strip task metadata', () {

--- a/test/types/sampling_test.dart
+++ b/test/types/sampling_test.dart
@@ -455,6 +455,23 @@ void main() {
       expect(msg.content, isA<SamplingTextContent>());
     });
 
+    test('validates role wire values', () {
+      expect(
+        () => SamplingMessage.fromJson({
+          'role': 'system',
+          'content': {'type': 'text', 'text': 'Question'},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => SamplingMessage.fromJson({
+          'role': 1,
+          'content': {'type': 'text', 'text': 'Question'},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
     test('supports array content with normalized contentBlocks', () {
       final msg = const SamplingMessage(
         role: SamplingMessageRole.assistant,
@@ -730,6 +747,25 @@ void main() {
       };
       final result = CreateMessageResult.fromJson(json);
       expect(result.stopReason, equals('customReason'));
+    });
+
+    test('validates role wire values', () {
+      expect(
+        () => CreateMessageResult.fromJson({
+          'role': 'system',
+          'content': {'type': 'text', 'text': 'Msg'},
+          'model': 'model-x',
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => CreateMessageResult.fromJson({
+          'role': 1,
+          'content': {'type': 'text', 'text': 'Msg'},
+          'model': 'model-x',
+        }),
+        throwsA(isA<FormatException>()),
+      );
     });
 
     test('rejects non-JSON metadata objects', () {

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -1104,6 +1104,23 @@ void main() {
       expect(deserialized.description, equals('Argument 1'));
       expect(deserialized.required, equals(true));
     });
+
+    test('PromptMessage validates role wire values', () {
+      expect(
+        () => PromptMessage.fromJson({
+          'role': 'system',
+          'content': {'type': 'text', 'text': 'Hello'},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => PromptMessage.fromJson({
+          'role': 1,
+          'content': {'type': 'text', 'text': 'Hello'},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
   });
   group('CreateMessageResult Tests', () {
     test('CreateMessageResult serialization and deserialization', () {


### PR DESCRIPTION
## Summary
- add shared validation for MCP `Role` wire values (`user` or `assistant`)
- use the role validator for prompt messages, sampling messages, and create-message results
- keep the typed enum APIs unchanged while rejecting malformed wire JSON as `FormatException`

## Validation
- dart format lib/src/types/validation.dart lib/src/types/sampling.dart lib/src/types/prompts.dart test/types/sampling_test.dart test/types_test.dart test/mcp_2025_11_25_test.dart
- dart test test/types/sampling_test.dart test/types_test.dart test/mcp_2025_11_25_test.dart
- dart analyze
- git diff --check
- dart test
- dart pub global run coverage:test_with_coverage

Stacked on #264. This remains a draft RC PR and stays off `main` until the official spec release.