### PR TITLE
Validate enum wire fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@
   out-of-range priorities, and non-string `lastModified` values.
 - Rejected malformed `Role` values in prompt and sampling messages instead of
   allowing raw enum lookup failures.
+- Rejected malformed logging level, sampling `includeContext`, and sampling
+  `toolChoice.mode` enum values with protocol parse errors.
 - Rejected non-finite numeric values for progress, annotation priority, model
   priority, and sampling temperature fields so SDK-built payloads remain valid
   JSON numbers.

--- a/lib/src/types/logging.dart
+++ b/lib/src/types/logging.dart
@@ -22,7 +22,11 @@ class SetLevelRequest {
 
   factory SetLevelRequest.fromJson(Map<String, dynamic> json) =>
       SetLevelRequest(
-        level: LoggingLevel.values.byName(json['level'] as String),
+        level: readRequiredEnumValue(
+          json['level'],
+          LoggingLevel.values,
+          'SetLevelRequest.level',
+        ),
       );
 
   Map<String, dynamic> toJson() => {'level': level.name};
@@ -74,7 +78,11 @@ class LoggingMessageNotification {
     Map<String, dynamic> json,
   ) =>
       LoggingMessageNotification(
-        level: LoggingLevel.values.byName(json['level'] as String),
+        level: readRequiredEnumValue(
+          json['level'],
+          LoggingLevel.values,
+          'LoggingMessageNotification.level',
+        ),
         logger: json['logger'] as String?,
         data: json['data'],
       );

--- a/lib/src/types/sampling.dart
+++ b/lib/src/types/sampling.dart
@@ -596,11 +596,13 @@ class ToolChoice {
       return const ToolChoice();
     }
 
-    if (rawMode is! String) {
-      throw FormatException('Expected toolChoice mode string, got $rawMode');
-    }
-
-    return ToolChoice(mode: ToolChoiceMode.values.byName(rawMode));
+    return ToolChoice(
+      mode: readRequiredEnumValue(
+        rawMode,
+        ToolChoiceMode.values,
+        'ToolChoice.mode',
+      ),
+    );
   }
 
   Map<String, dynamic> toJson() => {
@@ -667,9 +669,14 @@ class CreateMessageRequest {
   });
 
   factory CreateMessageRequest.fromJson(Map<String, dynamic> json) {
-    final ctxStr = json['includeContext'] as String?;
-    final task = _asJsonObjectOrNull(json['task']);
-    final toolChoice = _asJsonObjectOrNull(json['toolChoice']);
+    final task = _asJsonObjectOrNull(json['task'], 'CreateMessageRequest.task');
+    final toolChoice = _asJsonObjectOrNull(
+      json['toolChoice'],
+      'CreateMessageRequest.toolChoice',
+    );
+    if (toolChoice != null) {
+      ToolChoice.fromJson(toolChoice);
+    }
     final messages = json['messages'];
     if (messages is! List) {
       throw const FormatException('CreateMessageRequest.messages is required');
@@ -680,8 +687,11 @@ class CreateMessageRequest {
           .toList(),
       task: task == null ? null : TaskCreation.fromJson(task),
       systemPrompt: json['systemPrompt'] as String?,
-      includeContext:
-          ctxStr == null ? null : IncludeContext.values.byName(ctxStr),
+      includeContext: readOptionalEnumValue(
+        json['includeContext'],
+        IncludeContext.values,
+        'CreateMessageRequest.includeContext',
+      ),
       temperature: readOptionalFiniteDouble(
         json['temperature'],
         'CreateMessageRequest.temperature',

--- a/lib/src/types/validation.dart
+++ b/lib/src/types/validation.dart
@@ -85,6 +85,32 @@ void validateBase64String(String value, String field) {
   }
 }
 
+T readRequiredEnumValue<T extends Enum>(
+  Object? value,
+  Iterable<T> values,
+  String field,
+) {
+  final name = readRequiredString(value, field);
+  for (final enumValue in values) {
+    if (enumValue.name == name) {
+      return enumValue;
+    }
+  }
+  final allowed = values.map((value) => '"${value.name}"').join(', ');
+  throw FormatException('$field must be one of: $allowed');
+}
+
+T? readOptionalEnumValue<T extends Enum>(
+  Object? value,
+  Iterable<T> values,
+  String field,
+) {
+  if (value == null) {
+    return null;
+  }
+  return readRequiredEnumValue(value, values, field);
+}
+
 bool isRoleString(String value) {
   return value == 'user' || value == 'assistant';
 }

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -1555,6 +1555,42 @@ void main() {
           }),
           throwsA(isA<FormatException>()),
         );
+        expect(
+          () => SetLevelRequestParams.fromJson({'level': 'verbose'}),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => LoggingMessageNotificationParams.fromJson({
+            'level': 'verbose',
+          }),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => CreateMessageRequestParams.fromJson({
+            'messages': [
+              {
+                'role': 'user',
+                'content': {'type': 'text', 'text': 'Hello'},
+              },
+            ],
+            'maxTokens': 100,
+            'includeContext': 'nearbyServers',
+          }),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => CreateMessageRequestParams.fromJson({
+            'messages': [
+              {
+                'role': 'user',
+                'content': {'type': 'text', 'text': 'Hello'},
+              },
+            ],
+            'maxTokens': 100,
+            'toolChoice': {'mode': 'sometimes'},
+          }),
+          throwsA(isA<FormatException>()),
+        );
       });
 
       test('bare task containers strip task metadata', () {

--- a/test/types/logging_types_test.dart
+++ b/test/types/logging_types_test.dart
@@ -48,6 +48,17 @@ void main() {
         expect(params.level, equals(level));
       }
     });
+
+    test('rejects malformed logging levels', () {
+      expect(
+        () => SetLevelRequestParams.fromJson({'level': 'verbose'}),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => SetLevelRequestParams.fromJson({'level': 1}),
+        throwsA(isA<FormatException>()),
+      );
+    });
   });
 
   group('JsonRpcSetLevelRequest', () {
@@ -186,6 +197,23 @@ void main() {
       expect(restored.level, equals(original.level));
       expect(restored.logger, equals(original.logger));
       expect(restored.data, equals(original.data));
+    });
+
+    test('rejects malformed logging levels', () {
+      expect(
+        () => LoggingMessageNotificationParams.fromJson({
+          'level': 'verbose',
+          'data': 'message',
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => LoggingMessageNotificationParams.fromJson({
+          'level': 1,
+          'data': 'message',
+        }),
+        throwsA(isA<FormatException>()),
+      );
     });
   });
 

--- a/test/types/sampling_test.dart
+++ b/test/types/sampling_test.dart
@@ -592,6 +592,47 @@ void main() {
       expect(params.includeContext, equals(IncludeContext.allServers));
     });
 
+    test('validates enum wire fields', () {
+      final messages = [
+        {
+          'role': 'user',
+          'content': {'type': 'text', 'text': 'Hello'},
+        },
+      ];
+      expect(
+        () => CreateMessageRequestParams.fromJson({
+          'messages': messages,
+          'maxTokens': 100,
+          'includeContext': 'nearbyServers',
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => CreateMessageRequestParams.fromJson({
+          'messages': messages,
+          'maxTokens': 100,
+          'includeContext': 1,
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => CreateMessageRequestParams.fromJson({
+          'messages': messages,
+          'maxTokens': 100,
+          'toolChoice': {'mode': 'sometimes'},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => CreateMessageRequestParams.fromJson({
+          'messages': messages,
+          'maxTokens': 100,
+          'toolChoice': {'mode': 1},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
     test('accepts whole-number JSON maxTokens values', () {
       final messages = [
         {


### PR DESCRIPTION
## Summary
- add shared enum wire-value parsing for protocol enum fields
- reject malformed logging levels and sampling enum fields with `FormatException`
- validate `toolChoice.mode` during request parsing while preserving legacy raw map storage

## Validation
- dart format lib/src/types/validation.dart lib/src/types/logging.dart lib/src/types/sampling.dart test/types/logging_types_test.dart test/types/sampling_test.dart test/mcp_2025_11_25_test.dart
- dart test test/types/logging_types_test.dart test/types/sampling_test.dart test/mcp_2025_11_25_test.dart
- dart analyze
- git diff --check
- dart test
- dart pub global run coverage:test_with_coverage

Stacked on #265. This remains a draft RC PR and stays off `main` until the official spec release.