### PR TITLE
Consolidate MCP 2026 transport enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,64 @@
 - Added opt-in client discovery via `McpClientOptions(useServerDiscover: true)`
   while keeping the stable `initialize` flow as the default until the 2026
   stateless transport and MRTR implementation is complete.
+- Added 2026 cacheable result support for `tools/list`, `prompts/list`,
+  `resources/list`, `resources/templates/list`, and `resources/read`, including
+  stateless server defaults for `resultType`, `ttlMs`, and `cacheScope` while
+  keeping legacy result serialization unchanged unless cache hints are set.
+- Rejected core RPCs removed from stateless MCP 2026 requests
+  (`initialize`, `ping`, `logging/setLevel`, `resources/subscribe`,
+  `resources/unsubscribe`, `notifications/initialized`, and
+  `notifications/roots/list_changed`) while preserving legacy session behavior.
+- Synced registered tool `x-mcp-header` metadata into Streamable HTTP server
+  transports so 2026 stateless `tools/call` requests reject missing or
+  mismatched `Mcp-Param-*` argument headers.
+- Rejected `x-mcp-header` usage on JSON Schema `number` parameters, keeping
+  mirrored tool headers limited to string, JavaScript-safe integer, and boolean
+  parameters.
+- Removed `Mcp-Session-Id` from 2026 stateless Streamable HTTP requests by
+  stripping it from client sends and ignoring it on stateless server POSTs.
+- Enforced 2026 stateless Streamable HTTP POST-only behavior by skipping
+  legacy client GET/DELETE session paths and returning `Allow: POST` for
+  stateless non-POST server requests.
+- Rejected server-initiated JSON-RPC requests on 2026 stateless Streamable HTTP
+  response streams so client input is routed through MRTR input-required
+  results instead.
+- Escaped sentinel-shaped `Mcp-Param-*` values with Base64 encoding so literal
+  values beginning with `=?base64?` and ending with `?=` round-trip correctly.
+- Synced nested 2026 `x-mcp-header` mappings into Streamable HTTP transports
+  using JSON Pointer selectors for nested tool arguments.
+- Returned HTTP 404 with JSON-RPC `Method not found` for unsupported or removed
+  2026 stateless Streamable HTTP request methods before opening response
+  streams.
+- Treated client closure of a 2026 stateless Streamable HTTP SSE response stream
+  as cancellation of that pending request.
+- Sorted 2026 stateless high-level `tools/list` responses by tool name for
+  deterministic list results while preserving legacy registration-order output.
+- Gated 2026 stateless task extension methods on advertised server extension
+  support and rejected legacy task result shapes on extension `tasks/get`,
+  `tasks/update`, and `tasks/cancel` handlers.
+- Added request-scoped stateless logging gating via
+  `io.modelcontextprotocol/logLevel` metadata so 2026 log notifications are
+  emitted only when the current request opts in.
+- Rejected unrecognized 2026 stateless response `resultType` values on the
+  client while keeping absent `resultType` compatible with stable result parsing.
+- Added `X-Accel-Buffering: no` to Streamable HTTP SSE responses and marked
+  JSON-RPC error bodies with `Content-Type: application/json`.
+- Tightened `x-mcp-header` and `Mcp-Param-*` suffix validation to RFC 9110
+  HTTP field-name token syntax.
+- Removed invalid `x-mcp-header` annotations from 2026 stateless `tools/list`
+  responses when the server has already rejected those header mappings.
+- Rejected server-initiated JSON-RPC requests received on 2026 stateless
+  Streamable HTTP client response streams; servers must use MRTR
+  `input_required` results instead.
+- Enforced `subscriptions/listen` stream ordering and filters for 2026
+  subscription notifications.
+- Retried `server/discover` with an advertised compatible stateless protocol
+  version after `UnsupportedProtocolVersionError` instead of falling back to
+  legacy initialization.
+- Added client-side `subscriptions/listen` handles that correlate stream
+  notifications by `io.modelcontextprotocol/subscriptionId`, validate the
+  acknowledgment, and cancel long-lived streams with `notifications/cancelled`.
 
 ## 2.2.0
 

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+
 import 'package:mcp_dart/src/shared/json_schema/json_schema_validator.dart';
 import 'package:mcp_dart/src/shared/logging.dart';
+import 'package:mcp_dart/src/shared/mcp_header_validation.dart';
 import 'package:mcp_dart/src/shared/protocol.dart';
 import 'package:mcp_dart/src/shared/transport.dart';
 import 'package:mcp_dart/src/types.dart';
@@ -37,6 +39,36 @@ class McpClientOptions extends ProtocolOptions {
 /// Deprecated alias for [McpClientOptions].
 @Deprecated('Use McpClientOptions instead')
 typedef ClientOptions = McpClientOptions;
+
+/// Handle for an active `subscriptions/listen` stream opened by [McpClient].
+class McpSubscription {
+  final void Function([Object? reason]) _cancel;
+
+  /// JSON-RPC request ID that identifies this subscription stream.
+  final int id;
+
+  /// Acknowledgment sent as the first message on the subscription stream.
+  final Future<SubscriptionsAcknowledgedNotification> acknowledged;
+
+  /// Notifications delivered on this subscription stream after acknowledgment.
+  final Stream<JsonRpcNotification> notifications;
+
+  /// Completes when the `subscriptions/listen` request ends.
+  final Future<EmptyResult> done;
+
+  McpSubscription._({
+    required this.id,
+    required this.acknowledged,
+    required this.notifications,
+    required this.done,
+    required void Function([Object? reason]) cancel,
+  }) : _cancel = cancel;
+
+  /// Cancels this subscription stream.
+  void cancel([Object? reason]) {
+    _cancel(reason);
+  }
+}
 
 // Recursively applies default values from a JSON Schema to a data object.
 void _applyElicitationDefaults(JsonSchema schema, Map<String, dynamic> data) {
@@ -97,6 +129,7 @@ class McpClient extends Protocol {
   final Map<String, JsonSchema> _cachedToolOutputSchemas = {};
   final Set<String> _cachedRequiredTaskTools = {};
   final ToolParameterHeaderMappings _cachedToolParameterHeaders = {};
+  final Map<Object, _ClientSubscriptionState> _activeSubscriptions = {};
 
   /// Callback for handling elicitation requests from the server.
   ///
@@ -294,19 +327,56 @@ class McpClient extends Protocol {
     );
   }
 
-  Future<DiscoverResult> discoverServer() async {
+  String? _retryableDiscoveryProtocolVersion(
+    McpError error,
+    String attemptedVersion,
+  ) {
+    if (error.code != ErrorCode.unsupportedProtocolVersion.value) {
+      return null;
+    }
+
+    final data = error.data;
+    if (data is! Map) {
+      return null;
+    }
+
+    final supported = data['supported'];
+    if (supported is! Iterable) {
+      return null;
+    }
+
+    final advertisedVersions = <String>[];
+    for (final version in supported) {
+      if (version is String) {
+        advertisedVersions.add(version);
+      }
+    }
+
+    final retryVersion = negotiateProtocolVersion(
+      advertisedVersions,
+      localSupportedVersions: statelessProtocolVersions,
+    );
+    if (retryVersion == null || retryVersion == attemptedVersion) {
+      return null;
+    }
+    return retryVersion;
+  }
+
+  Future<DiscoverResult> _discoverServerWithVersion(
+    String protocolVersion,
+  ) async {
     final activeTransport = transport;
     final ProtocolVersionAwareTransport? versionedTransport =
         activeTransport is ProtocolVersionAwareTransport
             ? activeTransport as ProtocolVersionAwareTransport
             : null;
-    versionedTransport?.protocolVersion = _preferredProtocolVersion;
+    versionedTransport?.protocolVersion = protocolVersion;
 
     final result = await super.request<DiscoverResult>(
       JsonRpcServerDiscoverRequest(
         id: -1,
         meta: buildProtocolRequestMeta(
-          protocolVersion: _preferredProtocolVersion,
+          protocolVersion: protocolVersion,
           clientInfo: _clientInfo,
           clientCapabilities: _capabilities,
         ),
@@ -314,17 +384,17 @@ class McpClient extends Protocol {
       (json) => DiscoverResult.fromJson(json),
     );
 
-    final protocolVersion = negotiateProtocolVersion(
+    final negotiatedProtocolVersion = negotiateProtocolVersion(
       result.supportedVersions,
       localSupportedVersions: supportedProtocolVersionsWithDraft,
     );
-    if (protocolVersion == null) {
+    if (negotiatedProtocolVersion == null) {
       throw McpError(
         ErrorCode.unsupportedProtocolVersion.value,
         "Server does not support a compatible MCP protocol version.",
         {
           'supported': result.supportedVersions,
-          'requested': _preferredProtocolVersion,
+          'requested': protocolVersion,
         },
       );
     }
@@ -332,17 +402,43 @@ class McpClient extends Protocol {
     _serverCapabilities = result.capabilities;
     _serverVersion = result.serverInfo;
     _instructions = result.instructions;
-    _negotiatedProtocolVersion = protocolVersion;
-    _usesStatelessProtocol = isStatelessProtocolVersion(protocolVersion);
+    _negotiatedProtocolVersion = negotiatedProtocolVersion;
+    _usesStatelessProtocol = isStatelessProtocolVersion(
+      negotiatedProtocolVersion,
+    );
     _sentInitialized = true;
 
-    versionedTransport?.protocolVersion = protocolVersion;
+    versionedTransport?.protocolVersion = negotiatedProtocolVersion;
 
     _logger.debug(
-      "MCP Server Discovered. Server: ${result.serverInfo.name} ${result.serverInfo.version}, Protocol: $protocolVersion",
+      "MCP Server Discovered. Server: ${result.serverInfo.name} ${result.serverInfo.version}, Protocol: $negotiatedProtocolVersion",
     );
 
     return result;
+  }
+
+  Future<DiscoverResult> discoverServer() async {
+    try {
+      return await _discoverServerWithVersion(_preferredProtocolVersion);
+    } catch (error) {
+      if (error is! McpError) {
+        rethrow;
+      }
+
+      final retryVersion = _retryableDiscoveryProtocolVersion(
+        error,
+        _preferredProtocolVersion,
+      );
+      if (retryVersion == null) {
+        rethrow;
+      }
+
+      _logger.debug(
+        "server/discover rejected protocol $_preferredProtocolVersion; "
+        "retrying with $retryVersion.",
+      );
+      return await _discoverServerWithVersion(retryVersion);
+    }
   }
 
   /// Connects to the server using the given [transport].
@@ -454,6 +550,16 @@ class McpClient extends Protocol {
   String? getProtocolVersion() => _negotiatedProtocolVersion;
 
   @override
+  bool isRecognizedResultType(String resultType) {
+    if (super.isRecognizedResultType(resultType)) {
+      return true;
+    }
+
+    return resultType == resultTypeTask &&
+        (_serverCapabilities?.supportsTasksExtension ?? false);
+  }
+
+  @override
   McpError? validateIncomingRequest(JsonRpcRequest request) {
     if (_sentInitialized || request.method == Method.ping) {
       return null;
@@ -481,6 +587,31 @@ class McpClient extends Protocol {
           ErrorCode.invalidRequest.value,
           "Received ${notification.method} before notifications/initialized was sent.",
         );
+    }
+  }
+
+  @override
+  void onIncomingNotificationAccepted(JsonRpcNotification notification) {
+    final subscriptionId = notification.meta?[McpMetaKey.subscriptionId];
+    if (subscriptionId is! int && subscriptionId is! String) {
+      return;
+    }
+
+    final activeSubscription = _activeSubscriptions[subscriptionId];
+    activeSubscription?.handleNotification(notification);
+  }
+
+  @override
+  void onConnectionClosed() {
+    final subscriptions = List<_ClientSubscriptionState>.from(
+      _activeSubscriptions.values,
+    );
+    _activeSubscriptions.clear();
+    for (final subscription in subscriptions) {
+      subscription.fail(
+        McpError(ErrorCode.connectionClosed.value, 'Connection closed'),
+        StackTrace.current,
+      );
     }
   }
 
@@ -762,6 +893,47 @@ class McpClient extends Protocol {
     return request<EmptyResult>(req, (json) => const EmptyResult(), options);
   }
 
+  /// Opens a `subscriptions/listen` stream and demultiplexes notifications.
+  McpSubscription listenSubscriptions(SubscriptionsListenRequest params) {
+    if (transport == null) {
+      throw StateError('Not connected to a transport.');
+    }
+
+    final requestId = reserveRequestId();
+    final abortController = BasicAbortController();
+    final state = _ClientSubscriptionState(
+      id: requestId,
+      requestedNotifications: params.notifications,
+      abortController: abortController,
+      onClose: () => _activeSubscriptions.remove(requestId),
+    );
+    _activeSubscriptions[requestId] = state;
+
+    final requestData = JsonRpcSubscriptionsListenRequest(
+      id: requestId,
+      listenParams: params,
+      meta: _usesStatelessProtocol ? _statelessRequestMeta(null) : null,
+    );
+    final requestDone = super.requestWithReservedId<EmptyResult>(
+      requestId,
+      requestData,
+      (json) => const EmptyResult(),
+      RequestOptions(
+        signal: abortController.signal,
+        timeoutEnabled: false,
+      ),
+    );
+    state.trackRequest(requestDone);
+
+    return McpSubscription._(
+      id: requestId,
+      acknowledged: state.acknowledged,
+      notifications: state.notifications,
+      done: state.done,
+      cancel: state.cancel,
+    );
+  }
+
   /// Sends a `tools/call` request to invoke a tool on the server.
   Future<CallToolResult> callTool(
     CallToolRequest params, {
@@ -879,60 +1051,104 @@ class McpClient extends Protocol {
 
     final mappings = <String, String>{};
     final seenHeaders = <String>{};
-    for (final entry in properties.entries) {
-      final propertyJson = entry.value.toJson();
-      if (!propertyJson.containsKey('x-mcp-header')) {
-        continue;
-      }
+    final rejectionReason = _collectToolParameterHeaderMappings(
+      properties: properties,
+      path: const [],
+      mappings: mappings,
+      seenHeaders: seenHeaders,
+    );
 
-      final rawHeader = propertyJson['x-mcp-header'];
-      if (rawHeader is! String) {
-        return _ToolParameterHeaderValidation.invalid(
-          'parameter "${entry.key}" has a non-string x-mcp-header value',
-        );
-      }
-
-      if (rawHeader.isEmpty) {
-        return _ToolParameterHeaderValidation.invalid(
-          'parameter "${entry.key}" has an empty x-mcp-header value',
-        );
-      }
-
-      if (!_isValidMcpHeaderNameSuffix(rawHeader)) {
-        return _ToolParameterHeaderValidation.invalid(
-          'parameter "${entry.key}" has invalid x-mcp-header value '
-          '"$rawHeader"',
-        );
-      }
-
-      final normalizedHeader = rawHeader.toLowerCase();
-      if (!seenHeaders.add(normalizedHeader)) {
-        return _ToolParameterHeaderValidation.invalid(
-          'x-mcp-header value "$rawHeader" is not unique',
-        );
-      }
-
-      if (!_isToolParameterHeaderPrimitive(entry.value)) {
-        return _ToolParameterHeaderValidation.invalid(
-          'parameter "${entry.key}" uses x-mcp-header on a non-primitive type',
-        );
-      }
-
-      mappings[entry.key] = rawHeader;
+    if (rejectionReason != null) {
+      return _ToolParameterHeaderValidation.invalid(rejectionReason);
     }
 
     return _ToolParameterHeaderValidation.valid(mappings);
   }
 
+  String? _collectToolParameterHeaderMappings({
+    required Map<String, JsonSchema> properties,
+    required List<String> path,
+    required Map<String, String> mappings,
+    required Set<String> seenHeaders,
+  }) {
+    for (final entry in properties.entries) {
+      final parameterPath = [...path, entry.key];
+      final parameterName = _toolParameterHeaderParameterName(parameterPath);
+      final propertyJson = entry.value.toJson();
+      if (!propertyJson.containsKey('x-mcp-header')) {
+        if (entry.value is JsonObject) {
+          final childProperties = (entry.value as JsonObject).properties;
+          if (childProperties != null && childProperties.isNotEmpty) {
+            final rejectionReason = _collectToolParameterHeaderMappings(
+              properties: childProperties,
+              path: parameterPath,
+              mappings: mappings,
+              seenHeaders: seenHeaders,
+            );
+            if (rejectionReason != null) {
+              return rejectionReason;
+            }
+          }
+        }
+        continue;
+      }
+
+      final rawHeader = propertyJson['x-mcp-header'];
+      if (rawHeader is! String) {
+        return 'parameter "$parameterName" has a non-string x-mcp-header value';
+      }
+
+      if (rawHeader.isEmpty) {
+        return 'parameter "$parameterName" has an empty x-mcp-header value';
+      }
+
+      if (!_isValidMcpHeaderNameSuffix(rawHeader)) {
+        return 'parameter "$parameterName" has invalid x-mcp-header value '
+            '"$rawHeader"';
+      }
+
+      final normalizedHeader = rawHeader.toLowerCase();
+      if (!seenHeaders.add(normalizedHeader)) {
+        return 'x-mcp-header value "$rawHeader" is not unique';
+      }
+
+      if (!_isToolParameterHeaderPrimitive(entry.value)) {
+        return 'parameter "$parameterName" uses x-mcp-header on a schema that '
+            'is not string, integer, or boolean';
+      }
+
+      mappings[_toolParameterHeaderSelector(parameterPath)] = rawHeader;
+    }
+
+    return null;
+  }
+
+  String _toolParameterHeaderSelector(List<String> path) {
+    if (path.length == 1) {
+      return path.single;
+    }
+
+    return '/${path.map(_escapeJsonPointerSegment).join('/')}';
+  }
+
+  String _toolParameterHeaderParameterName(List<String> path) {
+    if (path.length == 1) {
+      return path.single;
+    }
+
+    return _toolParameterHeaderSelector(path);
+  }
+
+  String _escapeJsonPointerSegment(String segment) {
+    return segment.replaceAll('~', '~0').replaceAll('/', '~1');
+  }
+
   bool _isValidMcpHeaderNameSuffix(String value) {
-    return value.codeUnits.every(
-      (unit) => unit >= 0x21 && unit <= 0x7E && unit != 0x3A,
-    );
+    return isValidMcpHeaderNameSuffix(value);
   }
 
   bool _isToolParameterHeaderPrimitive(JsonSchema schema) {
     return schema is JsonString ||
-        schema is JsonNumber ||
         schema is JsonInteger ||
         schema is JsonBoolean;
   }
@@ -947,6 +1163,174 @@ class McpClient extends Protocol {
 /// Deprecated alias for [McpClient].
 @Deprecated('Use McpClient instead')
 typedef Client = McpClient;
+
+class _ClientSubscriptionState {
+  final int id;
+  final SubscriptionFilter requestedNotifications;
+  final BasicAbortController abortController;
+  final void Function() onClose;
+  final StreamController<JsonRpcNotification> _notifications =
+      StreamController<JsonRpcNotification>.broadcast();
+  final Completer<SubscriptionsAcknowledgedNotification> _acknowledged =
+      Completer<SubscriptionsAcknowledgedNotification>();
+  final Completer<EmptyResult> _done = Completer<EmptyResult>();
+
+  SubscriptionFilter? _acknowledgedNotifications;
+  bool _closed = false;
+  bool _localCancellation = false;
+
+  _ClientSubscriptionState({
+    required this.id,
+    required this.requestedNotifications,
+    required this.abortController,
+    required this.onClose,
+  });
+
+  Future<SubscriptionsAcknowledgedNotification> get acknowledged =>
+      _acknowledged.future;
+
+  Stream<JsonRpcNotification> get notifications => _notifications.stream;
+
+  Future<EmptyResult> get done => _done.future;
+
+  void handleNotification(JsonRpcNotification notification) {
+    if (_closed) {
+      return;
+    }
+
+    if (_acknowledgedNotifications == null) {
+      if (notification.method !=
+          Method.notificationsSubscriptionsAcknowledged) {
+        fail(
+          McpError(
+            ErrorCode.invalidRequest.value,
+            'Subscription $id received ${notification.method} before '
+            '${Method.notificationsSubscriptionsAcknowledged}.',
+          ),
+          StackTrace.current,
+        );
+        return;
+      }
+
+      final acknowledgedParams =
+          (notification as JsonRpcSubscriptionsAcknowledgedNotification)
+              .acknowledgedParams;
+      final acknowledgedNotifications = acknowledgedParams.notifications;
+      if (!acknowledgedNotifications.isSubsetOf(requestedNotifications)) {
+        fail(
+          McpError(
+            ErrorCode.invalidRequest.value,
+            'Subscription $id acknowledged notifications that were not '
+            'requested.',
+          ),
+          StackTrace.current,
+        );
+        return;
+      }
+
+      _acknowledgedNotifications = acknowledgedNotifications;
+      if (!_acknowledged.isCompleted) {
+        _acknowledged.complete(acknowledgedParams);
+      }
+      return;
+    }
+
+    final acknowledgedNotifications = _acknowledgedNotifications!;
+    if (!acknowledgedNotifications.allowsNotification(notification)) {
+      fail(
+        McpError(
+          ErrorCode.invalidRequest.value,
+          '${notification.method} was not requested or acknowledged for '
+          'subscription $id.',
+        ),
+        StackTrace.current,
+      );
+      return;
+    }
+
+    _notifications.add(notification);
+  }
+
+  void trackRequest(Future<EmptyResult> requestDone) {
+    requestDone.then(
+      complete,
+      onError: (Object error, StackTrace stackTrace) {
+        if (_localCancellation) {
+          complete(const EmptyResult());
+        } else {
+          fail(error, stackTrace, abort: false);
+        }
+      },
+    );
+  }
+
+  void cancel([Object? reason]) {
+    if (_closed) {
+      return;
+    }
+
+    _localCancellation = true;
+    if (!_acknowledged.isCompleted) {
+      _acknowledged.completeError(AbortError(reason), StackTrace.current);
+    }
+    abortController.abort(reason);
+    complete(const EmptyResult());
+  }
+
+  void complete(EmptyResult result) {
+    if (_closed) {
+      return;
+    }
+
+    final missingAcknowledgment = _acknowledgedNotifications == null &&
+        !_localCancellation &&
+        !abortController.signal.aborted;
+    if (missingAcknowledgment) {
+      fail(
+        McpError(
+          ErrorCode.invalidRequest.value,
+          'Subscription $id completed before '
+          '${Method.notificationsSubscriptionsAcknowledged}.',
+        ),
+        StackTrace.current,
+        abort: false,
+      );
+      return;
+    }
+
+    _closed = true;
+    onClose();
+    if (!_done.isCompleted) {
+      _done.complete(result);
+    }
+    _notifications.close();
+  }
+
+  void fail(
+    Object error,
+    StackTrace stackTrace, {
+    bool abort = true,
+  }) {
+    if (_closed) {
+      return;
+    }
+
+    _closed = true;
+    onClose();
+    if (abort && !abortController.signal.aborted) {
+      abortController.abort(error);
+    }
+    if (!_acknowledged.isCompleted) {
+      _acknowledged.completeError(error, stackTrace);
+    }
+    if (!_done.isCompleted) {
+      _done.completeError(error, stackTrace);
+    }
+    _notifications
+      ..addError(error, stackTrace)
+      ..close();
+  }
+}
 
 class _ToolParameterHeaderValidation {
   final Map<String, String> mappings;

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -16,6 +16,9 @@ const _defaultStreamableHttpReconnectionOptions =
   maxRetries: 2,
 );
 
+const int _maxSafeHeaderInteger = 9007199254740991;
+const int _minSafeHeaderInteger = -9007199254740991;
+
 /// Error thrown for Streamable HTTP issues
 class StreamableHttpError extends Error {
   /// HTTP status code if applicable
@@ -48,11 +51,15 @@ class StartSseOptions {
   /// Default is true.
   final bool shouldReconnect;
 
+  /// Whether JSON-RPC requests received on this stream should be rejected.
+  final bool rejectServerRequests;
+
   const StartSseOptions({
     this.resumptionToken,
     this.onResumptionToken,
     this.replayMessageId,
     this.shouldReconnect = true,
+    this.rejectServerRequests = false,
   });
 }
 
@@ -575,11 +582,12 @@ class StreamableHttpClientTransport
     final argumentMap = arguments.cast<String, dynamic>();
     final headers = <String, String>{};
     for (final entry in mappings.entries) {
-      if (!argumentMap.containsKey(entry.key)) {
+      final argument = _toolParameterHeaderArgument(argumentMap, entry.key);
+      if (!argument.exists) {
         continue;
       }
 
-      final value = _toolParameterHeaderString(argumentMap[entry.key]);
+      final value = _toolParameterHeaderString(argument.value);
       if (value == null) {
         continue;
       }
@@ -590,13 +598,67 @@ class StreamableHttpClientTransport
     return headers;
   }
 
+  ({bool exists, Object? value}) _toolParameterHeaderArgument(
+    Map<String, dynamic> arguments,
+    String selector,
+  ) {
+    if (!selector.startsWith('/')) {
+      return (
+        exists: arguments.containsKey(selector),
+        value: arguments[selector],
+      );
+    }
+
+    Object? current = arguments;
+    for (final segment in _jsonPointerSegments(selector)) {
+      if (current is! Map || !current.containsKey(segment)) {
+        return (exists: false, value: null);
+      }
+      current = current[segment];
+    }
+    return (exists: true, value: current);
+  }
+
+  Iterable<String> _jsonPointerSegments(String selector) {
+    if (selector == '/') {
+      return const [''];
+    }
+    return selector
+        .substring(1)
+        .split('/')
+        .map((segment) => segment.replaceAll('~1', '/').replaceAll('~0', '~'));
+  }
+
   String? _toolParameterHeaderString(Object? value) {
+    final integer = _safeHeaderInteger(value);
+    if (integer != null) {
+      return integer.toString();
+    }
+
     return switch (value) {
       String() => value,
-      num() => value.toString(),
       bool() => value.toString(),
       _ => null,
     };
+  }
+
+  int? _safeHeaderInteger(Object? value) {
+    if (value is int) {
+      if (value < _minSafeHeaderInteger || value > _maxSafeHeaderInteger) {
+        return null;
+      }
+      return value;
+    }
+
+    if (value is double &&
+        value.isFinite &&
+        value.truncateToDouble() == value &&
+        value >= _minSafeHeaderInteger &&
+        value <= _maxSafeHeaderInteger) {
+      return value.toInt();
+    }
+
+    return null;
   }
 
   String _encodeToolParameterHeaderValue(String value) {
@@ -608,10 +670,15 @@ class StreamableHttpClientTransport
   }
 
   bool _isPlainToolParameterHeaderValue(String value) {
-    return value.trim() == value &&
+    return !_isBase64ToolParameterHeaderSentinel(value) &&
+        value.trim() == value &&
         value.codeUnits.every(
           (unit) => unit == 0x09 || (unit >= 0x20 && unit <= 0x7E),
         );
+  }
+
+  bool _isBase64ToolParameterHeaderSentinel(String value) {
+    return value.startsWith('=?base64?') && value.endsWith('?=');
   }
 
   String? _methodFrom(JsonRpcMessage message) {
@@ -683,6 +750,11 @@ class StreamableHttpClientTransport
   }
 
   Future<void> _startOrAuthSse(StartSseOptions options) async {
+    if (_protocolVersion != null &&
+        isStatelessProtocolVersion(_protocolVersion!)) {
+      return;
+    }
+
     final resumptionToken = options.resumptionToken;
     try {
       // Try to open an initial SSE stream with GET to listen for server messages
@@ -874,9 +946,15 @@ class StreamableHttpClientTransport
             result: message.result,
             meta: message.meta,
           );
-          onmessage?.call(newMessage);
+          _dispatchReceivedMessage(
+            newMessage,
+            rejectServerRequests: options.rejectServerRequests,
+          );
         } else {
-          onmessage?.call(message);
+          _dispatchReceivedMessage(
+            message,
+            rejectServerRequests: options.rejectServerRequests,
+          );
         }
       } catch (error) {
         if (error is Error) {
@@ -999,6 +1077,25 @@ class StreamableHttpClientTransport
     });
   }
 
+  void _dispatchReceivedMessage(
+    JsonRpcMessage message, {
+    required bool rejectServerRequests,
+  }) {
+    if (rejectServerRequests && message is JsonRpcRequest) {
+      onerror?.call(
+        McpError(
+          ErrorCode.invalidRequest.value,
+          'Server-initiated JSON-RPC requests are not supported on 2026 '
+          'stateless MCP response streams; return input_required with '
+          'inputRequests instead.',
+        ),
+      );
+      return;
+    }
+
+    onmessage?.call(message);
+  }
+
   @override
   Future<void> start() async {
     if (_abortController != null) {
@@ -1117,6 +1214,12 @@ class StreamableHttpClientTransport
 
       final headers = await _commonHeaders();
       headers.addAll(_headersForMessage(message));
+      final protocolVersion = _protocolVersion ?? _protocolVersionFrom(message);
+      final isStatelessRequest = protocolVersion != null &&
+          isStatelessProtocolVersion(protocolVersion);
+      if (isStatelessRequest) {
+        headers.remove('mcp-session-id');
+      }
       final requestSessionId = headers['mcp-session-id'];
       headers['content-type'] = 'application/json';
       headers['accept'] = 'application/json, text/event-stream';
@@ -1174,7 +1277,7 @@ class StreamableHttpClientTransport
 
       // Handle session ID received from successful stateful responses.
       final sessionId = response.headers['mcp-session-id'];
-      if (sessionId != null) {
+      if (sessionId != null && !isStatelessRequest) {
         _sessionId = sessionId;
         _staleSessionDetected = false;
       }
@@ -1226,6 +1329,7 @@ class StreamableHttpClientTransport
             StartSseOptions(
               onResumptionToken: onResumptionToken,
               shouldReconnect: false, // Do not reconnect for POST responses
+              rejectServerRequests: isStatelessRequest,
             ),
           );
         } else if (contentType?.contains('application/json') ?? false) {
@@ -1236,11 +1340,17 @@ class StreamableHttpClientTransport
           if (data is List) {
             for (final item in data) {
               final msg = JsonRpcMessage.fromJson(item);
-              onmessage?.call(msg);
+              _dispatchReceivedMessage(
+                msg,
+                rejectServerRequests: isStatelessRequest,
+              );
             }
           } else {
             final msg = JsonRpcMessage.fromJson(data);
-            onmessage?.call(msg);
+            _dispatchReceivedMessage(
+              msg,
+              rejectServerRequests: isStatelessRequest,
+            );
           }
         } else {
           throw StreamableHttpError(
@@ -1292,6 +1402,13 @@ class StreamableHttpClientTransport
   /// The server MAY respond with HTTP 405 Method Not Allowed, indicating that
   /// the server does not allow clients to terminate sessions.
   Future<void> terminateSession() async {
+    if (_protocolVersion != null &&
+        isStatelessProtocolVersion(_protocolVersion!)) {
+      _sessionId = null;
+      _staleSessionDetected = false;
+      return;
+    }
+
     if (_sessionId == null) {
       return; // No session to terminate
     }

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -1,7 +1,8 @@
 import 'dart:async';
-import 'package:mcp_dart/src/shared/json_schema/json_schema_validator.dart';
 
+import 'package:mcp_dart/src/shared/json_schema/json_schema_validator.dart';
 import 'package:mcp_dart/src/shared/logging.dart';
+import 'package:mcp_dart/src/shared/mcp_header_validation.dart';
 import 'package:mcp_dart/src/shared/protocol.dart';
 import 'package:mcp_dart/src/shared/task_interfaces.dart';
 import 'package:mcp_dart/src/shared/tool_name_validation.dart';
@@ -592,12 +593,16 @@ class _RegisteredToolImpl implements RegisteredTool {
     _server._registeredTools[name] = this;
   }
 
-  Tool toTool({bool includeExecution = true}) {
+  Tool toTool({
+    bool includeExecution = true,
+    ToolInputSchema? inputSchemaOverride,
+  }) {
     return Tool(
       name: name,
       title: title,
       description: description,
-      inputSchema: inputSchema ?? const ToolInputSchema(),
+      inputSchema:
+          inputSchemaOverride ?? inputSchema ?? const ToolInputSchema(),
       outputSchema: outputSchema,
       annotations: annotations,
       icon: icon,
@@ -972,6 +977,7 @@ class McpServer {
 
   /// Connects the server to a communication [transport].
   Future<void> connect(Transport transport) async {
+    _syncToolParameterHeaderMappings(transport);
     return await server.connect(transport);
   }
 
@@ -984,11 +990,20 @@ class McpServer {
   bool get isConnected => server.transport != null;
 
   /// Sends a logging message to the client, if connected.
+  ///
+  /// For stateless MCP requests, pass [requestMeta] from
+  /// [RequestHandlerExtra.meta] so log notifications honor the request-scoped
+  /// `io.modelcontextprotocol/logLevel` opt-in.
   Future<void> sendLoggingMessage(
     LoggingMessageNotification params, {
     String? sessionId,
+    Map<String, dynamic>? requestMeta,
   }) async {
-    return server.sendLoggingMessage(params, sessionId: sessionId);
+    return server.sendLoggingMessage(
+      params,
+      sessionId: sessionId,
+      requestMeta: requestMeta,
+    );
   }
 
   /// Sets the error handler for the server.
@@ -1026,8 +1041,243 @@ class McpServer {
   /// Notifies clients that the list of available tools has changed.
   void sendToolListChanged() {
     if (server.transport != null) {
+      _syncToolParameterHeaderMappings();
       server.sendToolListChanged();
     }
+  }
+
+  void _syncToolParameterHeaderMappings([Transport? target]) {
+    final activeTransport = target ?? server.transport;
+    final headerAwareTransport =
+        activeTransport is ToolParameterHeaderAwareTransport
+            ? activeTransport as ToolParameterHeaderAwareTransport
+            : null;
+    if (headerAwareTransport != null) {
+      headerAwareTransport.setToolParameterHeaderMappings(
+        _buildToolParameterHeaderMappings(),
+      );
+    }
+  }
+
+  ToolParameterHeaderMappings _buildToolParameterHeaderMappings() {
+    final mappings = <String, Map<String, String>>{};
+
+    for (final tool in _registeredTools.values) {
+      if (!tool.enabled) {
+        continue;
+      }
+
+      final toolMappings = _toolParameterHeaderMappingsFor(tool);
+      if (toolMappings.isNotEmpty) {
+        mappings[tool.name] = toolMappings;
+      }
+    }
+
+    return mappings;
+  }
+
+  ToolInputSchema _toolInputSchemaForStatelessList(
+    _RegisteredToolImpl tool,
+  ) {
+    final inputSchema = tool.inputSchema ?? const ToolInputSchema();
+    final properties = inputSchema.properties;
+    if (properties == null || properties.isEmpty) {
+      return inputSchema;
+    }
+
+    final ignoredReason = _collectToolParameterHeaderMappings(
+      toolName: tool.name,
+      properties: properties,
+      path: const [],
+      mappings: <String, String>{},
+      seenHeaders: <String>{},
+    );
+    if (ignoredReason == null) {
+      return inputSchema;
+    }
+
+    return _stripToolParameterHeaderMetadata(inputSchema);
+  }
+
+  ToolInputSchema _stripToolParameterHeaderMetadata(ToolInputSchema schema) {
+    return JsonSchema.fromJson(
+      _stripToolParameterHeaderMetadataFromJson(schema.toJson()),
+    ) as ToolInputSchema;
+  }
+
+  Map<String, dynamic> _stripToolParameterHeaderMetadataFromJson(
+    Map<String, dynamic> json,
+  ) {
+    final stripped = Map<String, dynamic>.from(json)..remove('x-mcp-header');
+
+    final properties = stripped['properties'];
+    if (properties is Map) {
+      final strippedProperties = <String, dynamic>{};
+      for (final entry in properties.entries) {
+        final propertyName = entry.key as String;
+        final propertyValue = entry.value;
+        strippedProperties[propertyName] = propertyValue is Map
+            ? _stripToolParameterHeaderMetadataFromJson(
+                Map<String, dynamic>.from(propertyValue),
+              )
+            : propertyValue;
+      }
+      stripped['properties'] = strippedProperties;
+    }
+
+    final items = stripped['items'];
+    if (items is Map) {
+      stripped['items'] = _stripToolParameterHeaderMetadataFromJson(
+        Map<String, dynamic>.from(items),
+      );
+    }
+
+    final additionalProperties = stripped['additionalProperties'];
+    if (additionalProperties is Map) {
+      stripped['additionalProperties'] =
+          _stripToolParameterHeaderMetadataFromJson(
+        Map<String, dynamic>.from(additionalProperties),
+      );
+    }
+
+    for (final keyword in const ['allOf', 'anyOf', 'oneOf']) {
+      final schemas = stripped[keyword];
+      if (schemas is List) {
+        stripped[keyword] = [
+          for (final schema in schemas)
+            if (schema is Map)
+              _stripToolParameterHeaderMetadataFromJson(
+                Map<String, dynamic>.from(schema),
+              )
+            else
+              schema,
+        ];
+      }
+    }
+
+    final notSchema = stripped['not'];
+    if (notSchema is Map) {
+      stripped['not'] = _stripToolParameterHeaderMetadataFromJson(
+        Map<String, dynamic>.from(notSchema),
+      );
+    }
+
+    return stripped;
+  }
+
+  Map<String, String> _toolParameterHeaderMappingsFor(
+    _RegisteredToolImpl tool,
+  ) {
+    final properties = tool.inputSchema?.properties;
+    if (properties == null || properties.isEmpty) {
+      return const {};
+    }
+
+    final mappings = <String, String>{};
+    final seenHeaders = <String>{};
+    final ignoredReason = _collectToolParameterHeaderMappings(
+      toolName: tool.name,
+      properties: properties,
+      path: const [],
+      mappings: mappings,
+      seenHeaders: seenHeaders,
+    );
+
+    if (ignoredReason != null) {
+      _logger.warn(ignoredReason);
+      return const {};
+    }
+
+    return mappings;
+  }
+
+  String? _collectToolParameterHeaderMappings({
+    required String toolName,
+    required Map<String, JsonSchema> properties,
+    required List<String> path,
+    required Map<String, String> mappings,
+    required Set<String> seenHeaders,
+  }) {
+    for (final entry in properties.entries) {
+      final parameterPath = [...path, entry.key];
+      final parameterName = _toolParameterHeaderParameterName(parameterPath);
+      final propertyJson = entry.value.toJson();
+      if (!propertyJson.containsKey('x-mcp-header')) {
+        if (entry.value is JsonObject) {
+          final childProperties = (entry.value as JsonObject).properties;
+          if (childProperties != null && childProperties.isNotEmpty) {
+            final ignoredReason = _collectToolParameterHeaderMappings(
+              toolName: toolName,
+              properties: childProperties,
+              path: parameterPath,
+              mappings: mappings,
+              seenHeaders: seenHeaders,
+            );
+            if (ignoredReason != null) {
+              return ignoredReason;
+            }
+          }
+        }
+        continue;
+      }
+
+      final rawHeader = propertyJson['x-mcp-header'];
+      if (rawHeader is! String || rawHeader.isEmpty) {
+        return 'Ignoring x-mcp-header mapping for tool "$toolName" parameter '
+            '"$parameterName": value must be a non-empty string.';
+      }
+
+      if (!_isValidMcpHeaderNameSuffix(rawHeader)) {
+        return 'Ignoring x-mcp-header mapping for tool "$toolName" parameter '
+            '"$parameterName": "$rawHeader" is not a valid Mcp-Param suffix.';
+      }
+
+      final normalizedHeader = rawHeader.toLowerCase();
+      if (!seenHeaders.add(normalizedHeader)) {
+        return 'Ignoring x-mcp-header mappings for tool "$toolName": '
+            '"$rawHeader" is not unique.';
+      }
+
+      if (!_isToolParameterHeaderPrimitive(entry.value)) {
+        return 'Ignoring x-mcp-header mapping for tool "$toolName" parameter '
+            '"$parameterName": only string, integer, and boolean schemas can '
+            'be mirrored.';
+      }
+
+      mappings[_toolParameterHeaderSelector(parameterPath)] = rawHeader;
+    }
+
+    return null;
+  }
+
+  String _toolParameterHeaderSelector(List<String> path) {
+    if (path.length == 1) {
+      return path.single;
+    }
+
+    return '/${path.map(_escapeJsonPointerSegment).join('/')}';
+  }
+
+  String _toolParameterHeaderParameterName(List<String> path) {
+    if (path.length == 1) {
+      return path.single;
+    }
+
+    return _toolParameterHeaderSelector(path);
+  }
+
+  String _escapeJsonPointerSegment(String segment) {
+    return segment.replaceAll('~', '~0').replaceAll('/', '~1');
+  }
+
+  bool _isValidMcpHeaderNameSuffix(String value) {
+    return isValidMcpHeaderNameSuffix(value);
+  }
+
+  bool _isToolParameterHeaderPrimitive(JsonSchema schema) {
+    return schema is JsonString ||
+        schema is JsonInteger ||
+        schema is JsonBoolean;
   }
 
   /// Notifies clients that the list of available prompts has changed.
@@ -1158,15 +1408,22 @@ class McpServer {
       Method.toolsList,
       (request, extra) async {
         final protocolVersion = request.meta?[McpMetaKey.protocolVersion];
-        final includeLegacyTaskExecution = protocolVersion is! String ||
-            !isStatelessProtocolVersion(protocolVersion);
+        final isStatelessRequest = protocolVersion is String &&
+            isStatelessProtocolVersion(protocolVersion);
+        final includeLegacyTaskExecution = !isStatelessRequest;
+        final tools = _registeredTools.values.where((t) => t.enabled).toList();
+        if (isStatelessRequest) {
+          tools.sort((a, b) => a.name.compareTo(b.name));
+        }
 
         return ListToolsResult(
-          tools: _registeredTools.values
-              .where((t) => t.enabled)
+          tools: tools
               .map(
-                (e) => e.toTool(
+                (tool) => tool.toTool(
                   includeExecution: includeLegacyTaskExecution,
+                  inputSchemaOverride: isStatelessRequest
+                      ? _toolInputSchemaForStatelessList(tool)
+                      : null,
                 ),
               )
               .toList(),

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -64,6 +64,19 @@ class Server extends Protocol {
     LoggingLevel.emergency: 7,
   };
 
+  static const Set<String> _statelessRemovedRequestMethods = {
+    Method.initialize,
+    Method.ping,
+    Method.loggingSetLevel,
+    Method.resourcesSubscribe,
+    Method.resourcesUnsubscribe,
+  };
+
+  static const Set<String> _statelessRemovedNotificationMethods = {
+    Method.notificationsInitialized,
+    Method.notificationsRootsListChanged,
+  };
+
   /// Callback to be notified when the server is fully initialized.
   void Function()? oninitialized;
 
@@ -181,6 +194,14 @@ class Server extends Protocol {
       );
     }
 
+    final logLevel = meta?[McpMetaKey.logLevel];
+    if (logLevel != null && _parseLoggingLevel(logLevel) == null) {
+      return McpError(
+        ErrorCode.invalidRequest.value,
+        'Invalid stateless request metadata: ${McpMetaKey.logLevel}',
+      );
+    }
+
     return null;
   }
 
@@ -225,6 +246,82 @@ class Server extends Protocol {
         isStatelessProtocolVersion(requestedProtocolVersion);
   }
 
+  bool _isStatelessNotification(JsonRpcNotification notification) {
+    final requestedProtocolVersion =
+        notification.meta?[McpMetaKey.protocolVersion];
+    return requestedProtocolVersion is String &&
+        isStatelessProtocolVersion(requestedProtocolVersion);
+  }
+
+  LoggingLevel? _parseLoggingLevel(Object? value) {
+    if (value is LoggingLevel) {
+      return value;
+    }
+    if (value is String) {
+      for (final level in LoggingLevel.values) {
+        if (level.name == value) {
+          return level;
+        }
+      }
+    }
+    return null;
+  }
+
+  bool _allowsStatelessLogging(
+    LoggingLevel messageLevel,
+    Map<String, dynamic>? requestMeta,
+  ) {
+    if (!_isStatelessMeta(requestMeta)) {
+      return true;
+    }
+
+    final requestedLevel = _parseLoggingLevel(
+      requestMeta?[McpMetaKey.logLevel],
+    );
+    if (requestedLevel == null) {
+      return false;
+    }
+
+    return _logLevelSeverity[messageLevel]! >=
+        _logLevelSeverity[requestedLevel]!;
+  }
+
+  bool _isStatelessMeta(Map<String, dynamic>? requestMeta) {
+    final requestedProtocolVersion = requestMeta?[McpMetaKey.protocolVersion];
+    return requestedProtocolVersion is String &&
+        isStatelessProtocolVersion(requestedProtocolVersion);
+  }
+
+  McpError? _validateStatelessRemovedRequestMethod(JsonRpcRequest request) {
+    if (!_isStatelessRequest(request)) {
+      return null;
+    }
+    if (!_statelessRemovedRequestMethods.contains(request.method)) {
+      return null;
+    }
+
+    return McpError(
+      ErrorCode.methodNotFound.value,
+      '${request.method} is not part of MCP stateless protocol versions.',
+    );
+  }
+
+  McpError? _validateStatelessRemovedNotificationMethod(
+    JsonRpcNotification notification,
+  ) {
+    if (!_isStatelessNotification(notification)) {
+      return null;
+    }
+    if (!_statelessRemovedNotificationMethods.contains(notification.method)) {
+      return null;
+    }
+
+    return McpError(
+      ErrorCode.methodNotFound.value,
+      '${notification.method} is not part of MCP stateless protocol versions.',
+    );
+  }
+
   McpError? _validateDraftTaskMethods(JsonRpcRequest request) {
     if (!_isStatelessRequest(request)) {
       return null;
@@ -236,6 +333,27 @@ class Server extends Protocol {
         return McpError(
           ErrorCode.methodNotFound.value,
           '${request.method} is not part of the MCP Tasks extension.',
+        );
+    }
+
+    return null;
+  }
+
+  McpError? _validateServerTasksExtensionSupport(JsonRpcRequest request) {
+    if (!_isStatelessRequest(request)) {
+      return null;
+    }
+
+    switch (request.method) {
+      case Method.tasksGet:
+      case Method.tasksCancel:
+      case Method.tasksUpdate:
+        if (_capabilities.supportsTasksExtension) {
+          return null;
+        }
+        return McpError(
+          ErrorCode.methodNotFound.value,
+          '${request.method} requires server support for $mcpTasksExtensionId.',
         );
     }
 
@@ -283,6 +401,11 @@ class Server extends Protocol {
       return removedMethodError;
     }
 
+    final serverExtensionError = _validateServerTasksExtensionSupport(request);
+    if (serverExtensionError != null) {
+      return serverExtensionError;
+    }
+
     final extensionCapabilityError =
         _validateTasksExtensionCapabilities(request);
     if (extensionCapabilityError != null) {
@@ -305,6 +428,33 @@ class Server extends Protocol {
     }
 
     return false;
+  }
+
+  bool _allowsTaskExtensionResult(
+    BaseResultData result,
+    JsonRpcRequest request,
+  ) {
+    if (!_isStatelessRequest(request)) {
+      return true;
+    }
+
+    return switch (request.method) {
+      Method.tasksGet => result is GetTaskExtensionResult,
+      Method.tasksCancel ||
+      Method.tasksUpdate =>
+        result is TaskExtensionAcknowledgementResult || result is EmptyResult,
+      _ => true,
+    };
+  }
+
+  String _expectedTaskExtensionResult(String method) {
+    return switch (method) {
+      Method.tasksGet => 'GetTaskExtensionResult',
+      Method.tasksCancel ||
+      Method.tasksUpdate =>
+        'TaskExtensionAcknowledgementResult or EmptyResult',
+      _ => 'valid MCP Tasks extension result',
+    };
   }
 
   bool _isLegacyTaskAugmentedRequest(JsonRpcCallToolRequest request) {
@@ -335,6 +485,12 @@ class Server extends Protocol {
       final metadataError = _validateStatelessRequestMetadata(request);
       if (metadataError != null) {
         return metadataError;
+      }
+      final removedMethodError = _validateStatelessRemovedRequestMethod(
+        request,
+      );
+      if (removedMethodError != null) {
+        return removedMethodError;
       }
       return _validateRequestTaskSemantics(request);
     }
@@ -372,6 +528,12 @@ class Server extends Protocol {
 
   @override
   McpError? validateIncomingNotification(JsonRpcNotification notification) {
+    final removedMethodError =
+        _validateStatelessRemovedNotificationMethod(notification);
+    if (removedMethodError != null) {
+      return removedMethodError;
+    }
+
     switch (notification.method) {
       case Method.notificationsCancelled:
       case Method.notificationsProgress:
@@ -434,6 +596,45 @@ class Server extends Protocol {
       _clientVersion = null;
       _lifecycleState = _ServerLifecycleState.uninitialized;
     }
+  }
+
+  bool _requiresCacheableResult(String method) {
+    return switch (method) {
+      Method.toolsList ||
+      Method.promptsList ||
+      Method.resourcesList ||
+      Method.resourcesTemplatesList ||
+      Method.resourcesRead =>
+        true,
+      _ => false,
+    };
+  }
+
+  @override
+  Map<String, dynamic> serializeIncomingResult(
+    JsonRpcRequest request,
+    BaseResultData result,
+  ) {
+    final json = super.serializeIncomingResult(request, result);
+    if (!_isStatelessRequest(request)) {
+      return json;
+    }
+
+    json.putIfAbsent('resultType', () => resultTypeComplete);
+    if (_requiresCacheableResult(request.method)) {
+      json.putIfAbsent(
+        'ttlMs',
+        () => result is CacheableResultData ? result.ttlMs ?? 0 : 0,
+      );
+      json.putIfAbsent(
+        'cacheScope',
+        () => result is CacheableResultData
+            ? result.cacheScope ?? CacheScope.private
+            : CacheScope.private,
+      );
+    }
+
+    return json;
   }
 
   @override
@@ -502,6 +703,24 @@ class Server extends Protocol {
               "Invalid tools/call result: Expected CallToolResult",
             );
           }
+        }
+        return result;
+      }
+
+      super.setRequestHandler(method, wrappedHandler, requestFactory);
+    } else if (method == Method.tasksGet ||
+        method == Method.tasksCancel ||
+        method == Method.tasksUpdate) {
+      Future<BaseResultData> wrappedHandler(
+        ReqT request,
+        RequestHandlerExtra extra,
+      ) async {
+        final result = await handler(request, extra);
+        if (!_allowsTaskExtensionResult(result, request)) {
+          throw McpError(
+            ErrorCode.invalidParams.value,
+            "Invalid ${request.method} result for MCP Tasks extension: Expected ${_expectedTaskExtensionResult(request.method)}",
+          );
         }
         return result;
       }
@@ -988,12 +1207,20 @@ class Server extends Protocol {
   }
 
   /// Sends a `notifications/message` (logging) notification to the client.
+  ///
+  /// For stateless MCP requests, pass [requestMeta] from
+  /// [RequestHandlerExtra.meta] so log notifications honor the request-scoped
+  /// `io.modelcontextprotocol/logLevel` opt-in.
   Future<void> sendLoggingMessage(
     LoggingMessageNotification params, {
     String? sessionId,
+    Map<String, dynamic>? requestMeta,
   }) async {
     if (_capabilities.logging != null) {
-      if (!_isMessageIgnored(params.level, sessionId)) {
+      final statelessLogContext = _isStatelessMeta(requestMeta);
+      if (_allowsStatelessLogging(params.level, requestMeta) &&
+          (statelessLogContext ||
+              !_isMessageIgnored(params.level, sessionId))) {
         final notif = JsonRpcLoggingMessageNotification(logParams: params);
         return notification(notif);
       }

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -3,11 +3,16 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:mcp_dart/src/shared/mcp_header_validation.dart';
 import 'package:mcp_dart/src/shared/uuid.dart';
 
 import '../shared/transport.dart';
 import '../types.dart';
 import 'dns_rebinding_protection.dart';
+
+const int _maxSafeHeaderInteger = 9007199254740991;
+const int _minSafeHeaderInteger = -9007199254740991;
+const String _xAccelBufferingHeader = 'X-Accel-Buffering';
 
 /// ID for SSE streams
 typedef StreamId = String;
@@ -153,7 +158,11 @@ class StreamableHTTPServerTransportOptions {
 /// - Session ID is only included in initialization responses
 /// - No session validation is performed
 class StreamableHTTPServerTransport
-    implements Transport, RequestIdAwareTransport {
+    implements
+        Transport,
+        RequestIdAwareTransport,
+        IncomingRequestValidationAwareTransport,
+        ToolParameterHeaderAwareTransport {
   // when sessionId is not set (null), it means the transport is in stateless mode
   final String? Function()? _sessionIdGenerator;
   bool _started = false;
@@ -163,6 +172,8 @@ class StreamableHTTPServerTransport
   final Set<StreamId> _ownedStreamIds = {};
   final Map<dynamic, String> _requestToStreamMapping = {};
   final Map<dynamic, JsonRpcMessage> _requestResponseMap = {};
+  final Set<dynamic> _statelessRequestIds = {};
+  final Map<StreamId, Socket> _responseStreamSockets = {};
   bool _initialized = false;
   bool _terminated = false;
   final bool _enableJsonResponse;
@@ -176,6 +187,9 @@ class StreamableHTTPServerTransport
   final bool _strictProtocolVersionHeaderValidation;
   final bool _rejectBatchJsonRpcPayloads;
   final int _maxReplayedEvents;
+  ToolParameterHeaderMappings _toolParameterHeaderMappings = const {};
+  McpError? Function(JsonRpcRequest request)? _incomingRequestValidator;
+  bool Function(String method)? _isRequestMethodSupported;
   static const JsonRpcNotification _ssePrimingMessage =
       JsonRpcNotification(method: 'notifications/experimental/sse/priming');
 
@@ -216,6 +230,28 @@ class StreamableHTTPServerTransport
     _started = true;
   }
 
+  @override
+  void setToolParameterHeaderMappings(
+    ToolParameterHeaderMappings mappings,
+  ) {
+    _toolParameterHeaderMappings = {
+      for (final entry in mappings.entries)
+        entry.key: Map.unmodifiable(Map<String, String>.from(entry.value)),
+    };
+  }
+
+  @override
+  void setIncomingRequestValidator(
+    McpError? Function(JsonRpcRequest request) validator,
+  ) {
+    _incomingRequestValidator = validator;
+  }
+
+  @override
+  void setRequestMethodSupported(bool Function(String method) isSupported) {
+    _isRequestMethodSupported = isSupported;
+  }
+
   /// Handles an incoming HTTP request, whether GET or POST
   Future<void> handleRequest(HttpRequest req, [dynamic parsedBody]) async {
     req.response.bufferOutput = false;
@@ -238,8 +274,7 @@ class StreamableHTTPServerTransport
 
     if (req.method == "POST") {
       await _handlePostRequest(req, parsedBody);
-    } else if (_isStatelessProtocolVersionRequest(req) &&
-        (req.method == "GET" || req.method == "DELETE")) {
+    } else if (_isStatelessProtocolVersionRequest(req)) {
       await _handleStatelessUnsupportedRequest(req.response);
     } else if (req.method == "GET") {
       await _handleGetRequest(req);
@@ -309,6 +344,15 @@ class StreamableHTTPServerTransport
     return _isValidVisibleAsciiToken(sessionId);
   }
 
+  Map<String, String> _sseResponseHeaders() {
+    return {
+      HttpHeaders.contentTypeHeader: 'text/event-stream; charset=utf-8',
+      HttpHeaders.cacheControlHeader: 'no-cache, no-transform',
+      HttpHeaders.connectionHeader: 'keep-alive',
+      _xAccelBufferingHeader: 'no',
+    };
+  }
+
   void _validateSseEventId(EventId eventId) {
     if (!_isValidVisibleAsciiToken(eventId)) {
       throw StateError(
@@ -325,14 +369,33 @@ class StreamableHTTPServerTransport
     required String message,
     RequestId? id,
     Object? data,
+  }) {
+    return _writeJsonRpcErrorCodeResponse(
+      response,
+      httpStatus: httpStatus,
+      errorCode: errorCode.value,
+      message: message,
+      id: id,
+      data: data,
+    );
+  }
+
+  Future<void> _writeJsonRpcErrorCodeResponse(
+    HttpResponse response, {
+    required int httpStatus,
+    required int errorCode,
+    required String message,
+    RequestId? id,
+    Object? data,
   }) async {
     response.statusCode = httpStatus;
+    response.headers.contentType = ContentType.json;
     response.write(
       jsonEncode(
         JsonRpcError(
           id: id,
           error: JsonRpcErrorData(
-            code: errorCode.value,
+            code: errorCode,
             message: message,
             data: data,
           ),
@@ -340,6 +403,14 @@ class StreamableHTTPServerTransport
       ),
     );
     await _safeClose(response);
+  }
+
+  int _statelessHttpStatusForErrorCode(int code) {
+    if (code == ErrorCode.methodNotFound.value) {
+      return HttpStatus.notFound;
+    }
+
+    return HttpStatus.badRequest;
   }
 
   Future<void> _writeHeaderMismatchResponse(
@@ -437,13 +508,56 @@ class StreamableHTTPServerTransport
   }
 
   String? _primitiveHeaderString(Object? value) {
+    final integer = _safeHeaderInteger(value);
+    if (integer != null) {
+      return integer.toString();
+    }
+
     return switch (value) {
       null => null,
       String() => value,
-      num() => value.toString(),
       bool() => value.toString(),
       _ => null,
     };
+  }
+
+  int? _safeHeaderInteger(Object? value) {
+    if (value is int) {
+      if (value < _minSafeHeaderInteger || value > _maxSafeHeaderInteger) {
+        return null;
+      }
+      return value;
+    }
+
+    if (value is double &&
+        value.isFinite &&
+        value.truncateToDouble() == value &&
+        value >= _minSafeHeaderInteger &&
+        value <= _maxSafeHeaderInteger) {
+      return value.toInt();
+    }
+
+    return null;
+  }
+
+  bool _headerValueMatchesPrimitive(Object? bodyValue, String headerValue) {
+    final integer = _safeHeaderInteger(bodyValue);
+    if (integer != null) {
+      final headerInteger = _safeHeaderInteger(num.tryParse(headerValue));
+      return headerInteger != null && headerInteger == integer;
+    }
+
+    final value = _primitiveHeaderString(bodyValue);
+    return value != null && headerValue == value;
+  }
+
+  String? _toolName(JsonRpcMessage message) {
+    if (_messageMethod(message) != Method.toolsCall) {
+      return null;
+    }
+
+    final name = _messageParams(message)?['name'];
+    return name is String ? name : null;
   }
 
   Future<bool> _validateMcpParamHeaders(
@@ -451,56 +565,192 @@ class StreamableHTTPServerTransport
     HttpResponse res,
     JsonRpcMessage message,
   ) async {
+    final headers = <String, _McpParamHeader>{};
+    req.headers.forEach((name, values) {
+      const prefix = 'mcp-param-';
+      final lowerName = name.toLowerCase();
+      if (!lowerName.startsWith(prefix)) {
+        return;
+      }
+
+      final headerSuffix = name.substring(prefix.length);
+      if (!isValidMcpHeaderNameSuffix(headerSuffix)) {
+        headers[lowerName] = _McpParamHeader.invalidName(
+          name: name,
+          suffix: headerSuffix,
+        );
+        return;
+      }
+
+      final headerValue = req.headers.value(name);
+      final decodedValue =
+          headerValue == null ? null : _decodeMcpParamHeaderValue(headerValue);
+      if (decodedValue == null) {
+        headers[lowerName] = _McpParamHeader.invalidValue(
+          name: name,
+          suffix: headerSuffix,
+        );
+        return;
+      }
+
+      headers[headerSuffix.toLowerCase()] = _McpParamHeader(
+        name: name,
+        suffix: headerSuffix,
+        value: decodedValue,
+      );
+    });
+
+    _McpParamHeader? invalidHeader;
+    for (final header in headers.values) {
+      if (header.validationError != null) {
+        invalidHeader = header;
+        break;
+      }
+    }
+    if (invalidHeader != null) {
+      final messageText =
+          invalidHeader.validationError == _McpParamHeaderValidationError.name
+              ? '${invalidHeader.name} header name is malformed'
+              : '${invalidHeader.name} header value is malformed';
+      await _writeHeaderMismatchResponse(res, message, messageText);
+      return false;
+    }
+
     final params = _messageParams(message);
     final arguments = params?['arguments'];
     if (arguments is! Map) {
-      return true;
+      if (headers.isEmpty) {
+        return true;
+      }
+      await _writeHeaderMismatchResponse(
+        res,
+        message,
+        '${headers.values.first.name} header has no matching body arguments',
+      );
+      return false;
     }
+
     final argumentMap = arguments.cast<String, dynamic>();
+    final consumedHeaders = <String>{};
+    final toolName = _toolName(message);
+    final headerMappings =
+        toolName == null ? null : _toolParameterHeaderMappings[toolName];
 
-    final headerNames = <String>[];
-    req.headers.forEach((name, values) {
-      headerNames.add(name);
-    });
+    if (headerMappings != null) {
+      for (final entry in headerMappings.entries) {
+        final argumentName = entry.key;
+        final headerSuffix = entry.value;
+        final header = headers[headerSuffix.toLowerCase()];
+        final argument = _toolParameterHeaderArgument(argumentMap, entry.key);
+        final hasArgument = argument.exists;
+        final bodyArgument = argument.value;
+        final bodyValue =
+            hasArgument ? _primitiveHeaderString(bodyArgument) : null;
 
-    for (final headerName in headerNames) {
-      const prefix = 'mcp-param-';
-      if (!headerName.toLowerCase().startsWith(prefix)) {
+        if (!hasArgument || bodyValue == null) {
+          if (header != null) {
+            await _writeHeaderMismatchResponse(
+              res,
+              message,
+              '${header.name} header has no matching primitive body argument '
+              "'$argumentName'",
+            );
+            return false;
+          }
+          continue;
+        }
+
+        if (header == null) {
+          await _writeHeaderMismatchResponse(
+            res,
+            message,
+            'Mcp-Param-$headerSuffix header is required for body argument '
+            "'$argumentName'",
+          );
+          return false;
+        }
+
+        consumedHeaders.add(header.suffix.toLowerCase());
+        if (!_headerValueMatchesPrimitive(bodyArgument, header.value!)) {
+          await _writeHeaderMismatchResponse(
+            res,
+            message,
+            '${header.name} header value does not match body argument '
+            "'$argumentName'",
+          );
+          return false;
+        }
+      }
+    }
+
+    final argumentNamesByLowercase = <String, String>{};
+    for (final argumentName in argumentMap.keys) {
+      argumentNamesByLowercase.putIfAbsent(
+        argumentName.toLowerCase(),
+        () => argumentName,
+      );
+    }
+
+    for (final header in headers.values) {
+      if (consumedHeaders.contains(header.suffix.toLowerCase())) {
         continue;
       }
 
-      final headerSuffix = headerName.substring(prefix.length);
-      if (headerSuffix.isEmpty ||
-          !headerSuffix.codeUnits.every(
-            (unit) => unit >= 0x21 && unit <= 0x7E && unit != 0x3A,
-          )) {
+      final argumentName = argumentMap.containsKey(header.suffix)
+          ? header.suffix
+          : argumentNamesByLowercase[header.suffix.toLowerCase()];
+      if (argumentName == null) {
         await _writeHeaderMismatchResponse(
           res,
           message,
-          "$headerName header name is malformed",
+          '${header.name} header has no matching body argument',
         );
         return false;
       }
 
-      if (!argumentMap.containsKey(headerSuffix)) {
-        continue;
-      }
-
-      final headerValue = req.headers.value(headerName);
-      final decodedValue =
-          headerValue == null ? null : _decodeMcpParamHeaderValue(headerValue);
-      final bodyValue = _primitiveHeaderString(argumentMap[headerSuffix]);
-      if (decodedValue == null || decodedValue != bodyValue) {
+      final bodyArgument = argumentMap[argumentName];
+      if (!_headerValueMatchesPrimitive(bodyArgument, header.value!)) {
         await _writeHeaderMismatchResponse(
           res,
           message,
-          "$headerName header value does not match body argument '$headerSuffix'",
+          "${header.name} header value does not match body argument '$argumentName'",
         );
         return false;
       }
     }
 
     return true;
+  }
+
+  ({bool exists, Object? value}) _toolParameterHeaderArgument(
+    Map<String, dynamic> arguments,
+    String selector,
+  ) {
+    if (!selector.startsWith('/')) {
+      return (
+        exists: arguments.containsKey(selector),
+        value: arguments[selector],
+      );
+    }
+
+    Object? current = arguments;
+    for (final segment in _jsonPointerSegments(selector)) {
+      if (current is! Map || !current.containsKey(segment)) {
+        return (exists: false, value: null);
+      }
+      current = current[segment];
+    }
+    return (exists: true, value: current);
+  }
+
+  Iterable<String> _jsonPointerSegments(String selector) {
+    if (selector == '/') {
+      return const [''];
+    }
+    return selector
+        .substring(1)
+        .split('/')
+        .map((segment) => segment.replaceAll('~1', '/').replaceAll('~0', '~'));
   }
 
   Future<bool> _validateStatelessHttpHeaders(
@@ -558,7 +808,6 @@ class StreamableHTTPServerTransport
       );
       return false;
     }
-
     final method = _messageMethod(message);
     if (method == null) {
       return true;
@@ -603,7 +852,39 @@ class StreamableHTTPServerTransport
       }
     }
 
-    return _validateMcpParamHeaders(req, req.response, message);
+    if (!await _validateMcpParamHeaders(req, req.response, message)) {
+      return false;
+    }
+
+    if (message is JsonRpcRequest) {
+      final validationError = _incomingRequestValidator?.call(message);
+      if (validationError != null) {
+        await _writeJsonRpcErrorCodeResponse(
+          req.response,
+          httpStatus: _statelessHttpStatusForErrorCode(validationError.code),
+          errorCode: validationError.code,
+          id: message.id,
+          message: validationError.message,
+          data: validationError.data,
+        );
+        return false;
+      }
+
+      final isRequestMethodSupported = _isRequestMethodSupported;
+      if (isRequestMethodSupported != null &&
+          !isRequestMethodSupported(message.method)) {
+        await _writeJsonRpcErrorResponse(
+          req.response,
+          httpStatus: HttpStatus.notFound,
+          errorCode: ErrorCode.methodNotFound,
+          id: message.id,
+          message: 'Method not found: ${message.method}',
+        );
+        return false;
+      }
+    }
+
+    return true;
   }
 
   bool _isStandaloneSseStreamId(StreamId streamId) {
@@ -681,20 +962,12 @@ class StreamableHTTPServerTransport
     // The client MUST include an Accept header, listing text/event-stream as a supported content type.
     final acceptedMediaTypes = _parseAcceptedMediaTypes(req);
     if (!_acceptsMediaType(acceptedMediaTypes, 'text/event-stream')) {
-      req.response
-        ..statusCode = HttpStatus.notAcceptable
-        ..write(
-          jsonEncode(
-            JsonRpcError(
-              id: null,
-              error: JsonRpcErrorData(
-                code: ErrorCode.connectionClosed.value,
-                message: 'Not Acceptable: Client must accept text/event-stream',
-              ),
-            ).toJson(),
-          ),
-        );
-      await _safeClose(req.response);
+      await _writeJsonRpcErrorResponse(
+        req.response,
+        httpStatus: HttpStatus.notAcceptable,
+        errorCode: ErrorCode.connectionClosed,
+        message: 'Not Acceptable: Client must accept text/event-stream',
+      );
       return;
     }
 
@@ -716,11 +989,7 @@ class StreamableHTTPServerTransport
 
     // The server MUST either return Content-Type: text/event-stream in response to this HTTP GET,
     // or else return HTTP 405 Method Not Allowed
-    final headers = {
-      HttpHeaders.contentTypeHeader: "text/event-stream; charset=utf-8",
-      HttpHeaders.cacheControlHeader: "no-cache, no-transform",
-      HttpHeaders.connectionHeader: "keep-alive",
-    };
+    final headers = _sseResponseHeaders();
 
     // After initialization, always include the session ID if we have one
     if (sessionId != null) {
@@ -730,6 +999,7 @@ class StreamableHTTPServerTransport
     // We need to send headers immediately as messages will arrive much later,
     // otherwise the client will just wait for the first message
     req.response.statusCode = HttpStatus.ok;
+    req.response.bufferOutput = false;
     headers.forEach((key, value) {
       req.response.headers.set(key, value);
     });
@@ -786,11 +1056,7 @@ class StreamableHTTPServerTransport
         return;
       }
 
-      final headers = {
-        HttpHeaders.contentTypeHeader: "text/event-stream; charset=utf-8",
-        HttpHeaders.cacheControlHeader: "no-cache, no-transform",
-        HttpHeaders.connectionHeader: "keep-alive",
-      };
+      final headers = _sseResponseHeaders();
 
       if (sessionId != null) {
         headers["mcp-session-id"] = sessionId!;
@@ -859,6 +1125,14 @@ class StreamableHTTPServerTransport
     }
   }
 
+  Future<void> _safeCloseSocket(Socket socket) async {
+    try {
+      await socket.close().timeout(const Duration(milliseconds: 100));
+    } catch (e) {
+      socket.destroy();
+    }
+  }
+
   /// Writes an event to the SSE stream with proper formatting
   Future<bool> _writeSSEEvent(
     HttpResponse res,
@@ -882,6 +1156,41 @@ class StreamableHTTPServerTransport
     }
   }
 
+  Future<Socket> _detachSseSocket(
+    HttpRequest req,
+    Map<String, String> headers,
+  ) async {
+    final socket = await req.response.detachSocket(writeHeaders: false);
+    final responseHeaders = {
+      ...headers,
+      HttpHeaders.connectionHeader: 'close',
+    };
+    final responseHead = StringBuffer('HTTP/1.1 200 OK\r\n');
+    responseHeaders.forEach((key, value) {
+      responseHead.write('$key: $value\r\n');
+    });
+    responseHead.write('\r\n');
+    socket.add(utf8.encode(responseHead.toString()));
+    await socket.flush();
+    return socket;
+  }
+
+  Future<bool> _writeSSEEventToSocket(
+    Socket socket,
+    JsonRpcMessage message,
+  ) async {
+    try {
+      var eventData = "event: message\n";
+      eventData += "data: ${jsonEncode(message.toJson())}\n\n";
+
+      socket.add(utf8.encode(eventData));
+      await socket.flush();
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
   Future<bool> _writeSSEPrimingEvent(
     HttpResponse res,
     EventId eventId,
@@ -890,6 +1199,16 @@ class StreamableHTTPServerTransport
       _validateSseEventId(eventId);
       res.add(utf8.encode('id: $eventId\ndata:\n\n'));
       await res.flush();
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  Future<bool> _writeSSECommentToSocket(Socket socket) async {
+    try {
+      socket.add(utf8.encode(':\n\n'));
+      await socket.flush();
       return true;
     } catch (e) {
       return false;
@@ -921,39 +1240,33 @@ class StreamableHTTPServerTransport
     }
   }
 
+  Future<bool> _primeSseSocket(Socket socket) async {
+    final sent = await _writeSSECommentToSocket(socket);
+    if (!sent) {
+      onerror?.call(StateError('Failed to send initial SSE comment'));
+    }
+    return sent;
+  }
+
   /// Handles unsupported requests (PUT, PATCH, etc.)
   Future<void> _handleUnsupportedRequest(HttpResponse res) async {
-    res.statusCode = HttpStatus.methodNotAllowed;
     res.headers.set(HttpHeaders.allowHeader, "GET, POST, DELETE");
-    res.write(
-      jsonEncode(
-        JsonRpcError(
-          id: null,
-          error: JsonRpcErrorData(
-            code: ErrorCode.connectionClosed.value,
-            message: 'Method not allowed.',
-          ),
-        ).toJson(),
-      ),
+    await _writeJsonRpcErrorResponse(
+      res,
+      httpStatus: HttpStatus.methodNotAllowed,
+      errorCode: ErrorCode.connectionClosed,
+      message: 'Method not allowed.',
     );
-    await _safeClose(res);
   }
 
   Future<void> _handleStatelessUnsupportedRequest(HttpResponse res) async {
-    res.statusCode = HttpStatus.methodNotAllowed;
     res.headers.set(HttpHeaders.allowHeader, "POST");
-    res.write(
-      jsonEncode(
-        JsonRpcError(
-          id: null,
-          error: JsonRpcErrorData(
-            code: ErrorCode.connectionClosed.value,
-            message: 'Method not allowed for stateless MCP requests.',
-          ),
-        ).toJson(),
-      ),
+    await _writeJsonRpcErrorResponse(
+      res,
+      httpStatus: HttpStatus.methodNotAllowed,
+      errorCode: ErrorCode.connectionClosed,
+      message: 'Method not allowed for stateless MCP requests.',
     );
-    await _safeClose(res);
   }
 
   /// Handles POST requests containing JSON-RPC messages
@@ -964,39 +1277,25 @@ class StreamableHTTPServerTransport
       // The client MUST include an Accept header, listing both application/json and text/event-stream as supported content types.
       if (!_acceptsMediaType(acceptedMediaTypes, 'application/json') ||
           !_acceptsMediaType(acceptedMediaTypes, 'text/event-stream')) {
-        req.response.statusCode = HttpStatus.notAcceptable;
-        req.response.write(
-          jsonEncode(
-            JsonRpcError(
-              id: null,
-              error: JsonRpcErrorData(
-                code: ErrorCode.connectionClosed.value,
-                message:
-                    'Not Acceptable: Client must accept both application/json and text/event-stream',
-              ),
-            ).toJson(),
-          ),
+        await _writeJsonRpcErrorResponse(
+          req.response,
+          httpStatus: HttpStatus.notAcceptable,
+          errorCode: ErrorCode.connectionClosed,
+          message:
+              'Not Acceptable: Client must accept both application/json and text/event-stream',
         );
-        await _safeClose(req.response);
         return;
       }
 
       final contentType = req.headers.contentType?.value ?? '';
       if (!contentType.contains("application/json")) {
-        req.response.statusCode = HttpStatus.unsupportedMediaType;
-        req.response.write(
-          jsonEncode(
-            JsonRpcError(
-              id: null,
-              error: JsonRpcErrorData(
-                code: ErrorCode.connectionClosed.value,
-                message:
-                    'Unsupported Media Type: Content-Type must be application/json',
-              ),
-            ).toJson(),
-          ),
+        await _writeJsonRpcErrorResponse(
+          req.response,
+          httpStatus: HttpStatus.unsupportedMediaType,
+          errorCode: ErrorCode.connectionClosed,
+          message:
+              'Unsupported Media Type: Content-Type must be application/json',
         );
-        await _safeClose(req.response);
         return;
       }
 
@@ -1103,36 +1402,22 @@ class StreamableHTTPServerTransport
             return;
           }
 
-          req.response.statusCode = HttpStatus.badRequest;
-          req.response.write(
-            jsonEncode(
-              JsonRpcError(
-                id: null,
-                error: JsonRpcErrorData(
-                  code: ErrorCode.invalidRequest.value,
-                  message: 'Invalid Request: Server already initialized',
-                ),
-              ).toJson(),
-            ),
+          await _writeJsonRpcErrorResponse(
+            req.response,
+            httpStatus: HttpStatus.badRequest,
+            errorCode: ErrorCode.invalidRequest,
+            message: 'Invalid Request: Server already initialized',
           );
-          await _safeClose(req.response);
           return;
         }
         if (messages.length > 1) {
-          req.response.statusCode = HttpStatus.badRequest;
-          req.response.write(
-            jsonEncode(
-              JsonRpcError(
-                id: null,
-                error: JsonRpcErrorData(
-                  code: ErrorCode.invalidRequest.value,
-                  message:
-                      'Invalid Request: Only one initialization request is allowed',
-                ),
-              ).toJson(),
-            ),
+          await _writeJsonRpcErrorResponse(
+            req.response,
+            httpStatus: HttpStatus.badRequest,
+            errorCode: ErrorCode.invalidRequest,
+            message:
+                'Invalid Request: Only one initialization request is allowed',
           );
-          await _safeClose(req.response);
           return;
         }
 
@@ -1200,22 +1485,24 @@ class StreamableHTTPServerTransport
         // The default behavior is to use SSE streaming
         // but in some cases server will return JSON responses
         final streamId = generateUUID();
+        Socket? responseSocket;
         if (!_enableJsonResponse) {
-          final headers = {
-            HttpHeaders.contentTypeHeader: "text/event-stream; charset=utf-8",
-            HttpHeaders.cacheControlHeader: "no-cache",
-            HttpHeaders.connectionHeader: "keep-alive",
-          };
+          final headers = _sseResponseHeaders();
 
           // After initialization, always include the session ID if we have one
           if (sessionId != null) {
             headers["mcp-session-id"] = sessionId!;
           }
 
-          req.response.statusCode = HttpStatus.ok;
-          headers.forEach((key, value) {
-            req.response.headers.set(key, value);
-          });
+          if (isStatelessRequest) {
+            responseSocket = await _detachSseSocket(req, headers);
+          } else {
+            req.response.statusCode = HttpStatus.ok;
+            req.response.bufferOutput = false;
+            headers.forEach((key, value) {
+              req.response.headers.set(key, value);
+            });
+          }
         }
 
         // Store the response for this request to send messages back through this connection
@@ -1224,30 +1511,70 @@ class StreamableHTTPServerTransport
           if (_isJsonRpcRequest(message)) {
             final reqId = (message as JsonRpcRequest).id;
             _ownedStreamIds.add(streamId);
-            _streamMapping[streamId] = req.response;
+            if (responseSocket == null) {
+              _streamMapping[streamId] = req.response;
+            } else {
+              _responseStreamSockets[streamId] = responseSocket;
+            }
             _requestToStreamMapping[reqId] = streamId;
+            if (_isStatelessJsonRpcRequest(message)) {
+              _statelessRequestIds.add(reqId);
+            }
           }
         }
 
-        if (!_enableJsonResponse &&
-            !await _primeSseStream(streamId, req.response)) {
+        final ssePrimed = _enableJsonResponse ||
+            (responseSocket == null
+                ? await _primeSseStream(
+                    streamId,
+                    req.response,
+                  )
+                : await _primeSseSocket(
+                    responseSocket,
+                  ));
+        if (!ssePrimed) {
           _streamMapping.remove(streamId);
+          _responseStreamSockets.remove(streamId)?.destroy();
           _ownedStreamIds.remove(streamId);
           for (final message in messages) {
             if (_isJsonRpcRequest(message)) {
               final reqId = (message as JsonRpcRequest).id;
               _requestToStreamMapping.remove(reqId);
               _requestResponseMap.remove(reqId);
+              _statelessRequestIds.remove(reqId);
             }
           }
           await _safeClose(req.response);
           return;
         }
 
+        var responseDoneHandled = false;
+        void handleResponseDone() {
+          if (responseDoneHandled) {
+            return;
+          }
+          responseDoneHandled = true;
+          if (_enableJsonResponse) {
+            _streamMapping.remove(streamId);
+          } else {
+            _handleResponseStreamClosed(streamId);
+          }
+        }
+
         // Set up close handler for client disconnects
-        req.response.done.then((_) {
-          _streamMapping.remove(streamId);
-        });
+        if (responseSocket == null) {
+          req.response.done.then(
+            (_) => handleResponseDone(),
+            onError: (Object _, StackTrace __) => handleResponseDone(),
+          );
+        } else {
+          responseSocket.listen(
+            null,
+            onDone: handleResponseDone,
+            onError: (Object _, StackTrace __) => handleResponseDone(),
+            cancelOnError: true,
+          );
+        }
 
         // Handle each message
         for (final message in messages) {
@@ -1308,19 +1635,12 @@ class StreamableHTTPServerTransport
   Future<bool> _validateSession(HttpRequest req, HttpResponse res) async {
     if (!_initialized) {
       // If the server has not been initialized yet, reject all requests
-      res.statusCode = HttpStatus.badRequest;
-      res.write(
-        jsonEncode(
-          JsonRpcError(
-            id: null,
-            error: JsonRpcErrorData(
-              code: ErrorCode.connectionClosed.value,
-              message: 'Bad Request: Server not initialized',
-            ),
-          ).toJson(),
-        ),
+      await _writeJsonRpcErrorResponse(
+        res,
+        httpStatus: HttpStatus.badRequest,
+        errorCode: ErrorCode.connectionClosed,
+        message: 'Bad Request: Server not initialized',
       );
-      await _safeClose(res);
       return false;
     }
 
@@ -1334,35 +1654,21 @@ class StreamableHTTPServerTransport
 
     if (requestSessionId == null) {
       // Non-initialization requests without a session ID should return 400 Bad Request
-      res.statusCode = HttpStatus.badRequest;
-      res.write(
-        jsonEncode(
-          JsonRpcError(
-            id: null,
-            error: JsonRpcErrorData(
-              code: ErrorCode.connectionClosed.value,
-              message: 'Bad Request: Mcp-Session-Id header is required',
-            ),
-          ).toJson(),
-        ),
+      await _writeJsonRpcErrorResponse(
+        res,
+        httpStatus: HttpStatus.badRequest,
+        errorCode: ErrorCode.connectionClosed,
+        message: 'Bad Request: Mcp-Session-Id header is required',
       );
-      await _safeClose(res);
       return false;
     } else if (_terminated || requestSessionId != sessionId) {
       // Reject terminated or invalid session IDs with 404 Not Found.
-      res.statusCode = HttpStatus.notFound;
-      res.write(
-        jsonEncode(
-          JsonRpcError(
-            id: null,
-            error: JsonRpcErrorData(
-              code: ErrorCode.connectionClosed.value,
-              message: 'Session not found',
-            ),
-          ).toJson(),
-        ),
+      await _writeJsonRpcErrorResponse(
+        res,
+        httpStatus: HttpStatus.notFound,
+        errorCode: ErrorCode.connectionClosed,
+        message: 'Session not found',
       );
-      await _safeClose(res);
       return false;
     }
 
@@ -1385,6 +1691,11 @@ class StreamableHTTPServerTransport
     for (final response in responses) {
       await _safeClose(response);
     }
+    final sockets = _responseStreamSockets.values.toList();
+    for (final socket in sockets) {
+      await _safeCloseSocket(socket);
+    }
+    _responseStreamSockets.clear();
     _streamMapping.clear();
     _standaloneSseStreamIds.clear();
     _standaloneSseResponses.clear();
@@ -1393,6 +1704,7 @@ class StreamableHTTPServerTransport
     // Clear any pending responses
     _requestResponseMap.clear();
     _requestToStreamMapping.clear(); // Also clear this map
+    _statelessRequestIds.clear();
     onclose?.call();
   }
 
@@ -1410,6 +1722,15 @@ class StreamableHTTPServerTransport
     if (_isJsonRpcResponse(message) || _isJsonRpcError(message)) {
       // If the message is a response, use the request ID from the message
       requestId = _getMessageId(message);
+    }
+
+    if (message is JsonRpcRequest &&
+        requestId != null &&
+        _statelessRequestIds.contains(requestId)) {
+      throw StateError(
+        "Cannot send JSON-RPC requests on stateless MCP response streams; "
+        "return an InputRequiredResult for client input instead.",
+      );
     }
 
     // Check if this message should be sent on the standalone SSE stream (no request ID)
@@ -1456,25 +1777,52 @@ class StreamableHTTPServerTransport
     }
 
     final response = _streamMapping[streamId];
+    final responseSocket = _responseStreamSockets[streamId];
+    final isStatelessRequestStream =
+        requestId != null && _statelessRequestIds.contains(requestId);
 
     if (!_enableJsonResponse) {
+      if (response == null && responseSocket == null) {
+        if (isStatelessRequestStream) {
+          _handleResponseStreamClosed(streamId);
+          return;
+        }
+      }
+
       // For SSE responses, generate event ID if event store is provided
       String? eventId;
 
-      if (_eventStore != null) {
+      if (_eventStore != null && !isStatelessRequestStream) {
         eventId = await _eventStore!.storeEvent(streamId, message);
       }
 
-      if (response != null) {
+      if (responseSocket != null) {
+        final sent = await _writeSSEEventToSocket(
+          responseSocket,
+          message,
+        );
+        if (!sent && isStatelessRequestStream) {
+          _handleResponseStreamClosed(streamId);
+          return;
+        }
+      } else if (response != null) {
         // Write the event to the response stream
-        await _writeSSEEvent(response, message, eventId);
+        final sent = await _writeSSEEvent(response, message, eventId);
+        if (!sent && isStatelessRequestStream) {
+          _handleResponseStreamClosed(streamId);
+          return;
+        }
       }
     }
 
     if (_isJsonRpcResponse(message)) {
+      if (!_requestToStreamMapping.containsKey(requestId)) {
+        return;
+      }
+
       _requestResponseMap[requestId] = message;
       final relatedIds = _requestToStreamMapping.entries
-          .where((entry) => _streamMapping[entry.value] == response)
+          .where((entry) => entry.value == streamId)
           .map((entry) => entry.key)
           .toList();
 
@@ -1484,7 +1832,7 @@ class StreamableHTTPServerTransport
       );
 
       if (allResponsesReady) {
-        if (response == null) {
+        if (response == null && responseSocket == null) {
           throw StateError(
             "No connection established for request ID: $requestId",
           );
@@ -1504,28 +1852,76 @@ class StreamableHTTPServerTransport
               relatedIds.map((id) => _requestResponseMap[id]!).toList();
 
           headers.forEach((key, value) {
-            response.headers.set(key, value);
+            response!.headers.set(key, value);
           });
 
           if (responses.length == 1) {
-            response.write(jsonEncode(responses[0].toJson()));
+            response!.write(jsonEncode(responses[0].toJson()));
           } else {
-            response.write(
+            response!.write(
               jsonEncode(responses.map((r) => r.toJson()).toList()),
             );
           }
           await _safeClose(response);
+        } else if (responseSocket != null) {
+          await _safeCloseSocket(responseSocket);
         } else {
           // End the SSE stream
-          await _safeClose(response);
+          await _safeClose(response!);
         }
 
         // Clean up
+        _responseStreamSockets.remove(streamId);
         for (final id in relatedIds) {
           _requestResponseMap.remove(id);
           _requestToStreamMapping.remove(id);
+          _statelessRequestIds.remove(id);
         }
       }
+    }
+  }
+
+  void _handleResponseStreamClosed(StreamId streamId) {
+    _responseStreamSockets.remove(streamId)?.destroy();
+    final relatedIds = _requestToStreamMapping.entries
+        .where((entry) => entry.value == streamId)
+        .map((entry) => entry.key)
+        .toList();
+
+    _streamMapping.remove(streamId);
+
+    final statelessIds = relatedIds
+        .where((requestId) => _statelessRequestIds.contains(requestId))
+        .toList();
+    if (statelessIds.isEmpty) {
+      return;
+    }
+
+    for (final requestId in statelessIds) {
+      if (_requestResponseMap.containsKey(requestId)) {
+        continue;
+      }
+
+      try {
+        onmessage?.call(
+          JsonRpcCancelledNotification(
+            cancelParams: CancelledNotification(
+              requestId: requestId,
+              reason: 'SSE response stream closed by client',
+            ),
+          ),
+        );
+      } catch (error) {
+        onerror?.call(
+          error is Error ? error : StateError(error.toString()),
+        );
+      }
+    }
+
+    for (final requestId in statelessIds) {
+      _requestResponseMap.remove(requestId);
+      _requestToStreamMapping.remove(requestId);
+      _statelessRequestIds.remove(requestId);
     }
   }
 
@@ -1570,4 +1966,31 @@ class StreamableHTTPServerTransport
     }
     return null;
   }
+}
+
+enum _McpParamHeaderValidationError { name, value }
+
+class _McpParamHeader {
+  final String name;
+  final String suffix;
+  final String? value;
+  final _McpParamHeaderValidationError? validationError;
+
+  const _McpParamHeader({
+    required this.name,
+    required this.suffix,
+    required String this.value,
+  }) : validationError = null;
+
+  const _McpParamHeader.invalidName({
+    required this.name,
+    required this.suffix,
+  })  : value = null,
+        validationError = _McpParamHeaderValidationError.name;
+
+  const _McpParamHeader.invalidValue({
+    required this.name,
+    required this.suffix,
+  })  : value = null,
+        validationError = _McpParamHeaderValidationError.value;
 }

--- a/lib/src/server/streamable_mcp_server.dart
+++ b/lib/src/server/streamable_mcp_server.dart
@@ -419,6 +419,8 @@ class StreamableMcpServer {
     try {
       if (request.method == 'POST') {
         await _handlePostRequest(request);
+      } else if (_isStatelessProtocolVersionRequest(request)) {
+        await _createStatelessTransport().handleRequest(request);
       } else if (request.method == 'GET') {
         await _handleGetRequest(request);
       } else if (request.method == 'DELETE') {

--- a/lib/src/shared/mcp_header_validation.dart
+++ b/lib/src/shared/mcp_header_validation.dart
@@ -1,0 +1,31 @@
+/// Validates an MCP parameter header suffix against RFC 9110 field-name token
+/// syntax.
+bool isValidMcpHeaderNameSuffix(String value) {
+  return value.isNotEmpty && value.codeUnits.every(isHttpFieldNameTokenChar);
+}
+
+/// Returns whether [unit] is an RFC 9110 HTTP field-name token character.
+bool isHttpFieldNameTokenChar(int unit) {
+  return unit >= 0x30 && unit <= 0x39 ||
+      unit >= 0x41 && unit <= 0x5A ||
+      unit >= 0x61 && unit <= 0x7A ||
+      switch (unit) {
+        0x21 ||
+        0x23 ||
+        0x24 ||
+        0x25 ||
+        0x26 ||
+        0x27 ||
+        0x2A ||
+        0x2B ||
+        0x2D ||
+        0x2E ||
+        0x5E ||
+        0x5F ||
+        0x60 ||
+        0x7C ||
+        0x7E =>
+          true,
+        _ => false,
+      };
+}

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -12,6 +12,12 @@ final _logger = Logger("mcp_dart.shared.protocol");
 bool _isProgressToken(Object? token) => token is int || token is String;
 
 final _lastProgressByExtra = Expando<double>();
+final _subscriptionStateByExtra = Expando<_SubscriptionStreamState>();
+
+class _SubscriptionStreamState {
+  bool acknowledgmentSent = false;
+  SubscriptionFilter acknowledgedNotifications = const SubscriptionFilter();
+}
 
 /// Callback for progress notifications.
 typedef ProgressCallback = void Function(Progress progress);
@@ -72,6 +78,12 @@ class RequestOptions {
   /// Maximum total time to wait for a response.
   final Duration? maxTotalTimeout;
 
+  /// Whether this request should use protocol-level timeout handling.
+  ///
+  /// Long-lived requests such as `subscriptions/listen` can disable this and
+  /// rely on explicit cancellation or transport closure instead.
+  final bool timeoutEnabled;
+
   /// Augments the request with task creation parameters.
   final TaskCreation? task;
 
@@ -85,6 +97,7 @@ class RequestOptions {
     this.timeout,
     this.resetTimeoutOnProgress = false,
     this.maxTotalTimeout,
+    this.timeoutEnabled = true,
     this.task,
     this.relatedTask,
   });
@@ -152,6 +165,16 @@ class RequestHandlerExtra {
     this.closeStandaloneSSEStream,
   });
 
+  _SubscriptionStreamState get _activeSubscriptionState =>
+      (_subscriptionStateByExtra[this] ??= _SubscriptionStreamState());
+
+  void _validateSubscriptionNotification(JsonRpcNotification notification) {
+    _recordOrValidateSubscriptionNotification(
+      _activeSubscriptionState,
+      notification,
+    );
+  }
+
   /// Sends a progress notification for the current request.
   ///
   /// This method automatically retrieves the `progressToken` from the request metadata.
@@ -215,19 +238,71 @@ class RequestHandlerExtra {
   Future<void> sendSubscriptionNotification(
     JsonRpcNotification notification,
   ) {
-    final meta = <String, dynamic>{
-      ...?notification.meta,
-      McpMetaKey.subscriptionId: requestId,
-    };
+    final subscriptionNotification =
+        _withSubscriptionId(notification, requestId);
 
-    return sendNotification(
-      JsonRpcNotification(
-        method: notification.method,
-        params: notification.params,
-        meta: meta,
-      ),
+    _validateSubscriptionNotification(subscriptionNotification);
+
+    return sendNotification(subscriptionNotification);
+  }
+}
+
+JsonRpcNotification _withSubscriptionId(
+  JsonRpcNotification notification,
+  RequestId requestId,
+) {
+  final meta = <String, dynamic>{
+    ...?notification.meta,
+    McpMetaKey.subscriptionId: requestId,
+  };
+  return JsonRpcNotification(
+    method: notification.method,
+    params: notification.params,
+    meta: meta,
+  );
+}
+
+void _recordOrValidateSubscriptionNotification(
+  _SubscriptionStreamState state,
+  JsonRpcNotification notification,
+) {
+  if (notification.method == Method.notificationsSubscriptionsAcknowledged) {
+    state
+      ..acknowledgmentSent = true
+      ..acknowledgedNotifications =
+          _acknowledgedSubscriptionFilter(notification);
+    return;
+  }
+
+  if (!state.acknowledgmentSent) {
+    throw McpError(
+      ErrorCode.invalidRequest.value,
+      'subscriptions/listen streams must send '
+      '${Method.notificationsSubscriptionsAcknowledged} before '
+      '${notification.method}.',
     );
   }
+
+  if (!state.acknowledgedNotifications.allowsNotification(notification)) {
+    throw McpError(
+      ErrorCode.invalidRequest.value,
+      '${notification.method} was not requested or acknowledged for this '
+      'subscriptions/listen stream.',
+    );
+  }
+}
+
+SubscriptionFilter _acknowledgedSubscriptionFilter(
+  JsonRpcNotification notification,
+) {
+  final params = notification.params;
+  if (params == null) {
+    throw const FormatException(
+      'subscriptions acknowledged notification params are required',
+    );
+  }
+
+  return SubscriptionsAcknowledgedNotification.fromJson(params).notifications;
 }
 
 /// Internal class holding timeout state for a request.
@@ -399,6 +474,50 @@ abstract class Protocol {
     }
   }
 
+  /// Returns whether [resultType] is recognized for result parsing.
+  @protected
+  bool isRecognizedResultType(String resultType) {
+    return resultType == resultTypeComplete ||
+        resultType == resultTypeInputRequired;
+  }
+
+  bool _usesStatelessResultTypes(JsonRpcRequest request) {
+    final requestProtocolVersion = request.meta?[McpMetaKey.protocolVersion];
+    if (requestProtocolVersion is String &&
+        isStatelessProtocolVersion(requestProtocolVersion)) {
+      return true;
+    }
+
+    final Object? activeTransport = _transport;
+    if (activeTransport is! ProtocolVersionAwareTransport) {
+      return false;
+    }
+
+    final transportProtocolVersion = activeTransport.protocolVersion;
+    return transportProtocolVersion != null &&
+        isStatelessProtocolVersion(transportProtocolVersion);
+  }
+
+  void _validateResponseResultType(
+    JsonRpcRequest request,
+    Map<String, dynamic> resultJson,
+  ) {
+    if (!_usesStatelessResultTypes(request)) {
+      return;
+    }
+
+    final resultType = resultJson['resultType'];
+    if (resultType == null) {
+      return;
+    }
+    if (resultType is! String) {
+      throw const FormatException('MCP resultType must be a string');
+    }
+    if (!isRecognizedResultType(resultType)) {
+      throw FormatException('Unrecognized MCP resultType "$resultType"');
+    }
+  }
+
   void _registerTaskHandlers() {
     setRequestHandler<JsonRpcGetTaskRequest>(
       Method.tasksGet,
@@ -506,6 +625,15 @@ abstract class Protocol {
       throw StateError("Protocol already connected to a transport.");
     }
     _transport = transport;
+    if (transport is IncomingRequestValidationAwareTransport) {
+      final validationAwareTransport =
+          transport as IncomingRequestValidationAwareTransport;
+      validationAwareTransport.setIncomingRequestValidator(
+        validateIncomingRequest,
+      );
+      validationAwareTransport
+          .setRequestMethodSupported(_supportsRequestMethod);
+    }
     _transport!.onclose = _onclose;
     _transport!.onerror = _onerror;
     _transport!.onmessage = (message) {
@@ -541,6 +669,9 @@ abstract class Protocol {
       rethrow;
     }
   }
+
+  bool _supportsRequestMethod(String method) =>
+      _requestHandlers.containsKey(method) || fallbackRequestHandler != null;
 
   /// Gets the currently attached transport, or null if not connected.
   Transport? get transport => _transport;
@@ -886,6 +1017,10 @@ abstract class Protocol {
   @protected
   void onIncomingRequestAccepted(JsonRpcRequest request) {}
 
+  /// Subclass hook called after an incoming notification has passed validation.
+  @protected
+  void onIncomingNotificationAccepted(JsonRpcNotification notification) {}
+
   /// Subclass hook called after an incoming request handler has completed and
   /// its response has been sent or enqueued.
   @protected
@@ -899,6 +1034,14 @@ abstract class Protocol {
   @protected
   void onIncomingRequestFailed(JsonRpcRequest request, Object error) {}
 
+  /// Converts a handler result into the JSON object sent on the wire.
+  @protected
+  Map<String, dynamic> serializeIncomingResult(
+    JsonRpcRequest request,
+    BaseResultData result,
+  ) =>
+      result.toJson();
+
   /// Subclass hook called after protocol-owned state has been cleared for a
   /// closed transport.
   @protected
@@ -911,6 +1054,8 @@ abstract class Protocol {
       _onerror(validationError);
       return;
     }
+
+    onIncomingNotificationAccepted(notification);
 
     if (notification is JsonRpcTaskStatusNotification) {
       _onTaskStatusNotification(notification);
@@ -1073,6 +1218,9 @@ abstract class Protocol {
 
     final abortController = BasicAbortController();
     _requestHandlerAbortControllers[request.id] = abortController;
+    final subscriptionState = request is JsonRpcSubscriptionsListenRequest
+        ? _SubscriptionStreamState()
+        : null;
 
     final extra = RequestHandlerExtra(
       signal: abortController.signal,
@@ -1090,12 +1238,22 @@ abstract class Protocol {
           : null,
       taskRequestedTtl:
           (request.params?['task'] as Map<String, dynamic>?)?['ttl'] as int?,
-      sendNotification: (notification, {relatedTask}) =>
-          _notificationWithRequestId(
-        notification,
-        relatedTask: relatedTask,
-        relatedRequestId: request.id,
-      ),
+      sendNotification: (notification, {relatedTask}) {
+        var outgoingNotification = notification;
+        if (subscriptionState != null) {
+          outgoingNotification = _withSubscriptionId(notification, request.id);
+          _recordOrValidateSubscriptionNotification(
+            subscriptionState,
+            outgoingNotification,
+          );
+        }
+
+        return _notificationWithRequestId(
+          outgoingNotification,
+          relatedTask: relatedTask,
+          relatedRequestId: request.id,
+        );
+      },
       sendRequest: <T extends BaseResultData>(
         JsonRpcRequest req,
         T Function(Map<String, dynamic>) resultFactory,
@@ -1107,6 +1265,7 @@ abstract class Protocol {
           timeout: options.timeout,
           resetTimeoutOnProgress: options.resetTimeoutOnProgress,
           maxTotalTimeout: options.maxTotalTimeout,
+          timeoutEnabled: options.timeoutEnabled,
           task: options.task,
           relatedTask: options.relatedTask ??
               (relatedTaskId != null
@@ -1121,6 +1280,9 @@ abstract class Protocol {
         );
       },
     );
+    if (subscriptionState != null) {
+      _subscriptionStateByExtra[extra] = subscriptionState;
+    }
 
     // If task creation is requested, check capability
     if (extra.taskRequestedTtl != null ||
@@ -1159,7 +1321,7 @@ abstract class Protocol {
 
         final response = JsonRpcResponse(
           id: request.id,
-          result: result.toJson(),
+          result: serializeIncomingResult(request, result),
           meta: _mergeRelatedTaskMeta(result.meta, relatedTaskJson),
         );
 
@@ -1384,11 +1546,35 @@ abstract class Protocol {
     );
   }
 
+  /// Reserves an outgoing integer request ID for APIs that need to correlate
+  /// side-channel data before the response arrives.
+  @protected
+  int reserveRequestId() => _requestMessageId++;
+
+  /// Sends a request using a previously reserved outgoing integer request ID.
+  @protected
+  Future<T> requestWithReservedId<T extends BaseResultData>(
+    int requestId,
+    JsonRpcRequest requestData,
+    T Function(Map<String, dynamic> resultJson) resultFactory, [
+    RequestOptions? options,
+    RequestId? relatedRequestId,
+  ]) {
+    return _requestWithRequestId(
+      requestData,
+      resultFactory,
+      options,
+      relatedRequestId,
+      requestId,
+    );
+  }
+
   Future<T> _requestWithRequestId<T extends BaseResultData>(
     JsonRpcRequest requestData,
     T Function(Map<String, dynamic> resultJson) resultFactory, [
     RequestOptions? options,
     RequestId? relatedRequestId,
+    int? reservedRequestId,
   ]) {
     if (_transport == null) {
       return Future.error(StateError("Not connected to a transport."));
@@ -1411,7 +1597,7 @@ abstract class Protocol {
       return Future.error(e);
     }
 
-    final messageId = _requestMessageId++;
+    final messageId = reservedRequestId ?? _requestMessageId++;
     final completer = Completer<JsonRpcResponse>();
     Error? capturedError;
     Object? progressToken;
@@ -1572,26 +1758,28 @@ abstract class Protocol {
       taskRequestState?.abortSubscription = abortSubscription;
     }
 
-    final timeoutDuration = options?.timeout ?? defaultRequestTimeout;
-    final maxTotalTimeoutDuration = options?.maxTotalTimeout;
-    void timeoutHandler() {
-      cancel(
-        McpError(
-          ErrorCode.requestTimeout.value,
-          "Request $messageId timed out after $timeoutDuration",
-          {'timeout': timeoutDuration.inMilliseconds},
-        ),
-        fromTimeout: true,
+    if (options?.timeoutEnabled ?? true) {
+      final timeoutDuration = options?.timeout ?? defaultRequestTimeout;
+      final maxTotalTimeoutDuration = options?.maxTotalTimeout;
+      void timeoutHandler() {
+        cancel(
+          McpError(
+            ErrorCode.requestTimeout.value,
+            "Request $messageId timed out after $timeoutDuration",
+            {'timeout': timeoutDuration.inMilliseconds},
+          ),
+          fromTimeout: true,
+        );
+      }
+
+      _setupTimeout(
+        messageId,
+        timeoutDuration,
+        maxTotalTimeoutDuration,
+        options?.resetTimeoutOnProgress ?? false,
+        timeoutHandler,
       );
     }
-
-    _setupTimeout(
-      messageId,
-      timeoutDuration,
-      maxTotalTimeoutDuration,
-      options?.resetTimeoutOnProgress ?? false,
-      timeoutHandler,
-    );
 
     // Queue request if related to a task
     if (options?.relatedTask != null) {
@@ -1654,8 +1842,10 @@ abstract class Protocol {
       Object? taskCancellationError;
       late final T result;
       try {
+        final resultJson = response.toJson()['result'] as Map<String, dynamic>;
+        _validateResponseResultType(jsonrpcRequest, resultJson);
         result = resultFactory(
-          response.toJson()['result'] as Map<String, dynamic>,
+          resultJson,
         );
         final state = taskRequestState;
         if (state != null) {

--- a/lib/src/shared/transport.dart
+++ b/lib/src/shared/transport.dart
@@ -93,7 +93,10 @@ abstract class ProtocolVersionAwareTransport {
   set protocolVersion(String? value);
 }
 
-/// Maps tool names to argument names and their `Mcp-Param-*` header suffixes.
+/// Maps tool names to argument selectors and their `Mcp-Param-*` header suffixes.
+///
+/// Top-level arguments use their argument name as the selector. Nested
+/// arguments use JSON Pointer selectors such as `/auth/tenant`.
 typedef ToolParameterHeaderMappings = Map<String, Map<String, String>>;
 
 /// Optional capability for transports that can mirror tool arguments into
@@ -103,4 +106,16 @@ abstract class ToolParameterHeaderAwareTransport {
   void setToolParameterHeaderMappings(
     ToolParameterHeaderMappings mappings,
   );
+}
+
+/// Optional capability for transports that can validate incoming requests
+/// before committing transport-level response details.
+abstract class IncomingRequestValidationAwareTransport {
+  /// Supplies the protocol-level request validator.
+  void setIncomingRequestValidator(
+    McpError? Function(JsonRpcRequest request) validator,
+  );
+
+  /// Supplies a live request-method support predicate.
+  void setRequestMethodSupported(bool Function(String method) isSupported);
 }

--- a/lib/src/types/completion.dart
+++ b/lib/src/types/completion.dart
@@ -260,13 +260,13 @@ class CompleteResult implements BaseResultData {
   'Stable MCP 2025-11-25 does not define completion list-changed notifications.',
 )
 class JsonRpcCompletionListChangedNotification extends JsonRpcNotification {
-  const JsonRpcCompletionListChangedNotification()
+  const JsonRpcCompletionListChangedNotification({super.meta})
       : super(method: Method.notificationsExperimentalCompletionsListChanged);
 
   factory JsonRpcCompletionListChangedNotification.fromJson(
     Map<String, dynamic> json,
   ) =>
-      const JsonRpcCompletionListChangedNotification();
+      JsonRpcCompletionListChangedNotification(meta: extractRequestMeta(json));
 }
 
 /// Deprecated alias for [CompleteRequest].

--- a/lib/src/types/initialization.dart
+++ b/lib/src/types/initialization.dart
@@ -983,11 +983,11 @@ class DiscoverResult implements BaseResultData {
 
 /// Notification sent from the client to the server after initialization is finished.
 class JsonRpcInitializedNotification extends JsonRpcNotification {
-  const JsonRpcInitializedNotification()
+  const JsonRpcInitializedNotification({super.meta})
       : super(method: Method.notificationsInitialized);
 
   factory JsonRpcInitializedNotification.fromJson(Map<String, dynamic> json) =>
-      const JsonRpcInitializedNotification();
+      JsonRpcInitializedNotification(meta: extractRequestMeta(json));
 }
 
 /// Deprecated alias for [InitializeRequest].

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -540,6 +540,23 @@ abstract class BaseResultData {
   Map<String, dynamic> toJson();
 }
 
+/// Result data that carries MCP cache freshness hints.
+abstract class CacheableResultData implements BaseResultData {
+  /// How long, in milliseconds, the client may consider this result fresh.
+  int? get ttlMs;
+
+  /// Intended cache visibility: [CacheScope.public] or [CacheScope.private].
+  String? get cacheScope;
+}
+
+/// Allowed cache scopes for MCP cacheable results.
+class CacheScope {
+  static const public = 'public';
+  static const private = 'private';
+
+  const CacheScope._();
+}
+
 /// Result type for completed MCP requests.
 const resultTypeComplete = 'complete';
 

--- a/lib/src/types/prompts.dart
+++ b/lib/src/types/prompts.dart
@@ -143,18 +143,32 @@ class JsonRpcListPromptsRequest extends JsonRpcRequest {
 }
 
 /// Result data for a successful `prompts/list` request.
-class ListPromptsResult implements BaseResultData {
+class ListPromptsResult implements CacheableResultData {
   /// The list of prompts/templates found.
   final List<Prompt> prompts;
 
   /// Opaque token for pagination.
   final Cursor? nextCursor;
 
+  /// How long, in milliseconds, the client may consider this result fresh.
+  @override
+  final int? ttlMs;
+
+  /// Intended cache visibility: `public` or `private`.
+  @override
+  final String? cacheScope;
+
   /// Optional metadata.
   @override
   final Map<String, dynamic>? meta;
 
-  const ListPromptsResult({required this.prompts, this.nextCursor, this.meta});
+  const ListPromptsResult({
+    required this.prompts,
+    this.nextCursor,
+    this.ttlMs,
+    this.cacheScope,
+    this.meta,
+  });
 
   factory ListPromptsResult.fromJson(Map<String, dynamic> json) {
     final meta = json['_meta'] as Map<String, dynamic>?;
@@ -167,16 +181,27 @@ class ListPromptsResult implements BaseResultData {
           .map((p) => Prompt.fromJson(p as Map<String, dynamic>))
           .toList(),
       nextCursor: json['nextCursor'] as String?,
+      ttlMs: readOptionalTtlMs(json['ttlMs'], 'ListPromptsResult.ttlMs'),
+      cacheScope: readOptionalCacheScope(
+        json['cacheScope'],
+        'ListPromptsResult.cacheScope',
+      ),
       meta: meta,
     );
   }
 
   @override
-  Map<String, dynamic> toJson() => {
-        'prompts': prompts.map((p) => p.toJson()).toList(),
-        if (nextCursor != null) 'nextCursor': nextCursor,
-        if (meta != null) '_meta': meta,
-      };
+  Map<String, dynamic> toJson() {
+    validateTtlMs(ttlMs, 'ListPromptsResult.ttlMs');
+    validateCacheScope(cacheScope, 'ListPromptsResult.cacheScope');
+    return {
+      'prompts': prompts.map((p) => p.toJson()).toList(),
+      if (nextCursor != null) 'nextCursor': nextCursor,
+      if (ttlMs != null) 'ttlMs': ttlMs,
+      if (cacheScope != null) 'cacheScope': cacheScope,
+      if (meta != null) '_meta': meta,
+    };
+  }
 }
 
 /// Parameters for the `prompts/get` request.
@@ -318,13 +343,13 @@ class GetPromptResult implements BaseResultData {
 
 /// Notification from server indicating the list of available prompts has changed.
 class JsonRpcPromptListChangedNotification extends JsonRpcNotification {
-  const JsonRpcPromptListChangedNotification()
+  const JsonRpcPromptListChangedNotification({super.meta})
       : super(method: Method.notificationsPromptsListChanged);
 
   factory JsonRpcPromptListChangedNotification.fromJson(
     Map<String, dynamic> json,
   ) =>
-      const JsonRpcPromptListChangedNotification();
+      JsonRpcPromptListChangedNotification(meta: extractRequestMeta(json));
 }
 
 /// Deprecated alias for [ListPromptsRequest].

--- a/lib/src/types/resources.dart
+++ b/lib/src/types/resources.dart
@@ -261,12 +261,20 @@ class JsonRpcListResourcesRequest extends JsonRpcRequest {
 }
 
 /// Result data for a successful `resources/list` request.
-class ListResourcesResult implements BaseResultData {
+class ListResourcesResult implements CacheableResultData {
   /// The list of resources found.
   final List<Resource> resources;
 
   /// Opaque token for pagination, indicating more results might be available.
   final Cursor? nextCursor;
+
+  /// How long, in milliseconds, the client may consider this result fresh.
+  @override
+  final int? ttlMs;
+
+  /// Intended cache visibility: `public` or `private`.
+  @override
+  final String? cacheScope;
 
   /// Optional metadata.
   @override
@@ -276,6 +284,8 @@ class ListResourcesResult implements BaseResultData {
   const ListResourcesResult({
     required this.resources,
     this.nextCursor,
+    this.ttlMs,
+    this.cacheScope,
     this.meta,
   });
 
@@ -291,17 +301,28 @@ class ListResourcesResult implements BaseResultData {
           .map((e) => Resource.fromJson(e as Map<String, dynamic>))
           .toList(),
       nextCursor: json['nextCursor'] as String?,
+      ttlMs: readOptionalTtlMs(json['ttlMs'], 'ListResourcesResult.ttlMs'),
+      cacheScope: readOptionalCacheScope(
+        json['cacheScope'],
+        'ListResourcesResult.cacheScope',
+      ),
       meta: meta,
     );
   }
 
   /// Converts to JSON (excluding meta).
   @override
-  Map<String, dynamic> toJson() => {
-        'resources': resources.map((r) => r.toJson()).toList(),
-        if (nextCursor != null) 'nextCursor': nextCursor,
-        if (meta != null) '_meta': meta,
-      };
+  Map<String, dynamic> toJson() {
+    validateTtlMs(ttlMs, 'ListResourcesResult.ttlMs');
+    validateCacheScope(cacheScope, 'ListResourcesResult.cacheScope');
+    return {
+      'resources': resources.map((r) => r.toJson()).toList(),
+      if (nextCursor != null) 'nextCursor': nextCursor,
+      if (ttlMs != null) 'ttlMs': ttlMs,
+      if (cacheScope != null) 'cacheScope': cacheScope,
+      if (meta != null) '_meta': meta,
+    };
+  }
 }
 
 /// Parameters for the `resources/templates/list` request. Includes pagination.
@@ -347,12 +368,20 @@ class JsonRpcListResourceTemplatesRequest extends JsonRpcRequest {
 }
 
 /// Result data for a successful `resources/templates/list` request.
-class ListResourceTemplatesResult implements BaseResultData {
+class ListResourceTemplatesResult implements CacheableResultData {
   /// The list of resource templates found.
   final List<ResourceTemplate> resourceTemplates;
 
   /// Opaque token for pagination.
   final Cursor? nextCursor;
+
+  /// How long, in milliseconds, the client may consider this result fresh.
+  @override
+  final int? ttlMs;
+
+  /// Intended cache visibility: `public` or `private`.
+  @override
+  final String? cacheScope;
 
   @override
   final Map<String, dynamic>? meta;
@@ -360,6 +389,8 @@ class ListResourceTemplatesResult implements BaseResultData {
   const ListResourceTemplatesResult({
     required this.resourceTemplates,
     this.nextCursor,
+    this.ttlMs,
+    this.cacheScope,
     this.meta,
   });
 
@@ -376,16 +407,30 @@ class ListResourceTemplatesResult implements BaseResultData {
           .map((e) => ResourceTemplate.fromJson(e as Map<String, dynamic>))
           .toList(),
       nextCursor: json['nextCursor'] as String?,
+      ttlMs: readOptionalTtlMs(
+        json['ttlMs'],
+        'ListResourceTemplatesResult.ttlMs',
+      ),
+      cacheScope: readOptionalCacheScope(
+        json['cacheScope'],
+        'ListResourceTemplatesResult.cacheScope',
+      ),
       meta: meta,
     );
   }
 
   @override
-  Map<String, dynamic> toJson() => {
-        'resourceTemplates': resourceTemplates.map((t) => t.toJson()).toList(),
-        if (nextCursor != null) 'nextCursor': nextCursor,
-        if (meta != null) '_meta': meta,
-      };
+  Map<String, dynamic> toJson() {
+    validateTtlMs(ttlMs, 'ListResourceTemplatesResult.ttlMs');
+    validateCacheScope(cacheScope, 'ListResourceTemplatesResult.cacheScope');
+    return {
+      'resourceTemplates': resourceTemplates.map((t) => t.toJson()).toList(),
+      if (nextCursor != null) 'nextCursor': nextCursor,
+      if (ttlMs != null) 'ttlMs': ttlMs,
+      if (cacheScope != null) 'cacheScope': cacheScope,
+      if (meta != null) '_meta': meta,
+    };
+  }
 }
 
 /// Parameters for the `resources/read` request.
@@ -452,14 +497,27 @@ class JsonRpcReadResourceRequest extends JsonRpcRequest {
 }
 
 /// Result data for a successful `resources/read` request.
-class ReadResourceResult implements BaseResultData {
+class ReadResourceResult implements CacheableResultData {
   /// The contents of the resource (can be multiple parts).
   final List<ResourceContents> contents;
+
+  /// How long, in milliseconds, the client may consider this result fresh.
+  @override
+  final int? ttlMs;
+
+  /// Intended cache visibility: `public` or `private`.
+  @override
+  final String? cacheScope;
 
   @override
   final Map<String, dynamic>? meta;
 
-  const ReadResourceResult({required this.contents, this.meta});
+  const ReadResourceResult({
+    required this.contents,
+    this.ttlMs,
+    this.cacheScope,
+    this.meta,
+  });
 
   factory ReadResourceResult.fromJson(Map<String, dynamic> json) {
     final meta = json['_meta'] as Map<String, dynamic>?;
@@ -471,26 +529,37 @@ class ReadResourceResult implements BaseResultData {
       contents: contents
           .map((e) => ResourceContents.fromJson(e as Map<String, dynamic>))
           .toList(),
+      ttlMs: readOptionalTtlMs(json['ttlMs'], 'ReadResourceResult.ttlMs'),
+      cacheScope: readOptionalCacheScope(
+        json['cacheScope'],
+        'ReadResourceResult.cacheScope',
+      ),
       meta: meta,
     );
   }
 
   @override
-  Map<String, dynamic> toJson() => {
-        'contents': contents.map((c) => c.toJson()).toList(),
-        if (meta != null) '_meta': meta,
-      };
+  Map<String, dynamic> toJson() {
+    validateTtlMs(ttlMs, 'ReadResourceResult.ttlMs');
+    validateCacheScope(cacheScope, 'ReadResourceResult.cacheScope');
+    return {
+      'contents': contents.map((c) => c.toJson()).toList(),
+      if (ttlMs != null) 'ttlMs': ttlMs,
+      if (cacheScope != null) 'cacheScope': cacheScope,
+      if (meta != null) '_meta': meta,
+    };
+  }
 }
 
 /// Notification from server indicating the list of available resources has changed.
 class JsonRpcResourceListChangedNotification extends JsonRpcNotification {
-  const JsonRpcResourceListChangedNotification()
+  const JsonRpcResourceListChangedNotification({super.meta})
       : super(method: Method.notificationsResourcesListChanged);
 
   factory JsonRpcResourceListChangedNotification.fromJson(
     Map<String, dynamic> json,
   ) =>
-      const JsonRpcResourceListChangedNotification();
+      JsonRpcResourceListChangedNotification(meta: extractRequestMeta(json));
 }
 
 /// Parameters for the `resources/subscribe` request.

--- a/lib/src/types/roots.dart
+++ b/lib/src/types/roots.dart
@@ -82,11 +82,11 @@ class ListRootsResult implements BaseResultData {
 
 /// Notification from client indicating the list of roots has changed.
 class JsonRpcRootsListChangedNotification extends JsonRpcNotification {
-  const JsonRpcRootsListChangedNotification()
+  const JsonRpcRootsListChangedNotification({super.meta})
       : super(method: Method.notificationsRootsListChanged);
 
   factory JsonRpcRootsListChangedNotification.fromJson(
     Map<String, dynamic> json,
   ) =>
-      const JsonRpcRootsListChangedNotification();
+      JsonRpcRootsListChangedNotification(meta: extractRequestMeta(json));
 }

--- a/lib/src/types/subscriptions.dart
+++ b/lib/src/types/subscriptions.dart
@@ -76,6 +76,50 @@ class SubscriptionFilter {
     );
   }
 
+  /// Whether this filter is a subset of [requested].
+  bool isSubsetOf(SubscriptionFilter requested) {
+    if (toolsListChanged == true && requested.toolsListChanged != true) {
+      return false;
+    }
+    if (promptsListChanged == true && requested.promptsListChanged != true) {
+      return false;
+    }
+    if (resourcesListChanged == true &&
+        requested.resourcesListChanged != true) {
+      return false;
+    }
+    if (!_stringListSubsetOf(
+      resourceSubscriptions,
+      requested.resourceSubscriptions,
+    )) {
+      return false;
+    }
+    if (!_stringListSubsetOf(taskIds, requested.taskIds)) {
+      return false;
+    }
+    return true;
+  }
+
+  /// Whether this acknowledged filter allows [notification].
+  bool allowsNotification(JsonRpcNotification notification) {
+    switch (notification.method) {
+      case Method.notificationsToolsListChanged:
+        return toolsListChanged == true;
+      case Method.notificationsPromptsListChanged:
+        return promptsListChanged == true;
+      case Method.notificationsResourcesListChanged:
+        return resourcesListChanged == true;
+      case Method.notificationsResourcesUpdated:
+        final uri = notification.params?['uri'];
+        return uri is String && (resourceSubscriptions?.contains(uri) ?? false);
+      case Method.notificationsTasks:
+        final taskId = notification.params?['taskId'];
+        return taskId is String && (taskIds?.contains(taskId) ?? false);
+      default:
+        return false;
+    }
+  }
+
   Map<String, dynamic> toJson() => {
         if (toolsListChanged != null) 'toolsListChanged': toolsListChanged,
         if (promptsListChanged != null)
@@ -231,6 +275,17 @@ List<String>? _readOptionalStringList(Object? value, String field) {
     throw FormatException('$field must contain only strings');
   }
   return value.cast<String>();
+}
+
+bool _stringListSubsetOf(List<String>? subset, List<String>? superset) {
+  if (subset == null || subset.isEmpty) {
+    return true;
+  }
+  final allowed = superset?.toSet();
+  if (allowed == null) {
+    return false;
+  }
+  return subset.every(allowed.contains);
 }
 
 Map<String, dynamic>? _readOptionalJsonObject(Object? value, String field) {

--- a/lib/src/types/tools.dart
+++ b/lib/src/types/tools.dart
@@ -271,12 +271,20 @@ class ListToolsRequest {
 typedef ListToolsRequestParams = ListToolsRequest;
 
 /// The server's response to a [ListToolsRequest].
-class ListToolsResult implements BaseResultData {
+class ListToolsResult implements CacheableResultData {
   /// A list of tools.
   final List<Tool> tools;
 
   /// An opaque token for pagination.
   final String? nextCursor;
+
+  /// How long, in milliseconds, the client may consider this result fresh.
+  @override
+  final int? ttlMs;
+
+  /// Intended cache visibility: `public` or `private`.
+  @override
+  final String? cacheScope;
 
   /// Optional metadata.
   @override
@@ -285,6 +293,8 @@ class ListToolsResult implements BaseResultData {
   const ListToolsResult({
     required this.tools,
     this.nextCursor,
+    this.ttlMs,
+    this.cacheScope,
     this.meta,
   });
 
@@ -297,16 +307,27 @@ class ListToolsResult implements BaseResultData {
       tools:
           tools.map((e) => Tool.fromJson(e as Map<String, dynamic>)).toList(),
       nextCursor: json['nextCursor'] as String?,
+      ttlMs: readOptionalTtlMs(json['ttlMs'], 'ListToolsResult.ttlMs'),
+      cacheScope: readOptionalCacheScope(
+        json['cacheScope'],
+        'ListToolsResult.cacheScope',
+      ),
       meta: json['_meta'] as Map<String, dynamic>?,
     );
   }
 
   @override
-  Map<String, dynamic> toJson() => {
-        'tools': tools.map((e) => e.toJson()).toList(),
-        if (nextCursor != null) 'nextCursor': nextCursor,
-        if (meta != null) '_meta': meta,
-      };
+  Map<String, dynamic> toJson() {
+    validateTtlMs(ttlMs, 'ListToolsResult.ttlMs');
+    validateCacheScope(cacheScope, 'ListToolsResult.cacheScope');
+    return {
+      'tools': tools.map((e) => e.toJson()).toList(),
+      if (nextCursor != null) 'nextCursor': nextCursor,
+      if (ttlMs != null) 'ttlMs': ttlMs,
+      if (cacheScope != null) 'cacheScope': cacheScope,
+      if (meta != null) '_meta': meta,
+    };
+  }
 }
 
 @Deprecated('Use [CallToolRequest] instead.')
@@ -435,13 +456,13 @@ class CallToolResult implements BaseResultData {
 
 /// Notification from server indicating the list of available tools has changed.
 class JsonRpcToolListChangedNotification extends JsonRpcNotification {
-  const JsonRpcToolListChangedNotification()
+  const JsonRpcToolListChangedNotification({super.meta})
       : super(method: Method.notificationsToolsListChanged);
 
   factory JsonRpcToolListChangedNotification.fromJson(
     Map<String, dynamic> json,
   ) =>
-      const JsonRpcToolListChangedNotification();
+      JsonRpcToolListChangedNotification(meta: extractRequestMeta(json));
 }
 
 void _validateObjectRootSchema(

--- a/lib/src/types/validation.dart
+++ b/lib/src/types/validation.dart
@@ -43,3 +43,48 @@ String? readOptionalString(Object? value, String field) {
   }
   throw FormatException('$field must be a string');
 }
+
+int? readOptionalTtlMs(Object? value, String field) {
+  final ttlMs = readOptionalInteger(value, field);
+  if (ttlMs == null) {
+    return null;
+  }
+  return ttlMs < 0 ? 0 : ttlMs;
+}
+
+void validateTtlMs(int? value, String field) {
+  if (value == null) {
+    return;
+  }
+  if (value < 0) {
+    throw ArgumentError.value(
+      value,
+      field,
+      'must be greater than or equal to 0',
+    );
+  }
+}
+
+String? readOptionalCacheScope(Object? value, String field) {
+  final scope = readOptionalString(value, field);
+  if (scope == null) {
+    return null;
+  }
+  if (scope == 'public' || scope == 'private') {
+    return scope;
+  }
+  throw FormatException('$field must be either "public" or "private"');
+}
+
+void validateCacheScope(String? value, String field) {
+  if (value == null) {
+    return;
+  }
+  if (value != 'public' && value != 'private') {
+    throw ArgumentError.value(
+      value,
+      field,
+      'must be either "public" or "private"',
+    );
+  }
+}

--- a/test/client/client_tool_validation_test.dart
+++ b/test/client/client_tool_validation_test.dart
@@ -150,9 +150,22 @@ void main() {
             inputSchema: JsonSchema.object(
               properties: {
                 'region': JsonSchema.string(mcpHeader: 'Region'),
-                'limit': JsonSchema.number(mcpHeader: 'Limit'),
+                'limit': JsonSchema.integer(mcpHeader: 'Limit'),
                 'dryRun': JsonSchema.boolean(mcpHeader: 'Dry-Run'),
                 'count': JsonSchema.integer(mcpHeader: 'Count'),
+                'auth': JsonSchema.object(
+                  properties: {
+                    'tenant': JsonSchema.string(mcpHeader: 'Tenant'),
+                  },
+                ),
+              },
+            ),
+          ),
+          Tool(
+            name: 'number_header',
+            inputSchema: JsonSchema.object(
+              properties: {
+                'ratio': JsonSchema.number(mcpHeader: 'Ratio'),
               },
             ),
           ),
@@ -170,6 +183,14 @@ void main() {
             inputSchema: JsonSchema.object(
               properties: {
                 'region': JsonSchema.string(mcpHeader: ''),
+              },
+            ),
+          ),
+          Tool(
+            name: 'separator_header',
+            inputSchema: JsonSchema.object(
+              properties: {
+                'region': JsonSchema.string(mcpHeader: 'Bad/Header'),
               },
             ),
           ),
@@ -210,11 +231,12 @@ void main() {
           'limit': 'Limit',
           'dryRun': 'Dry-Run',
           'count': 'Count',
+          '/auth/tenant': 'Tenant',
         },
       });
       expect(
         warnings.where((message) => message.contains('Rejecting tool')),
-        hasLength(4),
+        hasLength(6),
       );
     });
 

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -1069,9 +1069,11 @@ void main() {
             request.headers.value('mcp-protocol-version');
         capturedHeaders['method'] = request.headers.value('mcp-method');
         capturedHeaders['name'] = request.headers.value('mcp-name');
+        capturedHeaders['session'] = request.headers.value('mcp-session-id');
         await request.drain<void>();
         request.response
           ..statusCode = HttpStatus.ok
+          ..headers.set('mcp-session-id', 'ignored-stateless-session')
           ..headers.contentType = ContentType.json
           ..write(
             jsonEncode(
@@ -1086,6 +1088,9 @@ void main() {
 
       transport = StreamableHttpClientTransport(
         Uri.parse('http://localhost:${server.port}/mcp'),
+        opts: const StreamableHttpClientTransportOptions(
+          sessionId: 'legacy-session',
+        ),
       )..protocolVersion = draftProtocolVersion2026_07_28;
       await transport.start();
 
@@ -1110,6 +1115,8 @@ void main() {
       );
       expect(capturedHeaders['method'], Method.toolsCall);
       expect(capturedHeaders['name'], 'echo');
+      expect(capturedHeaders['session'], isNull);
+      expect(transport.sessionId, 'legacy-session');
     });
 
     test('send maps 2026 stateless headers for standard request types',
@@ -1240,6 +1247,94 @@ void main() {
       expect(capturedHeaders['name'], 'task-1');
     });
 
+    test('stateless SSE responses reject server-initiated requests', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        await request.drain<void>();
+        final serverRequest = const JsonRpcRequest(
+          id: 99,
+          method: Method.rootsList,
+        );
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType('text', 'event-stream')
+          ..write('data: ${jsonEncode(serverRequest.toJson())}\n\n');
+        await request.response.close();
+      });
+
+      transport = StreamableHttpClientTransport(
+        Uri.parse('http://localhost:${server.port}/mcp'),
+      )..protocolVersion = draftProtocolVersion2026_07_28;
+      await transport.start();
+
+      final errorCompleter = Completer<Error>();
+      final messages = <JsonRpcMessage>[];
+      transport
+        ..onmessage = messages.add
+        ..onerror = (error) {
+          if (!errorCompleter.isCompleted) {
+            errorCompleter.complete(error);
+          }
+        };
+
+      await transport.send(
+        JsonRpcListToolsRequest(id: 1, meta: _statelessMeta()),
+      );
+
+      final error = await errorCompleter.future.timeout(
+        const Duration(seconds: 5),
+      );
+      expect(error, isA<McpError>());
+      expect((error as McpError).code, ErrorCode.invalidRequest.value);
+      expect(error.message, contains('input_required'));
+      expect(messages, isEmpty);
+    });
+
+    test('stateless JSON responses reject server-initiated requests', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        await request.drain<void>();
+        final serverRequest = const JsonRpcRequest(
+          id: 99,
+          method: Method.rootsList,
+        );
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(jsonEncode([serverRequest.toJson()]));
+        await request.response.close();
+      });
+
+      transport = StreamableHttpClientTransport(
+        Uri.parse('http://localhost:${server.port}/mcp'),
+      )..protocolVersion = draftProtocolVersion2026_07_28;
+      await transport.start();
+
+      final errorCompleter = Completer<Error>();
+      final messages = <JsonRpcMessage>[];
+      transport
+        ..onmessage = messages.add
+        ..onerror = (error) {
+          if (!errorCompleter.isCompleted) {
+            errorCompleter.complete(error);
+          }
+        };
+
+      await transport.send(
+        JsonRpcListToolsRequest(id: 1, meta: _statelessMeta()),
+      );
+
+      final error = await errorCompleter.future.timeout(
+        const Duration(seconds: 5),
+      );
+      expect(error, isA<McpError>());
+      expect((error as McpError).code, ErrorCode.invalidRequest.value);
+      expect(error.message, contains('inputRequests'));
+      expect(messages, isEmpty);
+    });
+
     test('send mirrors mapped tool parameters into 2026 stateless headers',
         () async {
       final capturedHeaders = <String, String?>{};
@@ -1250,9 +1345,15 @@ void main() {
         capturedHeaders['greeting'] =
             request.headers.value('mcp-param-greeting');
         capturedHeaders['limit'] = request.headers.value('mcp-param-limit');
+        capturedHeaders['rounded'] = request.headers.value('mcp-param-rounded');
+        capturedHeaders['unsafe'] = request.headers.value('mcp-param-unsafe');
+        capturedHeaders['ratio'] = request.headers.value('mcp-param-ratio');
         capturedHeaders['dryRun'] = request.headers.value('mcp-param-dry-run');
         capturedHeaders['text'] = request.headers.value('mcp-param-text');
         capturedHeaders['payload'] = request.headers.value('mcp-param-payload');
+        capturedHeaders['sentinel'] =
+            request.headers.value('mcp-param-sentinel');
+        capturedHeaders['tenant'] = request.headers.value('mcp-param-tenant');
         await request.drain<void>();
         request.response
           ..statusCode = HttpStatus.ok
@@ -1278,9 +1379,14 @@ void main() {
               'region': 'Region',
               'greeting': 'Greeting',
               'limit': 'Limit',
+              'rounded': 'Rounded',
+              'unsafe': 'Unsafe',
+              'ratio': 'Ratio',
               'dryRun': 'Dry-Run',
               'text': 'Text',
               'payload': 'Payload',
+              'sentinel': 'Sentinel',
+              '/auth/tenant': 'Tenant',
             },
           },
         );
@@ -1298,9 +1404,14 @@ void main() {
               'region': 'us-west1',
               'greeting': 'Hello, 世界',
               'limit': 42,
+              'rounded': 42.0,
+              'unsafe': 9007199254740992,
+              'ratio': 1.5,
               'dryRun': false,
               'text': ' padded ',
               'payload': {'nested': true},
+              'sentinel': '=?base64?YWJj?=',
+              'auth': {'tenant': 'acme'},
             },
           },
           meta: _statelessMeta(),
@@ -1314,9 +1425,17 @@ void main() {
         '=?base64?${base64Encode(utf8.encode('Hello, 世界'))}?=',
       );
       expect(capturedHeaders['limit'], '42');
+      expect(capturedHeaders['rounded'], '42');
+      expect(capturedHeaders['unsafe'], isNull);
+      expect(capturedHeaders['ratio'], isNull);
       expect(capturedHeaders['dryRun'], 'false');
       expect(capturedHeaders['text'], '=?base64?IHBhZGRlZCA=?=');
       expect(capturedHeaders['payload'], isNull);
+      expect(
+        capturedHeaders['sentinel'],
+        '=?base64?${base64Encode(utf8.encode('=?base64?YWJj?='))}?=',
+      );
+      expect(capturedHeaders['tenant'], 'acme');
     });
 
     test('send with initialized notification triggers SSE establishment',
@@ -1988,6 +2107,72 @@ void main() {
         // Should complete without error
         await transport.terminateSession();
         expect(true, isTrue);
+      });
+
+      test('stateless protocol does not send DELETE for session termination',
+          () async {
+        var deleteRequests = 0;
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() => server.close(force: true));
+        server.listen((request) async {
+          if (request.method == 'DELETE') {
+            deleteRequests += 1;
+          }
+          request.response.statusCode = HttpStatus.ok;
+          await request.response.close();
+        });
+
+        transport = StreamableHttpClientTransport(
+          Uri.parse('http://localhost:${server.port}/mcp'),
+          opts: const StreamableHttpClientTransportOptions(
+            sessionId: 'legacy-session',
+          ),
+        );
+        transport.protocolVersion = draftProtocolVersion2026_07_28;
+        await transport.start();
+
+        await transport.terminateSession();
+
+        expect(deleteRequests, 0);
+        expect(transport.sessionId, isNull);
+      });
+
+      test('stateless protocol does not open legacy GET SSE after initialized',
+          () async {
+        var getRequests = 0;
+        var postRequests = 0;
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() => server.close(force: true));
+        server.listen((request) async {
+          if (request.method == 'GET') {
+            getRequests += 1;
+            request.response.statusCode = HttpStatus.methodNotAllowed;
+            await request.response.close();
+            return;
+          }
+
+          if (request.method == 'POST') {
+            postRequests += 1;
+            request.response.statusCode = HttpStatus.accepted;
+            await request.response.close();
+            return;
+          }
+
+          request.response.statusCode = HttpStatus.methodNotAllowed;
+          await request.response.close();
+        });
+
+        transport = StreamableHttpClientTransport(
+          Uri.parse('http://localhost:${server.port}/mcp'),
+        );
+        transport.protocolVersion = draftProtocolVersion2026_07_28;
+        await transport.start();
+
+        await transport.send(const JsonRpcInitializedNotification());
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        expect(postRequests, 1);
+        expect(getRequests, 0);
       });
 
       test('handles error callback configuration', () async {

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -42,9 +42,19 @@ class DiscoveringClientTransport extends Transport
     implements ProtocolVersionAwareTransport {
   DiscoveringClientTransport({
     this.discoverVersions = const [draftProtocolVersion2026_07_28],
+    this.unsupportedDiscoverProtocolVersions = const [],
+    this.unsupportedDiscoverData,
+    this.capabilities = const ServerCapabilities(
+      tools: ServerCapabilitiesTools(),
+    ),
+    this.toolsListResult = const {'tools': []},
   });
 
   final List<String> discoverVersions;
+  final List<String> unsupportedDiscoverProtocolVersions;
+  final Object? unsupportedDiscoverData;
+  final ServerCapabilities capabilities;
+  final Map<String, dynamic> toolsListResult;
   final List<JsonRpcMessage> sentMessages = [];
 
   @override
@@ -63,14 +73,34 @@ class DiscoveringClientTransport extends Transport
     sentMessages.add(message);
 
     if (message is JsonRpcRequest && message.method == Method.serverDiscover) {
+      final requestedProtocolVersion =
+          message.meta?[McpMetaKey.protocolVersion];
+      if (unsupportedDiscoverProtocolVersions.contains(
+        requestedProtocolVersion,
+      )) {
+        onmessage?.call(
+          JsonRpcError(
+            id: message.id,
+            error: JsonRpcErrorData(
+              code: ErrorCode.unsupportedProtocolVersion.value,
+              message: 'Unsupported protocol version',
+              data: unsupportedDiscoverData ??
+                  {
+                    'supported': discoverVersions,
+                    'requested': requestedProtocolVersion,
+                  },
+            ),
+          ),
+        );
+        return;
+      }
+
       onmessage?.call(
         JsonRpcResponse(
           id: message.id,
           result: DiscoverResult(
             supportedVersions: discoverVersions,
-            capabilities: const ServerCapabilities(
-              tools: ServerCapabilitiesTools(),
-            ),
+            capabilities: capabilities,
             serverInfo: const Implementation(name: 'server', version: '1.0.0'),
           ).toJson(),
         ),
@@ -82,7 +112,7 @@ class DiscoveringClientTransport extends Transport
       onmessage?.call(
         JsonRpcResponse(
           id: message.id,
-          result: const ListToolsResult(tools: []).toJson(),
+          result: toolsListResult,
         ),
       );
     }
@@ -94,6 +124,11 @@ class DiscoveringClientTransport extends Transport
 
 class LegacyFallbackTransport extends Transport
     implements ProtocolVersionAwareTransport {
+  LegacyFallbackTransport({
+    this.toolsListResult = const {'tools': []},
+  });
+
+  final Map<String, dynamic> toolsListResult;
   final List<JsonRpcMessage> sentMessages = [];
 
   @override
@@ -135,6 +170,16 @@ class LegacyFallbackTransport extends Transport
             ),
             serverInfo: Implementation(name: 'server', version: '1.0.0'),
           ).toJson(),
+        ),
+      );
+      return;
+    }
+
+    if (message is JsonRpcRequest && message.method == Method.toolsList) {
+      onmessage?.call(
+        JsonRpcResponse(
+          id: message.id,
+          result: toolsListResult,
         ),
       );
     }
@@ -189,11 +234,13 @@ class CompletedTaskHandler extends CancelTaskResultHandler {
 Map<String, dynamic> _clientMeta({
   String? protocolVersion,
   ClientCapabilities clientCapabilities = const ClientCapabilities(),
+  Object? logLevel,
 }) {
   return buildProtocolRequestMeta(
     protocolVersion: protocolVersion ?? draftProtocolVersion2026_07_28,
     clientInfo: const Implementation(name: 'client', version: '1.0.0'),
     clientCapabilities: clientCapabilities,
+    logLevel: logLevel,
   );
 }
 
@@ -265,6 +312,91 @@ void main() {
       expect(
         DiscoverResult.fromJson(resultJson).instructions,
         'Use the tools.',
+      );
+    });
+
+    test('serializes cacheable result hints without changing legacy defaults',
+        () {
+      final toolsJson = const ListToolsResult(
+        tools: [],
+        ttlMs: 300000,
+        cacheScope: CacheScope.public,
+      ).toJson();
+      expect(toolsJson['ttlMs'], 300000);
+      expect(toolsJson['cacheScope'], CacheScope.public);
+      expect(toolsJson, isNot(contains('resultType')));
+      final parsedTools = ListToolsResult.fromJson(toolsJson);
+      expect(parsedTools.ttlMs, 300000);
+      expect(parsedTools.cacheScope, CacheScope.public);
+
+      final promptsJson = const ListPromptsResult(
+        prompts: [],
+        ttlMs: 600000,
+        cacheScope: CacheScope.private,
+      ).toJson();
+      expect(ListPromptsResult.fromJson(promptsJson).ttlMs, 600000);
+      expect(
+        ListPromptsResult.fromJson(promptsJson).cacheScope,
+        CacheScope.private,
+      );
+
+      final resourcesJson = const ListResourcesResult(
+        resources: [],
+        ttlMs: 120000,
+        cacheScope: CacheScope.public,
+      ).toJson();
+      expect(ListResourcesResult.fromJson(resourcesJson).ttlMs, 120000);
+      expect(
+        ListResourcesResult.fromJson(resourcesJson).cacheScope,
+        CacheScope.public,
+      );
+
+      final templatesJson = const ListResourceTemplatesResult(
+        resourceTemplates: [],
+        ttlMs: 30000,
+        cacheScope: CacheScope.public,
+      ).toJson();
+      expect(
+        ListResourceTemplatesResult.fromJson(templatesJson).ttlMs,
+        30000,
+      );
+      expect(
+        ListResourceTemplatesResult.fromJson(templatesJson).cacheScope,
+        CacheScope.public,
+      );
+
+      final readJson = const ReadResourceResult(
+        contents: [TextResourceContents(uri: 'file:///a.txt', text: 'a')],
+        ttlMs: 60000,
+        cacheScope: CacheScope.private,
+      ).toJson();
+      expect(ReadResourceResult.fromJson(readJson).ttlMs, 60000);
+      expect(
+        ReadResourceResult.fromJson(readJson).cacheScope,
+        CacheScope.private,
+      );
+
+      expect(const ListToolsResult(tools: []).toJson(), {'tools': []});
+      expect(
+        ListToolsResult.fromJson(const {'tools': [], 'ttlMs': -1}).ttlMs,
+        0,
+      );
+      expect(
+        () => ListToolsResult.fromJson(
+          const {'tools': [], 'cacheScope': 'shared'},
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => const ListToolsResult(tools: [], ttlMs: -1).toJson(),
+        throwsArgumentError,
+      );
+      expect(
+        () => const ListToolsResult(
+          tools: [],
+          cacheScope: 'shared',
+        ).toJson(),
+        throwsArgumentError,
       );
     });
 
@@ -504,6 +636,216 @@ void main() {
       expect(transport.sentMessages.last, isA<JsonRpcResponse>());
     });
 
+    test('server rejects subscription notifications before acknowledgment',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            tools: ServerCapabilitiesTools(listChanged: true),
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcSubscriptionsListenRequest>(
+        Method.subscriptionsListen,
+        (request, extra) async {
+          await extra.sendNotification(
+            const JsonRpcToolListChangedNotification(),
+          );
+          return const EmptyResult();
+        },
+        (id, params, meta) => JsonRpcSubscriptionsListenRequest(
+          id: id,
+          listenParams: SubscriptionsListenRequest.fromJson(params!),
+          meta: meta,
+        ),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcSubscriptionsListenRequest(
+          id: 'sub-1',
+          listenParams: const SubscriptionsListenRequest(
+            notifications: SubscriptionFilter(toolsListChanged: true),
+          ),
+          meta: _clientMeta(),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcError;
+      expect(response.error.code, ErrorCode.invalidRequest.value);
+      expect(
+        response.error.message,
+        contains(Method.notificationsSubscriptionsAcknowledged),
+      );
+    });
+
+    test('server tags direct subscription notifications with subscription id',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            tools: ServerCapabilitiesTools(listChanged: true),
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcSubscriptionsListenRequest>(
+        Method.subscriptionsListen,
+        (request, extra) async {
+          await extra.sendSubscriptionAcknowledged(
+            request.listenParams.notifications.acknowledgedBy(
+              const ServerCapabilities(
+                tools: ServerCapabilitiesTools(listChanged: true),
+              ),
+            ),
+          );
+          await extra.sendNotification(
+            const JsonRpcToolListChangedNotification(),
+          );
+          return const EmptyResult();
+        },
+        (id, params, meta) => JsonRpcSubscriptionsListenRequest(
+          id: id,
+          listenParams: SubscriptionsListenRequest.fromJson(params!),
+          meta: meta,
+        ),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcSubscriptionsListenRequest(
+          id: 'sub-1',
+          listenParams: const SubscriptionsListenRequest(
+            notifications: SubscriptionFilter(toolsListChanged: true),
+          ),
+          meta: _clientMeta(),
+        ),
+      );
+      await _pump();
+
+      expect(transport.sentMessages, hasLength(3));
+      expect(
+        transport.sentMessages.take(2).map((message) => message.toJson()),
+        everyElement(
+          containsPair(
+            'params',
+            containsPair(
+              '_meta',
+              containsPair(McpMetaKey.subscriptionId, 'sub-1'),
+            ),
+          ),
+        ),
+      );
+      expect(
+        (transport.sentMessages[1] as JsonRpcNotification).method,
+        Method.notificationsToolsListChanged,
+      );
+      expect(transport.sentMessages.last, isA<JsonRpcResponse>());
+    });
+
+    test('stateless server responses add complete result and cache defaults',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            prompts: ServerCapabilitiesPrompts(),
+            resources: ServerCapabilitiesResources(),
+            tools: ServerCapabilitiesTools(),
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcListToolsRequest>(
+        Method.toolsList,
+        (request, extra) async => const ListToolsResult(
+          tools: [],
+          ttlMs: 300000,
+          cacheScope: CacheScope.public,
+        ),
+        (id, params, meta) => JsonRpcListToolsRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      server.setRequestHandler<JsonRpcListPromptsRequest>(
+        Method.promptsList,
+        (request, extra) async => const ListPromptsResult(prompts: []),
+        (id, params, meta) => JsonRpcListPromptsRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      server.setRequestHandler<JsonRpcListResourcesRequest>(
+        Method.resourcesList,
+        (request, extra) async => const ListResourcesResult(resources: []),
+        (id, params, meta) => JsonRpcListResourcesRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      server.setRequestHandler<JsonRpcListResourceTemplatesRequest>(
+        Method.resourcesTemplatesList,
+        (request, extra) async =>
+            const ListResourceTemplatesResult(resourceTemplates: []),
+        (id, params, meta) => JsonRpcListResourceTemplatesRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      server.setRequestHandler<JsonRpcReadResourceRequest>(
+        Method.resourcesRead,
+        (request, extra) async => const ReadResourceResult(
+          contents: [TextResourceContents(uri: 'file:///a.txt', text: 'a')],
+        ),
+        (id, params, meta) => JsonRpcReadResourceRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      final requests = [
+        JsonRpcListToolsRequest(id: 'tools', meta: _clientMeta()),
+        JsonRpcListPromptsRequest(id: 'prompts', meta: _clientMeta()),
+        JsonRpcListResourcesRequest(id: 'resources', meta: _clientMeta()),
+        JsonRpcListResourceTemplatesRequest(
+          id: 'templates',
+          meta: _clientMeta(),
+        ),
+        JsonRpcReadResourceRequest(
+          id: 'read',
+          readParams: const ReadResourceRequest(uri: 'file:///a.txt'),
+          meta: _clientMeta(),
+        ),
+      ];
+      for (final request in requests) {
+        transport.receive(request);
+        await _pump();
+      }
+
+      final responses = transport.sentMessages.cast<JsonRpcResponse>().toList();
+      final tools = responses[0].result;
+      expect(tools['resultType'], resultTypeComplete);
+      expect(tools['ttlMs'], 300000);
+      expect(tools['cacheScope'], CacheScope.public);
+
+      for (final response in responses.skip(1)) {
+        expect(response.result['resultType'], resultTypeComplete);
+        expect(response.result['ttlMs'], 0);
+        expect(response.result['cacheScope'], CacheScope.private);
+      }
+    });
+
     test('server rejects task subscriptions without task extension capability',
         () async {
       final server = Server(
@@ -599,6 +941,185 @@ void main() {
             [mcpTasksExtensionId],
         isEmpty,
       );
+    });
+
+    test('server handles task extension methods with 2026 result shapes',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            extensions: {mcpTasksExtensionId: {}},
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcGetTaskRequest>(
+        Method.tasksGet,
+        (request, extra) async => const GetTaskExtensionResult(
+          task: TaskExtensionTask(
+            taskId: 'task-1',
+            status: TaskStatus.completed,
+            createdAt: '2026-07-28T00:00:00Z',
+            lastUpdatedAt: '2026-07-28T00:01:00Z',
+            ttlMs: 60000,
+            result: {
+              'content': [
+                {'type': 'text', 'text': 'done'},
+              ],
+            },
+          ),
+        ),
+        (id, params, meta) => JsonRpcGetTaskRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      server.setRequestHandler<JsonRpcCancelTaskRequest>(
+        Method.tasksCancel,
+        (request, extra) async => const TaskExtensionAcknowledgementResult(),
+        (id, params, meta) => JsonRpcCancelTaskRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      server.setRequestHandler<JsonRpcUpdateTaskRequest>(
+        Method.tasksUpdate,
+        (request, extra) async => const EmptyResult(),
+        (id, params, meta) => JsonRpcUpdateTaskRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+      final taskExtensionMeta = _clientMeta(
+        clientCapabilities: const ClientCapabilities(
+          extensions: {mcpTasksExtensionId: {}},
+        ),
+      );
+
+      transport
+        ..receive(
+          JsonRpcGetTaskRequest(
+            id: 'get-task',
+            getParams: const GetTaskRequest(taskId: 'task-1'),
+            meta: taskExtensionMeta,
+          ),
+        )
+        ..receive(
+          JsonRpcCancelTaskRequest(
+            id: 'cancel-task',
+            cancelParams: const CancelTaskRequest(taskId: 'task-1'),
+            meta: taskExtensionMeta,
+          ),
+        )
+        ..receive(
+          JsonRpcUpdateTaskRequest(
+            id: 'update-task',
+            updateParams: const UpdateTaskRequest(
+              taskId: 'task-1',
+              inputResponses: {},
+            ),
+            meta: taskExtensionMeta,
+          ),
+        );
+      await _pump();
+
+      final responses = transport.sentMessages.cast<JsonRpcResponse>().toList();
+      expect(responses, hasLength(3));
+      expect(responses[0].result['resultType'], resultTypeComplete);
+      expect(responses[0].result['taskId'], 'task-1');
+      expect(responses[0].result['ttlMs'], 60000);
+      expect(responses[0].result, isNot(contains('ttl')));
+      expect(responses[1].result, {'resultType': resultTypeComplete});
+      expect(responses[2].result, {'resultType': resultTypeComplete});
+    });
+
+    test('server does not expose legacy task handlers as task extension',
+        () async {
+      final server = McpServer(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+      var handlerCalled = false;
+      server.experimental.onGetTask((taskId, extra) async {
+        handlerCalled = true;
+        return Task(
+          taskId: taskId,
+          status: TaskStatus.completed,
+          ttl: null,
+          createdAt: '2026-07-28T00:00:00Z',
+          lastUpdatedAt: '2026-07-28T00:01:00Z',
+        );
+      });
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcGetTaskRequest(
+          id: 'get-task',
+          getParams: const GetTaskRequest(taskId: 'task-1'),
+          meta: _clientMeta(
+            clientCapabilities: const ClientCapabilities(
+              extensions: {mcpTasksExtensionId: {}},
+            ),
+          ),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcError;
+      expect(response.error.code, ErrorCode.methodNotFound.value);
+      expect(response.error.message, contains(mcpTasksExtensionId));
+      expect(handlerCalled, isFalse);
+    });
+
+    test('stateless task extension handlers reject legacy result shapes',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            extensions: {mcpTasksExtensionId: {}},
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcGetTaskRequest>(
+        Method.tasksGet,
+        (request, extra) async => Task(
+          taskId: request.getParams.taskId,
+          status: TaskStatus.completed,
+          ttl: null,
+          createdAt: '2026-07-28T00:00:00Z',
+          lastUpdatedAt: '2026-07-28T00:01:00Z',
+        ),
+        (id, params, meta) => JsonRpcGetTaskRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcGetTaskRequest(
+          id: 'get-task',
+          getParams: const GetTaskRequest(taskId: 'task-1'),
+          meta: _clientMeta(
+            clientCapabilities: const ClientCapabilities(
+              extensions: {mcpTasksExtensionId: {}},
+            ),
+          ),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcError;
+      expect(response.error.code, ErrorCode.invalidParams.value);
+      expect(response.error.message, contains('GetTaskExtensionResult'));
     });
 
     test('server rejects removed legacy task methods in stateless protocol',
@@ -882,6 +1403,30 @@ void main() {
       expect(tool, isNot(contains('execution')));
     });
 
+    test('stateless tools/list returns tools sorted by name', () async {
+      final server = McpServer(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+      for (final name in ['zeta', 'alpha', 'middle']) {
+        server.registerTool(
+          name,
+          callback: (args, extra) => const CallToolResult(
+            content: [TextContent(text: 'ok')],
+          ),
+        );
+      }
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport
+          .receive(JsonRpcListToolsRequest(id: 'tools', meta: _clientMeta()));
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      final tools = response.result['tools'] as List;
+      expect(tools.map((tool) => tool['name']), ['alpha', 'middle', 'zeta']);
+    });
+
     test('tasks/update handler requires task extension capability', () {
       final server = Server(
         const Implementation(name: 'server', version: '1.0.0'),
@@ -1071,6 +1616,208 @@ void main() {
           contains('Invalid stateless request metadata.'),
         ),
       );
+      expect(
+        validateToolRequest(_clientMeta(logLevel: 'verbose')),
+        isA<McpError>().having(
+          (error) => error.message,
+          'message',
+          contains(McpMetaKey.logLevel),
+        ),
+      );
+    });
+
+    test('server rejects core RPCs removed from stateless MCP', () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      final removedRequests = <JsonRpcRequest>[
+        JsonRpcRequest(
+          id: 1,
+          method: Method.initialize,
+          params: const {
+            'protocolVersion': draftProtocolVersion2026_07_28,
+            'capabilities': <String, dynamic>{},
+            'clientInfo': {'name': 'client', 'version': '1.0.0'},
+          },
+          meta: _clientMeta(),
+        ),
+        JsonRpcRequest(
+          id: 2,
+          method: Method.ping,
+          meta: _clientMeta(),
+        ),
+        JsonRpcRequest(
+          id: 3,
+          method: Method.loggingSetLevel,
+          params: const {'level': 'info'},
+          meta: _clientMeta(),
+        ),
+        JsonRpcRequest(
+          id: 4,
+          method: Method.resourcesSubscribe,
+          params: const {'uri': 'file:///tmp/example.txt'},
+          meta: _clientMeta(),
+        ),
+        JsonRpcRequest(
+          id: 5,
+          method: Method.resourcesUnsubscribe,
+          params: const {'uri': 'file:///tmp/example.txt'},
+          meta: _clientMeta(),
+        ),
+      ];
+
+      for (final request in removedRequests) {
+        transport.sentMessages.clear();
+
+        transport.receive(request);
+        await _pump();
+
+        final response = transport.sentMessages.single as JsonRpcError;
+        expect(response.id, request.id);
+        expect(response.error.code, ErrorCode.methodNotFound.value);
+        expect(response.error.message, contains(request.method));
+      }
+    });
+
+    test('server rejects notifications removed from stateless MCP', () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+      final errors = <Error>[];
+      server.onerror = errors.add;
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      final initialized = JsonRpcMessage.fromJson({
+        'jsonrpc': jsonRpcVersion,
+        'method': Method.notificationsInitialized,
+        'params': {'_meta': _clientMeta()},
+      }) as JsonRpcNotification;
+      final rootsListChanged = JsonRpcMessage.fromJson({
+        'jsonrpc': jsonRpcVersion,
+        'method': Method.notificationsRootsListChanged,
+        'params': {'_meta': _clientMeta()},
+      }) as JsonRpcNotification;
+
+      expect(
+        initialized.meta?[McpMetaKey.protocolVersion],
+        draftProtocolVersion2026_07_28,
+      );
+      expect(
+        rootsListChanged.meta?[McpMetaKey.protocolVersion],
+        draftProtocolVersion2026_07_28,
+      );
+
+      for (final notification in [initialized, rootsListChanged]) {
+        errors.clear();
+
+        transport.receive(notification);
+        await _pump();
+
+        final error = errors.single as McpError;
+        expect(error.code, ErrorCode.methodNotFound.value);
+        expect(error.message, contains(notification.method));
+      }
+      expect(transport.sentMessages, isEmpty);
+    });
+
+    test('server gates stateless logging by request metadata', () async {
+      late Server server;
+      server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            logging: {},
+            tools: ServerCapabilitiesTools(),
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcListToolsRequest>(
+        Method.toolsList,
+        (request, extra) async {
+          await server.sendLoggingMessage(
+            const LoggingMessageNotification(
+              level: LoggingLevel.debug,
+              data: 'skip',
+            ),
+            requestMeta: extra.meta,
+          );
+          await server.sendLoggingMessage(
+            const LoggingMessageNotification(
+              level: LoggingLevel.warning,
+              data: 'emit',
+            ),
+            requestMeta: extra.meta,
+          );
+          return const ListToolsResult(tools: []);
+        },
+        (id, params, meta) => JsonRpcListToolsRequest(
+          id: id,
+          params: params,
+          meta: meta,
+        ),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcListToolsRequest(
+          id: 1,
+          meta: _clientMeta(logLevel: 'warning'),
+        ),
+      );
+      await _pump();
+
+      expect(transport.sentMessages, hasLength(2));
+      final loggingNotification =
+          transport.sentMessages.first as JsonRpcNotification;
+      expect(loggingNotification.method, Method.notificationsMessage);
+      expect(loggingNotification.params?['level'], LoggingLevel.warning.name);
+      expect(loggingNotification.params?['data'], 'emit');
+      expect(transport.sentMessages.last, isA<JsonRpcResponse>());
+    });
+
+    test('server does not send stateless logging without request logLevel',
+        () async {
+      late Server server;
+      server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(
+            logging: {},
+            tools: ServerCapabilitiesTools(),
+          ),
+        ),
+      );
+      server.setRequestHandler<JsonRpcListToolsRequest>(
+        Method.toolsList,
+        (request, extra) async {
+          await server.sendLoggingMessage(
+            const LoggingMessageNotification(
+              level: LoggingLevel.error,
+              data: 'skip',
+            ),
+            requestMeta: extra.meta,
+          );
+          return const ListToolsResult(tools: []);
+        },
+        (id, params, meta) => JsonRpcListToolsRequest(
+          id: id,
+          params: params,
+          meta: meta,
+        ),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(JsonRpcListToolsRequest(id: 1, meta: _clientMeta()));
+      await _pump();
+
+      expect(transport.sentMessages, hasLength(1));
+      expect(transport.sentMessages.single, isA<JsonRpcResponse>());
     });
 
     test('client can opt in to server/discover and sends stateless metadata',
@@ -1105,6 +1852,546 @@ void main() {
       expect(listRequest.meta?[McpMetaKey.clientCapabilities], {});
     });
 
+    test('client listenSubscriptions requires a connected transport', () {
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+      );
+
+      expect(
+        () => client.listenSubscriptions(
+          const SubscriptionsListenRequest(
+            notifications: SubscriptionFilter(toolsListChanged: true),
+          ),
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('client listenSubscriptions demultiplexes by subscription id',
+        () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+          resources: ServerCapabilitiesResources(),
+        ),
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+
+      final toolsSubscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+      );
+      final resourcesSubscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(
+            resourceSubscriptions: ['file:///project/config.json'],
+          ),
+        ),
+      );
+      await _pump();
+
+      final listenRequests = transport.sentMessages
+          .whereType<JsonRpcRequest>()
+          .where((message) => message.method == Method.subscriptionsListen)
+          .toList();
+      expect(listenRequests, hasLength(2));
+      expect(listenRequests[0].id, toolsSubscription.id);
+      expect(listenRequests[1].id, resourcesSubscription.id);
+      expect(
+        listenRequests[0].meta?[McpMetaKey.protocolVersion],
+        draftProtocolVersion2026_07_28,
+      );
+      expect(listenRequests[0].params?['notifications'], {
+        'toolsListChanged': true,
+      });
+
+      transport.onmessage?.call(
+        JsonRpcSubscriptionsAcknowledgedNotification(
+          acknowledgedParams: const SubscriptionsAcknowledgedNotification(
+            notifications: SubscriptionFilter(
+              resourceSubscriptions: ['file:///project/config.json'],
+            ),
+          ),
+          meta: {McpMetaKey.subscriptionId: resourcesSubscription.id},
+        ),
+      );
+      transport.onmessage?.call(
+        JsonRpcSubscriptionsAcknowledgedNotification(
+          acknowledgedParams: const SubscriptionsAcknowledgedNotification(
+            notifications: SubscriptionFilter(toolsListChanged: true),
+          ),
+          meta: {McpMetaKey.subscriptionId: toolsSubscription.id},
+        ),
+      );
+
+      final toolsAcknowledged = await toolsSubscription.acknowledged;
+      final resourcesAcknowledged = await resourcesSubscription.acknowledged;
+      expect(toolsAcknowledged.notifications.toolsListChanged, isTrue);
+      expect(
+        resourcesAcknowledged.notifications.resourceSubscriptions,
+        ['file:///project/config.json'],
+      );
+
+      final toolNotification = toolsSubscription.notifications.first;
+      final resourceNotification = resourcesSubscription.notifications.first;
+      transport.onmessage?.call(
+        JsonRpcToolListChangedNotification(
+          meta: {McpMetaKey.subscriptionId: toolsSubscription.id},
+        ),
+      );
+      transport.onmessage?.call(
+        JsonRpcResourceUpdatedNotification(
+          updatedParams: const ResourceUpdatedNotification(
+            uri: 'file:///project/config.json',
+          ),
+          meta: {McpMetaKey.subscriptionId: resourcesSubscription.id},
+        ),
+      );
+
+      expect(
+        (await toolNotification).method,
+        Method.notificationsToolsListChanged,
+      );
+      expect(
+        (await resourceNotification).method,
+        Method.notificationsResourcesUpdated,
+      );
+
+      toolsSubscription.cancel('done');
+      resourcesSubscription.cancel('done');
+      await expectLater(toolsSubscription.done, completes);
+      await expectLater(resourcesSubscription.done, completes);
+      await _pump();
+
+      final cancellations =
+          transport.sentMessages.whereType<JsonRpcCancelledNotification>();
+      expect(
+        cancellations
+            .map((notification) => notification.cancelParams.requestId),
+        containsAll([toolsSubscription.id, resourcesSubscription.id]),
+      );
+    });
+
+    test('client subscription rejects notifications before acknowledgment',
+        () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+        ),
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+
+      final subscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+      );
+      subscription.notifications.listen(null, onError: (_) {});
+      await _pump();
+
+      final acknowledgedExpectation = expectLater(
+        subscription.acknowledged,
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.message,
+            'message',
+            contains(Method.notificationsSubscriptionsAcknowledged),
+          ),
+        ),
+      );
+      final doneExpectation = expectLater(
+        subscription.done,
+        throwsA(isA<McpError>()),
+      );
+
+      transport.onmessage?.call(
+        JsonRpcToolListChangedNotification(
+          meta: {McpMetaKey.subscriptionId: subscription.id},
+        ),
+      );
+
+      await acknowledgedExpectation;
+      await doneExpectation;
+      await _pump();
+
+      final cancellation = transport.sentMessages
+          .whereType<JsonRpcCancelledNotification>()
+          .single;
+      expect(cancellation.cancelParams.requestId, subscription.id);
+    });
+
+    test('client subscription fails when the connection closes', () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+        ),
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+
+      final subscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+      );
+      subscription.notifications.listen(null, onError: (_) {});
+      await _pump();
+
+      final acknowledgedExpectation = expectLater(
+        subscription.acknowledged,
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.code,
+            'code',
+            ErrorCode.connectionClosed.value,
+          ),
+        ),
+      );
+      final doneExpectation = expectLater(
+        subscription.done,
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.message,
+            'message',
+            'Connection closed',
+          ),
+        ),
+      );
+
+      await transport.close();
+
+      await acknowledgedExpectation;
+      await doneExpectation;
+    });
+
+    test('client subscription rejects acknowledgments outside requested filter',
+        () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+          prompts: ServerCapabilitiesPrompts(listChanged: true),
+        ),
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+
+      final subscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+      );
+      subscription.notifications.listen(null, onError: (_) {});
+      await _pump();
+
+      final acknowledgedExpectation = expectLater(
+        subscription.acknowledged,
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.message,
+            'message',
+            contains('not requested'),
+          ),
+        ),
+      );
+      final doneExpectation = expectLater(
+        subscription.done,
+        throwsA(isA<McpError>()),
+      );
+
+      transport.onmessage?.call(
+        JsonRpcNotification(
+          method: Method.notificationsSubscriptionsAcknowledged,
+          params: const {
+            'notifications': {'promptsListChanged': true},
+          },
+          meta: {McpMetaKey.subscriptionId: subscription.id},
+        ),
+      );
+
+      await acknowledgedExpectation;
+      await doneExpectation;
+      await _pump();
+
+      final cancellation = transport.sentMessages
+          .whereType<JsonRpcCancelledNotification>()
+          .single;
+      expect(cancellation.cancelParams.requestId, subscription.id);
+    });
+
+    test('client subscription rejects unacknowledged notification types',
+        () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+          prompts: ServerCapabilitiesPrompts(listChanged: true),
+        ),
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+
+      final subscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+      );
+      subscription.notifications.listen(null, onError: (_) {});
+      await _pump();
+
+      transport.onmessage?.call(
+        JsonRpcSubscriptionsAcknowledgedNotification(
+          acknowledgedParams: const SubscriptionsAcknowledgedNotification(
+            notifications: SubscriptionFilter(toolsListChanged: true),
+          ),
+          meta: {McpMetaKey.subscriptionId: subscription.id},
+        ),
+      );
+      await subscription.acknowledged;
+
+      final doneExpectation = expectLater(
+        subscription.done,
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.message,
+            'message',
+            contains(Method.notificationsPromptsListChanged),
+          ),
+        ),
+      );
+
+      transport.onmessage?.call(
+        JsonRpcPromptListChangedNotification(
+          meta: {McpMetaKey.subscriptionId: subscription.id},
+        ),
+      );
+
+      await doneExpectation;
+      await _pump();
+
+      final cancellation = transport.sentMessages
+          .whereType<JsonRpcCancelledNotification>()
+          .single;
+      expect(cancellation.cancelParams.requestId, subscription.id);
+    });
+
+    test('client subscription cancel before ack completes done', () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+        ),
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+
+      final subscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+      );
+      await _pump();
+
+      final acknowledgedExpectation = expectLater(
+        subscription.acknowledged,
+        throwsA(
+          isA<AbortError>().having(
+            (error) => error.reason,
+            'reason',
+            'user cancelled',
+          ),
+        ),
+      );
+
+      subscription.cancel('user cancelled');
+
+      await acknowledgedExpectation;
+      await expectLater(subscription.done, completes);
+      await _pump();
+
+      final cancellation = transport.sentMessages
+          .whereType<JsonRpcCancelledNotification>()
+          .single;
+      expect(cancellation.cancelParams.requestId, subscription.id);
+    });
+
+    test('client subscription rejects completion before acknowledgment',
+        () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: const ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+        ),
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+
+      final subscription = client.listenSubscriptions(
+        const SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(toolsListChanged: true),
+        ),
+      );
+      subscription.notifications.listen(null, onError: (_) {});
+      await _pump();
+
+      final acknowledgedExpectation = expectLater(
+        subscription.acknowledged,
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.message,
+            'message',
+            contains('completed before'),
+          ),
+        ),
+      );
+      final doneExpectation = expectLater(
+        subscription.done,
+        throwsA(isA<McpError>()),
+      );
+
+      transport.onmessage?.call(
+        JsonRpcResponse(
+          id: subscription.id,
+          result: const EmptyResult().toJson(),
+        ),
+      );
+
+      await acknowledgedExpectation;
+      await doneExpectation;
+    });
+
+    test('client rejects unrecognized stateless resultType values', () async {
+      final transport = DiscoveringClientTransport(
+        toolsListResult: const {
+          'resultType': 'future_extension',
+          'tools': [],
+        },
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+
+      await client.connect(transport);
+
+      await expectLater(
+        client.listTools(),
+        throwsA(
+          isA<McpError>()
+              .having(
+                (error) => error.code,
+                'code',
+                ErrorCode.internalError.value,
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                contains('Failed to parse result for ${Method.toolsList}'),
+              )
+              .having(
+                (error) => error.data.toString(),
+                'data',
+                contains('Unrecognized MCP resultType "future_extension"'),
+              ),
+        ),
+      );
+    });
+
+    test('client rejects non-string stateless resultType values', () async {
+      final transport = DiscoveringClientTransport(
+        toolsListResult: const {
+          'resultType': 42,
+          'tools': [],
+        },
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+
+      await client.connect(transport);
+
+      await expectLater(
+        client.listTools(),
+        throwsA(
+          isA<McpError>()
+              .having(
+                (error) => error.code,
+                'code',
+                ErrorCode.internalError.value,
+              )
+              .having(
+                (error) => error.data.toString(),
+                'data',
+                contains('MCP resultType must be a string'),
+              ),
+        ),
+      );
+    });
+
+    test('client accepts advertised task extension resultType values',
+        () async {
+      final transport = DiscoveringClientTransport(
+        capabilities: ServerCapabilities(
+          tools: const ServerCapabilitiesTools(),
+          extensions: withMcpTasksExtension(null),
+        ),
+        toolsListResult: const {
+          'resultType': resultTypeTask,
+          'tools': [],
+        },
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+
+      await client.connect(transport);
+
+      final result = await client.listTools();
+      expect(result.tools, isEmpty);
+    });
+
+    test('stable client sessions do not validate future resultType values',
+        () async {
+      final transport = LegacyFallbackTransport(
+        toolsListResult: const {
+          'resultType': 'future_extension',
+          'tools': [],
+        },
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+
+      await client.connect(transport);
+
+      final result = await client.listTools();
+      expect(client.getProtocolVersion(), stableProtocolVersion2025_11_25);
+      expect(result.tools, isEmpty);
+    });
+
     test('client rejects discovery when no compatible version is offered',
         () async {
       final transport = DiscoveringClientTransport(
@@ -1126,6 +2413,109 @@ void main() {
         ),
       );
     });
+
+    test(
+        'client retries discovery with advertised compatible stateless version',
+        () async {
+      final transport = DiscoveringClientTransport(
+        unsupportedDiscoverProtocolVersions: const ['1900-01-01'],
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(
+          protocolVersion: '1900-01-01',
+          useServerDiscover: true,
+        ),
+      );
+
+      await client.connect(transport);
+
+      final discoverRequests = transport.sentMessages
+          .whereType<JsonRpcRequest>()
+          .where((message) => message.method == Method.serverDiscover)
+          .toList();
+      expect(discoverRequests, hasLength(2));
+      expect(
+        discoverRequests.map(
+          (request) => request.meta?[McpMetaKey.protocolVersion],
+        ),
+        ['1900-01-01', draftProtocolVersion2026_07_28],
+      );
+      expect(client.getProtocolVersion(), draftProtocolVersion2026_07_28);
+      expect(transport.protocolVersion, draftProtocolVersion2026_07_28);
+      expect(
+        transport.sentMessages.whereType<JsonRpcRequest>().map(
+              (message) => message.method,
+            ),
+        isNot(contains(Method.initialize)),
+      );
+    });
+
+    for (final scenario in [
+      (
+        name: 'malformed error data',
+        requested: '1900-01-01',
+        discoverVersions: const [draftProtocolVersion2026_07_28],
+        data: 'not-an-object',
+      ),
+      (
+        name: 'missing supported versions',
+        requested: '1900-01-01',
+        discoverVersions: const [draftProtocolVersion2026_07_28],
+        data: const {'requested': '1900-01-01'},
+      ),
+      (
+        name: 'no compatible stateless version',
+        requested: '1900-01-01',
+        discoverVersions: const ['1900-01-01'],
+        data: null,
+      ),
+      (
+        name: 'advertised version matches rejected request',
+        requested: draftProtocolVersion2026_07_28,
+        discoverVersions: const [draftProtocolVersion2026_07_28],
+        data: const {
+          'supported': [draftProtocolVersion2026_07_28],
+          'requested': draftProtocolVersion2026_07_28,
+        },
+      ),
+    ]) {
+      test(
+        'client does not fall back to initialize after unsupported discovery '
+        '${scenario.name}',
+        () async {
+          final transport = DiscoveringClientTransport(
+            discoverVersions: scenario.discoverVersions,
+            unsupportedDiscoverProtocolVersions: [scenario.requested],
+            unsupportedDiscoverData: scenario.data,
+          );
+          final client = McpClient(
+            const Implementation(name: 'client', version: '1.0.0'),
+            options: McpClientOptions(
+              protocolVersion: scenario.requested,
+              useServerDiscover: true,
+            ),
+          );
+
+          await expectLater(
+            client.connect(transport),
+            throwsA(
+              isA<McpError>().having(
+                (error) => error.code,
+                'code',
+                ErrorCode.unsupportedProtocolVersion.value,
+              ),
+            ),
+          );
+          expect(
+            transport.sentMessages.whereType<JsonRpcRequest>().map(
+                  (message) => message.method,
+                ),
+            isNot(contains(Method.initialize)),
+          );
+        },
+      );
+    }
 
     test('client falls back to initialize when discovery is unavailable',
         () async {

--- a/test/server/mcp_server_test.dart
+++ b/test/server/mcp_server_test.dart
@@ -6,8 +6,10 @@ import 'package:mcp_dart/src/types.dart';
 import 'package:test/test.dart';
 
 /// Mock transport for McpServer tests
-class McpServerTestTransport implements Transport {
+class McpServerTestTransport
+    implements Transport, ToolParameterHeaderAwareTransport {
   final List<JsonRpcMessage> sentMessages = [];
+  final List<ToolParameterHeaderMappings> toolParameterHeaderMappings = [];
   bool _closed = false;
 
   @override
@@ -39,6 +41,13 @@ class McpServerTestTransport implements Transport {
   }
 
   @override
+  void setToolParameterHeaderMappings(
+    ToolParameterHeaderMappings mappings,
+  ) {
+    toolParameterHeaderMappings.add(mappings);
+  }
+
+  @override
   Future<void> start() async {
     if (_closed) throw StateError('Cannot start closed transport');
     onmessage?.call(
@@ -55,6 +64,23 @@ class McpServerTestTransport implements Transport {
     onmessage?.call(const JsonRpcInitializedNotification());
     await Future<void>.delayed(Duration.zero);
   }
+}
+
+Map<String, dynamic> _statelessMeta() => buildProtocolRequestMeta(
+      protocolVersion: draftProtocolVersion2026_07_28,
+      clientInfo: const Implementation(name: 'test-client', version: '1.0.0'),
+      clientCapabilities: const ClientCapabilities(),
+    );
+
+bool _containsMcpHeader(Object? value) {
+  if (value is Map) {
+    return value.containsKey('x-mcp-header') ||
+        value.values.any(_containsMcpHeader);
+  }
+  if (value is Iterable) {
+    return value.any(_containsMcpHeader);
+  }
+  return false;
 }
 
 void main() {
@@ -103,6 +129,270 @@ void main() {
       final tools = response.result['tools'] as List;
       expect(tools.length, equals(1));
       expect(tools.first['name'], equals('test-tool'));
+    });
+
+    test('connect syncs tool parameter header mappings to transports',
+        () async {
+      server.registerTool(
+        'header-tool',
+        inputSchema: const ToolInputSchema(
+          properties: {
+            'dryRun': JsonBoolean(mcpHeader: 'Dry-Run'),
+            'region': JsonString(mcpHeader: 'Region'),
+            'auth': JsonObject(
+              properties: {
+                'tenant': JsonString(mcpHeader: 'Tenant'),
+              },
+            ),
+          },
+        ),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+
+      await server.connect(transport);
+
+      expect(transport.toolParameterHeaderMappings, isNotEmpty);
+      expect(
+        transport.toolParameterHeaderMappings.last,
+        equals(
+          const {
+            'header-tool': {
+              'dryRun': 'Dry-Run',
+              'region': 'Region',
+              '/auth/tenant': 'Tenant',
+            },
+          },
+        ),
+      );
+
+      transport.receiveMessage(
+        JsonRpcListToolsRequest(id: 1, meta: _statelessMeta()),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final response = transport.sentMessages.last as JsonRpcResponse;
+      final tools = response.result['tools'] as List;
+      final tool = tools.single as Map;
+      final inputSchema = tool['inputSchema'] as Map;
+      final properties = inputSchema['properties'] as Map;
+      final authProperties = (properties['auth'] as Map)['properties'] as Map;
+      expect((properties['region'] as Map)['x-mcp-header'], 'Region');
+      expect((authProperties['tenant'] as Map)['x-mcp-header'], 'Tenant');
+    });
+
+    test('tool updates refresh parameter header mappings on transports',
+        () async {
+      final registeredTool = server.registerTool(
+        'header-tool',
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+      await server.connect(transport);
+      transport.toolParameterHeaderMappings.clear();
+
+      registeredTool.update(
+        inputSchema: const ToolInputSchema(
+          properties: {
+            'dryRun': JsonBoolean(mcpHeader: 'Dry-Run'),
+          },
+        ),
+      );
+
+      expect(transport.toolParameterHeaderMappings, isNotEmpty);
+      expect(
+        transport.toolParameterHeaderMappings.last,
+        equals(
+          const {
+            'header-tool': {'dryRun': 'Dry-Run'},
+          },
+        ),
+      );
+
+      registeredTool.disable();
+
+      expect(transport.toolParameterHeaderMappings.last, isEmpty);
+    });
+
+    test('invalid tool parameter header metadata is not synced', () async {
+      server.registerTool(
+        'non-string-header-tool',
+        inputSchema: ToolInputSchema(
+          properties: {
+            'value': JsonSchema.fromJson(
+              {'type': 'string', 'x-mcp-header': 1},
+            ),
+          },
+        ),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+      server.registerTool(
+        'invalid-header-tool',
+        inputSchema: const ToolInputSchema(
+          properties: {
+            'value': JsonString(mcpHeader: 'Bad:Header'),
+          },
+        ),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+      server.registerTool(
+        'separator-header-tool',
+        inputSchema: const ToolInputSchema(
+          properties: {
+            'value': JsonString(mcpHeader: 'Bad/Header'),
+          },
+        ),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+      server.registerTool(
+        'number-header-tool',
+        inputSchema: const ToolInputSchema(
+          properties: {
+            'value': JsonNumber(mcpHeader: 'Value'),
+          },
+        ),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+      server.registerTool(
+        'duplicate-header-tool',
+        inputSchema: const ToolInputSchema(
+          properties: {
+            'primary': JsonString(mcpHeader: 'Region'),
+            'secondary': JsonString(mcpHeader: 'region'),
+          },
+        ),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+      server.registerTool(
+        'non-primitive-header-tool',
+        inputSchema: ToolInputSchema(
+          properties: {
+            'value': JsonSchema.fromJson(
+              {'type': 'object', 'x-mcp-header': 'Value'},
+            ),
+          },
+        ),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+
+      await server.connect(transport);
+
+      expect(transport.toolParameterHeaderMappings, isNotEmpty);
+      expect(transport.toolParameterHeaderMappings.last, isEmpty);
+
+      transport.receiveMessage(
+        JsonRpcListToolsRequest(id: 1, meta: _statelessMeta()),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final response = transport.sentMessages.last as JsonRpcResponse;
+      final tools = response.result['tools'] as List;
+      expect(tools, hasLength(6));
+      for (final tool in tools.cast<Map>()) {
+        expect(_containsMcpHeader(tool['inputSchema']), isFalse);
+      }
+    });
+
+    test('invalid stateless header metadata is stripped from nested schemas',
+        () async {
+      server.registerTool(
+        'nested-header-tool',
+        inputSchema: ToolInputSchema.fromJson({
+          'type': 'object',
+          'properties': {
+            'invalidArray': {
+              'type': 'array',
+              'x-mcp-header': 'Invalid',
+              'items': {
+                'type': 'string',
+                'x-mcp-header': 'Item',
+              },
+            },
+            'objectMap': {
+              'type': 'object',
+              'additionalProperties': {
+                'type': 'string',
+                'x-mcp-header': 'Additional',
+              },
+            },
+            'combined': {
+              'allOf': [
+                true,
+                {
+                  'type': 'string',
+                  'x-mcp-header': 'All',
+                },
+              ],
+              'anyOf': [
+                false,
+                {
+                  'type': 'integer',
+                  'x-mcp-header': 'Any',
+                },
+              ],
+              'oneOf': [
+                {
+                  'type': 'boolean',
+                  'x-mcp-header': 'One',
+                },
+              ],
+              'not': {
+                'type': 'string',
+                'x-mcp-header': 'Not',
+              },
+            },
+            'literalData': {
+              'default': {
+                'x-mcp-header': 'not schema metadata',
+              },
+            },
+            'preservedAny': {
+              'properties': {
+                'flag': true,
+              },
+            },
+          },
+        }),
+        callback: (args, extra) async => const CallToolResult(content: []),
+      );
+
+      await server.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcListToolsRequest(id: 1, meta: _statelessMeta()),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final response = transport.sentMessages.last as JsonRpcResponse;
+      final tools = response.result['tools'] as List;
+      final tool = tools.single as Map;
+      final inputSchema = tool['inputSchema'] as Map;
+      final properties = inputSchema['properties'] as Map;
+      final invalidArray = properties['invalidArray'] as Map;
+      final objectMap = properties['objectMap'] as Map;
+      final combined = properties['combined'] as Map;
+      final allOf = combined['allOf'] as List;
+      final anyOf = combined['anyOf'] as List;
+      final oneOf = combined['oneOf'] as List;
+      final literalData = properties['literalData'] as Map;
+      final preservedAny = properties['preservedAny'] as Map;
+
+      expect(invalidArray.containsKey('x-mcp-header'), isFalse);
+      expect(
+        (invalidArray['items'] as Map).containsKey('x-mcp-header'),
+        isFalse,
+      );
+      expect(
+        (objectMap['additionalProperties'] as Map).containsKey('x-mcp-header'),
+        isFalse,
+      );
+      expect((allOf[1] as Map).containsKey('x-mcp-header'), isFalse);
+      expect((anyOf[1] as Map).containsKey('x-mcp-header'), isFalse);
+      expect((oneOf.single as Map).containsKey('x-mcp-header'), isFalse);
+      expect((combined['not'] as Map).containsKey('x-mcp-header'), isFalse);
+      expect(
+        (literalData['default'] as Map)['x-mcp-header'],
+        'not schema metadata',
+      );
+      expect(((preservedAny['properties'] as Map)['flag'] as bool), isTrue);
     });
 
     test('registerTool can be updated', () async {

--- a/test/server/streamable_https_test.dart
+++ b/test/server/streamable_https_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:mcp_dart/src/server/server.dart';
 import 'package:mcp_dart/src/server/streamable_https.dart';
 import 'package:mcp_dart/src/shared/uuid.dart';
 import 'package:mcp_dart/src/types.dart';
@@ -316,6 +317,105 @@ void main() {
 
     // Helper to manually trigger initialization of the transport
 
+    test('JSON-RPC preflight errors advertise JSON content type', () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => 'preflight-session-id',
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      Future<HttpClientResponse> send(
+        String method, {
+        Map<String, String> headers = const {},
+        Object? body,
+        ContentType? contentType,
+      }) async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.openUrl(
+          method,
+          Uri.parse('$serverUrlBase/mcp'),
+        );
+        request.headers.contentType = contentType;
+        headers.forEach(request.headers.set);
+        if (body != null) {
+          request.write(jsonEncode(body));
+        }
+        return request.close();
+      }
+
+      final getWithoutSseAccept = await send(
+        'GET',
+        headers: {HttpHeaders.acceptHeader: 'application/json'},
+      );
+      expect(getWithoutSseAccept.statusCode, HttpStatus.notAcceptable);
+      expect(
+        getWithoutSseAccept.headers.contentType?.mimeType,
+        'application/json',
+      );
+      expect(
+        await utf8.decodeStream(getWithoutSseAccept),
+        contains('Client must accept text/event-stream'),
+      );
+
+      final unsupportedMethod = await send('PUT');
+      expect(unsupportedMethod.statusCode, HttpStatus.methodNotAllowed);
+      expect(
+        unsupportedMethod.headers.contentType?.mimeType,
+        'application/json',
+      );
+      expect(
+        unsupportedMethod.headers.value(HttpHeaders.allowHeader),
+        'GET, POST, DELETE',
+      );
+      expect(
+        await utf8.decodeStream(unsupportedMethod),
+        contains('Method not allowed.'),
+      );
+
+      final postWithoutSseAccept = await send(
+        'POST',
+        headers: {HttpHeaders.acceptHeader: 'application/json'},
+        contentType: ContentType.json,
+        body: const JsonRpcRequest(id: 1, method: 'ping').toJson(),
+      );
+      expect(postWithoutSseAccept.statusCode, HttpStatus.notAcceptable);
+      expect(
+        postWithoutSseAccept.headers.contentType?.mimeType,
+        'application/json',
+      );
+      expect(
+        await utf8.decodeStream(postWithoutSseAccept),
+        contains(
+          'Client must accept both application/json and text/event-stream',
+        ),
+      );
+
+      final postWithWrongContentType = await send(
+        'POST',
+        headers: {
+          HttpHeaders.acceptHeader: 'application/json, text/event-stream',
+        },
+        contentType: ContentType.text,
+        body: const JsonRpcRequest(id: 2, method: 'ping').toJson(),
+      );
+      expect(
+        postWithWrongContentType.statusCode,
+        HttpStatus.unsupportedMediaType,
+      );
+      expect(
+        postWithWrongContentType.headers.contentType?.mimeType,
+        'application/json',
+      );
+      expect(
+        await utf8.decodeStream(postWithWrongContentType),
+        contains('Content-Type must be application/json'),
+      );
+    });
+
     test('initialization with stateful session management', () async {
       // Create a new transport with session management
       final transport = StreamableHTTPServerTransport(
@@ -495,6 +595,7 @@ void main() {
           ),
         );
         expect(initResponse.statusCode, HttpStatus.ok);
+        expect(initResponse.headers.value('X-Accel-Buffering'), 'no');
         final initMessages = _decodeSseJsonMessages(
           await utf8.decodeStream(initResponse),
         );
@@ -511,6 +612,7 @@ void main() {
           response.headers.contentType?.mimeType,
           'text/event-stream',
         );
+        expect(response.headers.value('X-Accel-Buffering'), 'no');
 
         final messages =
             _decodeSseJsonMessages(await utf8.decodeStream(response));
@@ -704,6 +806,182 @@ void main() {
 
       expect(response.statusCode, HttpStatus.notFound);
       expect(body, contains('Session not found'));
+    });
+
+    test('stateful session JSON-RPC errors advertise JSON content type',
+        () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => 'json-error-session-id',
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      transport.onmessage = (message) {
+        if (message is JsonRpcRequest && message.method == 'initialize') {
+          unawaited(
+            transport.send(
+              JsonRpcResponse(
+                id: message.id,
+                result: const {
+                  'protocolVersion': latestProtocolVersion,
+                  'capabilities': {},
+                  'serverInfo': {
+                    'name': 'JsonErrorServer',
+                    'version': '1.0.0',
+                  },
+                },
+              ),
+            ),
+          );
+        }
+      };
+
+      Future<HttpClientResponse> postJsonRpc(
+        JsonRpcMessage message, {
+        String? sessionId,
+      }) async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers
+          ..contentType = ContentType.json
+          ..set(
+            HttpHeaders.acceptHeader,
+            'application/json, text/event-stream',
+          );
+        if (sessionId != null) {
+          request.headers.set('mcp-session-id', sessionId);
+        }
+        request.write(jsonEncode(message.toJson()));
+        return request.close();
+      }
+
+      final initialize = await postJsonRpc(
+        JsonRpcRequest(
+          id: 1,
+          method: 'initialize',
+          params: const InitializeRequestParams(
+            protocolVersion: latestProtocolVersion,
+            capabilities: ClientCapabilities(),
+            clientInfo: Implementation(name: 'Client', version: '1.0'),
+          ).toJson(),
+        ),
+      );
+      expect(initialize.statusCode, HttpStatus.ok);
+      expect(
+        initialize.headers.value('mcp-session-id'),
+        'json-error-session-id',
+      );
+      await initialize.drain<void>();
+
+      final missingSession = await postJsonRpc(
+        const JsonRpcRequest(id: 2, method: 'ping'),
+      );
+      expect(missingSession.statusCode, HttpStatus.badRequest);
+      expect(missingSession.headers.contentType?.mimeType, 'application/json');
+      expect(
+        await utf8.decodeStream(missingSession),
+        contains('Mcp-Session-Id header is required'),
+      );
+
+      final invalidSession = await postJsonRpc(
+        const JsonRpcRequest(id: 3, method: 'ping'),
+        sessionId: 'wrong-session-id',
+      );
+      expect(invalidSession.statusCode, HttpStatus.notFound);
+      expect(invalidSession.headers.contentType?.mimeType, 'application/json');
+      expect(
+        await utf8.decodeStream(invalidSession),
+        contains('Session not found'),
+      );
+    });
+
+    test('initialization JSON-RPC errors advertise JSON content type',
+        () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => 'duplicate-init-session-id',
+          rejectBatchJsonRpcPayloads: false,
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      transport.onmessage = (message) {
+        if (message is JsonRpcRequest && message.method == 'initialize') {
+          unawaited(
+            transport.send(
+              JsonRpcResponse(
+                id: message.id,
+                result: const {
+                  'protocolVersion': latestProtocolVersion,
+                  'capabilities': {},
+                  'serverInfo': {
+                    'name': 'DuplicateInitServer',
+                    'version': '1.0.0',
+                  },
+                },
+              ),
+            ),
+          );
+        }
+      };
+
+      Future<HttpClientResponse> postJson(Object body) async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers
+          ..contentType = ContentType.json
+          ..set(
+            HttpHeaders.acceptHeader,
+            'application/json, text/event-stream',
+          );
+        request.write(jsonEncode(body));
+        return request.close();
+      }
+
+      Map<String, dynamic> initializeBody(int id) {
+        return JsonRpcRequest(
+          id: id,
+          method: 'initialize',
+          params: const InitializeRequestParams(
+            protocolVersion: latestProtocolVersion,
+            capabilities: ClientCapabilities(),
+            clientInfo: Implementation(name: 'Client', version: '1.0'),
+          ).toJson(),
+        ).toJson();
+      }
+
+      final duplicateBatch = await postJson([
+        initializeBody(1),
+        initializeBody(2),
+      ]);
+      expect(duplicateBatch.statusCode, HttpStatus.badRequest);
+      expect(duplicateBatch.headers.contentType?.mimeType, 'application/json');
+      expect(
+        await utf8.decodeStream(duplicateBatch),
+        contains('Only one initialization request is allowed'),
+      );
+
+      final initialize = await postJson(initializeBody(3));
+      expect(initialize.statusCode, HttpStatus.ok);
+      await initialize.drain<void>();
+
+      final alreadyInitialized = await postJson(initializeBody(4));
+      expect(alreadyInitialized.statusCode, HttpStatus.badRequest);
+      expect(
+        alreadyInitialized.headers.contentType?.mimeType,
+        'application/json',
+      );
+      expect(
+        await utf8.decodeStream(alreadyInitialized),
+        contains('Server already initialized'),
+      );
     });
 
     test('rejects generated session IDs outside visible ASCII', () async {
@@ -1262,6 +1540,7 @@ void main() {
       final first = await firstFuture.timeout(const Duration(seconds: 3));
       expect(first.statusCode, HttpStatus.ok);
       expect(first.headers.contentType?.mimeType, 'text/event-stream');
+      expect(first.headers.value('X-Accel-Buffering'), 'no');
       final firstLines = StreamIterator(
         first.transform(utf8.decoder).transform(const LineSplitter()),
       );
@@ -1280,6 +1559,7 @@ void main() {
       final second = await secondFuture.timeout(const Duration(seconds: 3));
       expect(second.statusCode, HttpStatus.ok);
       expect(second.headers.contentType?.mimeType, 'text/event-stream');
+      expect(second.headers.value('X-Accel-Buffering'), 'no');
       final secondLines = StreamIterator(
         second.transform(utf8.decoder).transform(const LineSplitter()),
       );
@@ -1390,6 +1670,7 @@ void main() {
 
       final stream = await streamFuture.timeout(const Duration(seconds: 3));
       expect(stream.statusCode, HttpStatus.ok);
+      expect(stream.headers.value('X-Accel-Buffering'), 'no');
       final lines = StreamIterator(
         stream.transform(utf8.decoder).transform(const LineSplitter()),
       );
@@ -1417,6 +1698,7 @@ void main() {
       final otherStream =
           await otherStreamFuture.timeout(const Duration(seconds: 3));
       expect(otherStream.statusCode, HttpStatus.ok);
+      expect(otherStream.headers.value('X-Accel-Buffering'), 'no');
       final otherLines = StreamIterator(
         otherStream.transform(utf8.decoder).transform(const LineSplitter()),
       );
@@ -1430,6 +1712,7 @@ void main() {
 
       final replay = await openGetSse(sessionId, lastEventId: first.id);
       expect(replay.statusCode, HttpStatus.ok);
+      expect(replay.headers.value('X-Accel-Buffering'), 'no');
       final replayLines = StreamIterator(
         replay.transform(utf8.decoder).transform(const LineSplitter()),
       );
@@ -1821,6 +2104,7 @@ void main() {
       });
 
       expect(response.statusCode, HttpStatus.badRequest);
+      expect(response.headers.contentType?.mimeType, 'application/json');
       final body =
           jsonDecode(await utf8.decodeStream(response)) as Map<String, dynamic>;
       expect(body['id'], 1);
@@ -1931,6 +2215,53 @@ void main() {
       expect(body['error']['message'], contains('Mcp-Name header is required'));
     });
 
+    test('2026 stateless HTTP ignores session header', () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => "unused-session-id",
+          enableJsonResponse: true,
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      transport.onmessage = (message) {
+        if (message is JsonRpcListToolsRequest) {
+          unawaited(
+            transport.send(
+              JsonRpcResponse(
+                id: message.id,
+                result: const ListToolsResult(tools: []).toJson(),
+              ),
+            ),
+          );
+        }
+      };
+
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+      final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+      request.headers
+        ..contentType = ContentType.json
+        ..set(HttpHeaders.acceptHeader, 'application/json, text/event-stream')
+        ..set('MCP-Protocol-Version', draftProtocolVersion2026_07_28)
+        ..set('Mcp-Method', Method.toolsList)
+        ..set('Mcp-Session-Id', 'legacy-session');
+      request.write(
+        jsonEncode(JsonRpcListToolsRequest(id: 6, meta: _statelessMeta())),
+      );
+
+      final response = await request.close();
+
+      expect(response.statusCode, HttpStatus.ok);
+      expect(response.headers.value('mcp-session-id'), isNull);
+      final body =
+          jsonDecode(await utf8.decodeStream(response)) as Map<String, dynamic>;
+      expect(body['id'], 6);
+      expect(body['result']['tools'], isEmpty);
+    });
+
     test('2026 stateless HTTP accepts matching standard and parameter headers',
         () async {
       final transport = StreamableHTTPServerTransport(
@@ -1965,14 +2296,18 @@ void main() {
         ..set('MCP-Protocol-Version', draftProtocolVersion2026_07_28)
         ..set('Mcp-Method', Method.toolsCall)
         ..set('Mcp-Name', 'execute')
-        ..set('Mcp-Param-region', 'us-east1');
+        ..set('Mcp-Param-region', 'us-east1')
+        ..set('Mcp-Param-dryRun', 'false');
       request.write(
         jsonEncode(
           JsonRpcCallToolRequest(
             id: 3,
             params: const {
               'name': 'execute',
-              'arguments': {'region': 'us-east1'},
+              'arguments': {
+                'region': 'us-east1',
+                'dryRun': false,
+              },
             },
             meta: _statelessMeta(),
           ),
@@ -1986,6 +2321,366 @@ void main() {
       final body =
           jsonDecode(await utf8.decodeStream(response)) as Map<String, dynamic>;
       expect(body['id'], 3);
+      expect(body['result']['content'], isEmpty);
+    });
+
+    test('2026 stateless HTTP rejects server requests on response streams',
+        () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => null,
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      final sendError = Completer<Object>();
+      transport.onmessage = (message) {
+        if (message is JsonRpcListToolsRequest) {
+          final requestSend = transport.send(
+            const JsonRpcListRootsRequest(id: 99),
+            relatedRequestId: message.id,
+          );
+          unawaited(
+            requestSend.then(
+              (_) {},
+              onError: (Object error) {
+                if (!sendError.isCompleted) {
+                  sendError.complete(error);
+                }
+              },
+            ),
+          );
+          unawaited(
+            transport.send(
+              JsonRpcResponse(
+                id: message.id,
+                result: const ListToolsResult(tools: []).toJson(),
+              ),
+            ),
+          );
+        }
+      };
+
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+      final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+      request.headers
+        ..contentType = ContentType.json
+        ..set(HttpHeaders.acceptHeader, 'application/json, text/event-stream')
+        ..set('MCP-Protocol-Version', draftProtocolVersion2026_07_28)
+        ..set('Mcp-Method', Method.toolsList);
+      request.write(
+        jsonEncode(
+          JsonRpcListToolsRequest(id: 10, meta: _statelessMeta()).toJson(),
+        ),
+      );
+
+      final response = await request.close();
+      final messages =
+          _decodeSseJsonMessages(await utf8.decodeStream(response));
+      final error = await sendError.future.timeout(
+        const Duration(seconds: 1),
+      );
+
+      expect(response.statusCode, HttpStatus.ok);
+      expect(response.headers.value('X-Accel-Buffering'), 'no');
+      expect(messages, hasLength(1));
+      expect(messages.single['id'], 10);
+      expect(messages.single['result']['tools'], isEmpty);
+      expect(error, isA<StateError>());
+      expect(
+        error.toString(),
+        contains('stateless MCP response streams'),
+      );
+    });
+
+    test('2026 stateless HTTP cancels pending request when SSE response closes',
+        () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => null,
+        ),
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      final receivedRequest = Completer<JsonRpcListToolsRequest>();
+      final cancellation = Completer<JsonRpcCancelledNotification>();
+      transport.onmessage = (message) {
+        if (message is JsonRpcListToolsRequest) {
+          if (!receivedRequest.isCompleted) {
+            receivedRequest.complete(message);
+          }
+          return;
+        }
+
+        if (message is JsonRpcCancelledNotification) {
+          if (!cancellation.isCompleted) {
+            cancellation.complete(message);
+          }
+        }
+      };
+
+      final body = jsonEncode(
+        JsonRpcListToolsRequest(id: 11, meta: _statelessMeta()).toJson(),
+      );
+      final bodyBytes = utf8.encode(body);
+      final socket =
+          await Socket.connect(InternetAddress.loopbackIPv4, serverPort);
+      addTearDown(socket.destroy);
+      final responseBytes = <int>[];
+      final responseStarted = Completer<String>();
+      final socketSubscription = socket.listen((chunk) {
+        responseBytes.addAll(chunk);
+        final responseText = latin1.decode(responseBytes, allowInvalid: true);
+        if (!responseStarted.isCompleted && responseText.contains('\r\n\r\n')) {
+          responseStarted.complete(responseText);
+        }
+      });
+
+      socket.add(
+        utf8.encode(
+          'POST /mcp HTTP/1.1\r\n'
+          'Host: localhost:$serverPort\r\n'
+          'Content-Type: application/json\r\n'
+          'Accept: application/json, text/event-stream\r\n'
+          'MCP-Protocol-Version: $draftProtocolVersion2026_07_28\r\n'
+          'Mcp-Method: ${Method.toolsList}\r\n'
+          'Content-Length: ${bodyBytes.length}\r\n'
+          '\r\n',
+        ),
+      );
+      socket.add(bodyBytes);
+      await socket.flush();
+
+      final responseText = await responseStarted.future.timeout(
+        const Duration(seconds: 3),
+      );
+      expect(responseText, contains('200 OK'));
+      expect(responseText.toLowerCase(), contains('text/event-stream'));
+      expect(responseText.toLowerCase(), contains('x-accel-buffering: no'));
+      expect(
+        (await receivedRequest.future.timeout(const Duration(seconds: 3))).id,
+        11,
+      );
+
+      socket.destroy();
+      await socketSubscription.cancel();
+      final notification = await cancellation.future.timeout(
+        const Duration(seconds: 3),
+      );
+      expect(notification.cancelParams.requestId, 11);
+      expect(
+        notification.cancelParams.reason,
+        contains('SSE response stream closed'),
+      );
+    });
+
+    test('2026 stateless HTTP validates mapped tool parameter headers',
+        () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => "unused-session-id",
+          enableJsonResponse: true,
+        ),
+      );
+      transport.setToolParameterHeaderMappings(
+        const {
+          'execute': {
+            'dryRun': 'Dry-Run',
+            'rounded': 'Rounded',
+            'ratio': 'Ratio',
+            'region': 'Region',
+            'sentinel': 'Sentinel',
+            '/location/zone': 'Zone',
+          },
+        },
+      );
+      addTearDown(transport.close);
+      await transport.start();
+      transports['/mcp'] = transport;
+
+      transport.onmessage = (message) {
+        if (message is JsonRpcCallToolRequest) {
+          unawaited(
+            transport.send(
+              JsonRpcResponse(
+                id: message.id,
+                result: const CallToolResult(content: []).toJson(),
+              ),
+            ),
+          );
+        }
+      };
+
+      Future<(int, Map<String, dynamic>)> postToolCall({
+        required int id,
+        required Map<String, Object> headers,
+        Map<String, Object?> arguments = const {
+          'dryRun': false,
+          'region': 'us-east1',
+        },
+      }) async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers
+          ..contentType = ContentType.json
+          ..set(HttpHeaders.acceptHeader, 'application/json, text/event-stream')
+          ..set('MCP-Protocol-Version', draftProtocolVersion2026_07_28)
+          ..set('Mcp-Method', Method.toolsCall)
+          ..set('Mcp-Name', 'execute');
+        headers.forEach(request.headers.set);
+        request.write(
+          jsonEncode(
+            JsonRpcCallToolRequest(
+              id: id,
+              params: {
+                'name': 'execute',
+                'arguments': arguments,
+              },
+              meta: _statelessMeta(),
+            ),
+          ),
+        );
+
+        final response = await request.close();
+        return (
+          response.statusCode,
+          jsonDecode(await utf8.decodeStream(response)) as Map<String, dynamic>,
+        );
+      }
+
+      var (statusCode, body) = await postToolCall(
+        id: 30,
+        headers: const {
+          'Mcp-Param-Region': 'us-east1',
+        },
+      );
+      expect(statusCode, HttpStatus.badRequest);
+      expect(body['id'], 30);
+      expect(body['error']['code'], ErrorCode.headerMismatch.value);
+      expect(
+        body['error']['message'],
+        contains('Mcp-Param-Dry-Run header is required'),
+      );
+
+      (statusCode, body) = await postToolCall(
+        id: 31,
+        headers: const {
+          'Mcp-Param-Dry-Run': 'true',
+          'Mcp-Param-Region': 'us-east1',
+        },
+      );
+      expect(statusCode, HttpStatus.badRequest);
+      expect(body['id'], 31);
+      expect(
+        body['error']['message'],
+        contains("body argument 'dryRun'"),
+      );
+
+      (statusCode, body) = await postToolCall(
+        id: 32,
+        arguments: const {
+          'dryRun': {'nested': true},
+          'region': 'us-east1',
+        },
+        headers: const {
+          'Mcp-Param-Dry-Run': 'false',
+          'Mcp-Param-Region': 'us-east1',
+        },
+      );
+      expect(statusCode, HttpStatus.badRequest);
+      expect(body['id'], 32);
+      expect(
+        body['error']['message'],
+        contains('no matching primitive body argument'),
+      );
+
+      (statusCode, body) = await postToolCall(
+        id: 34,
+        arguments: const {
+          'dryRun': false,
+          'ratio': 1.5,
+          'region': 'us-east1',
+        },
+        headers: const {
+          'Mcp-Param-Dry-Run': 'false',
+          'Mcp-Param-Ratio': '1.5',
+          'Mcp-Param-Region': 'us-east1',
+        },
+      );
+      expect(statusCode, HttpStatus.badRequest);
+      expect(body['id'], 34);
+      expect(
+        body['error']['message'],
+        contains('no matching primitive body argument'),
+      );
+
+      (statusCode, body) = await postToolCall(
+        id: 35,
+        arguments: const {
+          'dryRun': false,
+          'rounded': 42.0,
+          'region': 'us-east1',
+        },
+        headers: const {
+          'Mcp-Param-Dry-Run': 'false',
+          'Mcp-Param-Rounded': '42.0',
+          'Mcp-Param-Region': 'us-east1',
+        },
+      );
+      expect(statusCode, HttpStatus.ok);
+      expect(body['id'], 35);
+      expect(body['result']['content'], isEmpty);
+
+      (statusCode, body) = await postToolCall(
+        id: 36,
+        arguments: const {
+          'dryRun': false,
+          'region': 'us-east1',
+          'sentinel': '=?base64?YWJj?=',
+        },
+        headers: {
+          'Mcp-Param-Dry-Run': 'false',
+          'Mcp-Param-Region': 'us-east1',
+          'Mcp-Param-Sentinel':
+              '=?base64?${base64Encode(utf8.encode('=?base64?YWJj?='))}?=',
+        },
+      );
+      expect(statusCode, HttpStatus.ok);
+      expect(body['id'], 36);
+      expect(body['result']['content'], isEmpty);
+
+      (statusCode, body) = await postToolCall(
+        id: 37,
+        arguments: const {
+          'dryRun': false,
+          'region': 'us-east1',
+          'location': {'zone': 'us-east1-b'},
+        },
+        headers: const {
+          'Mcp-Param-Dry-Run': 'false',
+          'Mcp-Param-Region': 'us-east1',
+          'Mcp-Param-Zone': 'us-east1-b',
+        },
+      );
+      expect(statusCode, HttpStatus.ok);
+      expect(body['id'], 37);
+      expect(body['result']['content'], isEmpty);
+
+      (statusCode, body) = await postToolCall(
+        id: 33,
+        headers: const {
+          'Mcp-Param-Dry-Run': 'false',
+          'Mcp-Param-Region': 'us-east1',
+        },
+      );
+      expect(statusCode, HttpStatus.ok);
+      expect(body['id'], 33);
       expect(body['result']['content'], isEmpty);
     });
 
@@ -2065,6 +2760,85 @@ void main() {
 
       body = await postJson(
         JsonRpcCallToolRequest(
+          id: 16,
+          params: const {
+            'name': 'execute',
+            'arguments': {'region': 'us-east1'},
+          },
+          meta: _statelessMeta(),
+        ).toJson(),
+        headers: {
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+          'Mcp-Method': Method.toolsCall,
+          'Mcp-Name': 'execute',
+          'Mcp-Param-': 'us-east1',
+        },
+      );
+      expect(body['id'], 16);
+      expect(body['error']['message'], contains('header name is malformed'));
+
+      body = await postJson(
+        JsonRpcCallToolRequest(
+          id: 17,
+          params: const {
+            'name': 'execute',
+            'arguments': {'region': 'us-east1'},
+          },
+          meta: _statelessMeta(),
+        ).toJson(),
+        headers: {
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+          'Mcp-Method': Method.toolsCall,
+          'Mcp-Name': 'execute',
+          'Mcp-Param-region': '=?base64?%%%?=',
+        },
+      );
+      expect(body['id'], 17);
+      expect(body['error']['message'], contains('header value is malformed'));
+
+      body = await postJson(
+        JsonRpcCallToolRequest(
+          id: 18,
+          params: const {'name': 'execute'},
+          meta: _statelessMeta(),
+        ).toJson(),
+        headers: {
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+          'Mcp-Method': Method.toolsCall,
+          'Mcp-Name': 'execute',
+          'Mcp-Param-region': 'us-east1',
+        },
+      );
+      expect(body['id'], 18);
+      expect(
+        body['error']['message'],
+        contains('header has no matching body arguments'),
+      );
+
+      body = await postJson(
+        JsonRpcCallToolRequest(
+          id: 19,
+          params: const {
+            'name': 'execute',
+            'arguments': {'region': 'us-east1'},
+          },
+          meta: _statelessMeta(),
+        ).toJson(),
+        headers: {
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+          'Mcp-Method': Method.toolsCall,
+          'Mcp-Name': 'execute',
+          'Mcp-Param-zone': 'us-east1-b',
+        },
+      );
+      expect(body['id'], 19);
+      expect(
+        body['error']['message'],
+        contains('header has no matching body argument'),
+      );
+
+      body = await postJson(
+        JsonRpcCallToolRequest(
           id: 7,
           params: const {
             'name': 'execute',
@@ -2090,6 +2864,66 @@ void main() {
         },
       );
       expect(body['error']['message'], contains('must contain one'));
+    });
+
+    test('2026 stateless HTTP returns 404 for method not found', () async {
+      final transport = StreamableHTTPServerTransport(
+        options: StreamableHTTPServerTransportOptions(
+          sessionIdGenerator: () => "unused-session-id",
+        ),
+      );
+      final server = Server(
+        const Implementation(name: 'StatelessServer', version: '1.0.0'),
+      );
+      addTearDown(server.close);
+      await server.connect(transport);
+      transports['/mcp'] = transport;
+
+      Future<Map<String, dynamic>> postStatelessRequest(
+        JsonRpcRequest message,
+      ) async {
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final request = await client.postUrl(Uri.parse('$serverUrlBase/mcp'));
+        request.headers
+          ..contentType = ContentType.json
+          ..set(
+            HttpHeaders.acceptHeader,
+            'application/json, text/event-stream',
+          )
+          ..set('MCP-Protocol-Version', draftProtocolVersion2026_07_28)
+          ..set('Mcp-Method', message.method);
+        request.write(jsonEncode(message.toJson()));
+
+        final response = await request.close();
+        expect(response.statusCode, HttpStatus.notFound);
+        final body = jsonDecode(await utf8.decodeStream(response))
+            as Map<String, dynamic>;
+        expect(body['id'], message.id);
+        expect(body['error']['code'], ErrorCode.methodNotFound.value);
+        return body;
+      }
+
+      var body = await postStatelessRequest(
+        JsonRpcRequest(
+          id: 20,
+          method: 'experimental/unknown',
+          meta: _statelessMeta(),
+        ),
+      );
+      expect(body['error']['message'], contains('experimental/unknown'));
+
+      body = await postStatelessRequest(
+        JsonRpcRequest(
+          id: 21,
+          method: Method.ping,
+          meta: _statelessMeta(),
+        ),
+      );
+      expect(
+        body['error']['message'],
+        contains('not part of MCP stateless protocol versions'),
+      );
     });
 
     test('stateless mode allows initialization with session header', () async {
@@ -2152,7 +2986,8 @@ void main() {
       expect(transport.sessionId, isNull);
     });
 
-    test('2026 stateless GET requests return method not allowed', () async {
+    test('2026 stateless non-POST requests return method not allowed',
+        () async {
       final transport = StreamableHTTPServerTransport(
         options: StreamableHTTPServerTransportOptions(
           sessionIdGenerator: () => null,
@@ -2175,10 +3010,34 @@ void main() {
           jsonDecode(await utf8.decodeStream(response)) as Map<String, dynamic>;
 
       expect(response.statusCode, HttpStatus.methodNotAllowed);
+      expect(response.headers.contentType?.mimeType, 'application/json');
       expect(response.headers.value(HttpHeaders.allowHeader), 'POST');
       expect(body['error']['code'], ErrorCode.connectionClosed.value);
       expect(
         body['error']['message'],
+        'Method not allowed for stateless MCP requests.',
+      );
+
+      final patchRequest = await client.openUrl(
+        'PATCH',
+        Uri.parse('$serverUrlBase/mcp'),
+      );
+      patchRequest.headers.set(
+        'MCP-Protocol-Version',
+        draftProtocolVersion2026_07_28,
+      );
+
+      final patchResponse = await patchRequest.close();
+      final patchBody = jsonDecode(
+        await utf8.decodeStream(patchResponse),
+      ) as Map<String, dynamic>;
+
+      expect(patchResponse.statusCode, HttpStatus.methodNotAllowed);
+      expect(patchResponse.headers.contentType?.mimeType, 'application/json');
+      expect(patchResponse.headers.value(HttpHeaders.allowHeader), 'POST');
+      expect(patchBody['error']['code'], ErrorCode.connectionClosed.value);
+      expect(
+        patchBody['error']['message'],
         'Method not allowed for stateless MCP requests.',
       );
     });

--- a/test/server/streamable_mcp_server_test.dart
+++ b/test/server/streamable_mcp_server_test.dart
@@ -361,7 +361,8 @@ void main() {
       );
     });
 
-    test('routes 2026 stateless GET and DELETE without a session ID', () async {
+    test('routes 2026 stateless non-POST methods without a session ID',
+        () async {
       final client = HttpClient();
       addTearDown(() => client.close(force: true));
 
@@ -384,6 +385,16 @@ void main() {
       expect(deleteResponse.statusCode, HttpStatus.methodNotAllowed);
       expect(deleteResponse.headers.value(HttpHeaders.allowHeader), 'POST');
       await deleteResponse.drain<void>();
+
+      final patchRequest = await client.openUrl('PATCH', Uri.parse(baseUrl));
+      patchRequest.headers.set(
+        'MCP-Protocol-Version',
+        draftProtocolVersion2026_07_28,
+      );
+      final patchResponse = await patchRequest.close();
+      expect(patchResponse.statusCode, HttpStatus.methodNotAllowed);
+      expect(patchResponse.headers.value(HttpHeaders.allowHeader), 'POST');
+      await patchResponse.drain<void>();
     });
 
     test('rejects unsupported MCP-Protocol-Version header by default',

--- a/test/shared/mcp_header_validation_test.dart
+++ b/test/shared/mcp_header_validation_test.dart
@@ -1,0 +1,50 @@
+import 'package:mcp_dart/src/shared/mcp_header_validation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('isValidMcpHeaderNameSuffix', () {
+    test('accepts RFC 9110 field-name token characters', () {
+      expect(
+        isValidMcpHeaderNameSuffix("AZaz09!#\$%&'*+-.^_`|~"),
+        isTrue,
+      );
+    });
+
+    test('rejects empty and separator characters', () {
+      expect(isValidMcpHeaderNameSuffix(''), isFalse);
+
+      for (final separator in [
+        '"',
+        '(',
+        ')',
+        ',',
+        '/',
+        ':',
+        ';',
+        '<',
+        '=',
+        '>',
+        '?',
+        '@',
+        '[',
+        r'\',
+        ']',
+        '{',
+        '}',
+      ]) {
+        expect(
+          isValidMcpHeaderNameSuffix('Bad${separator}Header'),
+          isFalse,
+          reason: 'separator $separator must be rejected',
+        );
+      }
+    });
+
+    test('rejects whitespace, control characters, and non-ASCII characters',
+        () {
+      for (final value in ['Bad Header', 'Bad\tHeader', 'Bad\nHeader', 'Bäd']) {
+        expect(isValidMcpHeaderNameSuffix(value), isFalse);
+      }
+    });
+  });
+}

--- a/test/types/subscriptions_test.dart
+++ b/test/types/subscriptions_test.dart
@@ -1,5 +1,26 @@
+import 'package:mcp_dart/src/shared/protocol.dart';
 import 'package:mcp_dart/src/types.dart';
 import 'package:test/test.dart';
+
+Future<T> _unusedRequest<T extends BaseResultData>(
+  JsonRpcRequest request,
+  T Function(Map<String, dynamic> resultJson) resultFactory,
+  RequestOptions options,
+) {
+  throw StateError('Unexpected request from subscription helper test');
+}
+
+RequestHandlerExtra _subscriptionExtra(List<JsonRpcNotification> sent) {
+  final abort = BasicAbortController();
+  return RequestHandlerExtra(
+    signal: abort.signal,
+    requestId: 'sub-1',
+    sendNotification: (notification, {relatedTask}) async {
+      sent.add(notification);
+    },
+    sendRequest: _unusedRequest,
+  );
+}
 
 void main() {
   group('SubscriptionFilter', () {
@@ -53,6 +74,73 @@ void main() {
 
       final acknowledged = requested.acknowledgedBy(const ServerCapabilities());
       expect(acknowledged.toJson(), isEmpty);
+    });
+
+    test('checks acknowledged subsets and allowed notifications', () {
+      const requested = SubscriptionFilter(
+        toolsListChanged: true,
+        resourceSubscriptions: [
+          'file:///project/config.json',
+          'file:///project/other.json',
+        ],
+      );
+      const acknowledged = SubscriptionFilter(
+        toolsListChanged: true,
+        resourceSubscriptions: ['file:///project/config.json'],
+      );
+
+      expect(acknowledged.isSubsetOf(requested), isTrue);
+      expect(
+        const SubscriptionFilter(promptsListChanged: true).isSubsetOf(
+          requested,
+        ),
+        isFalse,
+      );
+      expect(
+        const SubscriptionFilter(resourcesListChanged: true).isSubsetOf(
+          requested,
+        ),
+        isFalse,
+      );
+      expect(
+        const SubscriptionFilter(
+          resourceSubscriptions: ['file:///project/missing.json'],
+        ).isSubsetOf(requested),
+        isFalse,
+      );
+
+      expect(
+        acknowledged.allowsNotification(
+          const JsonRpcToolListChangedNotification(),
+        ),
+        isTrue,
+      );
+      expect(
+        acknowledged.allowsNotification(
+          JsonRpcResourceUpdatedNotification(
+            updatedParams: const ResourceUpdatedNotification(
+              uri: 'file:///project/config.json',
+            ),
+          ),
+        ),
+        isTrue,
+      );
+      expect(
+        acknowledged.allowsNotification(
+          JsonRpcResourceUpdatedNotification(
+            updatedParams: const ResourceUpdatedNotification(
+              uri: 'file:///project/missing.json',
+            ),
+          ),
+        ),
+        isFalse,
+      );
+      expect(
+        acknowledged.allowsNotification(
+          const JsonRpcPromptListChangedNotification(),
+        ),
+        isFalse,
+      );
     });
 
     test('rejects malformed filters', () {
@@ -130,6 +218,29 @@ void main() {
   });
 
   group('JsonRpcSubscriptionsAcknowledgedNotification', () {
+    test('preserves subscription metadata on list changed notifications', () {
+      for (final notification in [
+        const JsonRpcToolListChangedNotification(
+          meta: {McpMetaKey.subscriptionId: 'sub-1'},
+        ),
+        const JsonRpcPromptListChangedNotification(
+          meta: {McpMetaKey.subscriptionId: 'sub-1'},
+        ),
+        const JsonRpcResourceListChangedNotification(
+          meta: {McpMetaKey.subscriptionId: 'sub-1'},
+        ),
+        // ignore: deprecated_member_use_from_same_package, deprecated_member_use
+        const JsonRpcCompletionListChangedNotification(
+          meta: {McpMetaKey.subscriptionId: 'sub-1'},
+        ),
+      ]) {
+        final parsed = JsonRpcMessage.fromJson(notification.toJson())
+            as JsonRpcNotification;
+
+        expect(parsed.meta?[McpMetaKey.subscriptionId], 'sub-1');
+      }
+    });
+
     test('serializes and parses subscription acknowledgments', () {
       final notification = JsonRpcSubscriptionsAcknowledgedNotification(
         acknowledgedParams: const SubscriptionsAcknowledgedNotification(
@@ -172,6 +283,117 @@ void main() {
           },
         ),
         throwsFormatException,
+      );
+    });
+  });
+
+  group('RequestHandlerExtra subscription helpers', () {
+    test('require acknowledgment before stream notifications', () async {
+      final sent = <JsonRpcNotification>[];
+      final extra = _subscriptionExtra(sent);
+
+      expect(
+        () => extra.sendSubscriptionNotification(
+          const JsonRpcToolListChangedNotification(),
+        ),
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.message,
+            'message',
+            contains(Method.notificationsSubscriptionsAcknowledged),
+          ),
+        ),
+      );
+      expect(sent, isEmpty);
+    });
+
+    test('allow only acknowledged notification filters', () async {
+      final sent = <JsonRpcNotification>[];
+      final extra = _subscriptionExtra(sent);
+
+      await extra.sendSubscriptionAcknowledged(
+        const SubscriptionFilter(
+          toolsListChanged: true,
+          resourcesListChanged: true,
+          resourceSubscriptions: ['file:///project/config.json'],
+          taskIds: ['task-1'],
+        ),
+      );
+      expect(sent.single.method, Method.notificationsSubscriptionsAcknowledged);
+      sent.clear();
+
+      await extra.sendSubscriptionNotification(
+        const JsonRpcToolListChangedNotification(),
+      );
+      await extra.sendSubscriptionNotification(
+        JsonRpcResourceUpdatedNotification(
+          updatedParams: const ResourceUpdatedNotification(
+            uri: 'file:///project/config.json',
+          ),
+        ),
+      );
+      await extra.sendSubscriptionNotification(
+        const JsonRpcResourceListChangedNotification(),
+      );
+      await extra.sendSubscriptionNotification(
+        JsonRpcTaskNotification(
+          task: const TaskExtensionTask(
+            taskId: 'task-1',
+            status: TaskStatus.working,
+            createdAt: '2026-07-28T00:00:00Z',
+            lastUpdatedAt: '2026-07-28T00:01:00Z',
+            ttlMs: 300000,
+          ),
+        ),
+      );
+
+      expect(sent, hasLength(4));
+      expect(
+        sent.map(
+          (notification) => notification.meta?[McpMetaKey.subscriptionId],
+        ),
+        everyElement('sub-1'),
+      );
+
+      expect(
+        () => extra.sendSubscriptionNotification(
+          const JsonRpcPromptListChangedNotification(),
+        ),
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.message,
+            'message',
+            contains('not requested or acknowledged'),
+          ),
+        ),
+      );
+      expect(
+        () => extra.sendSubscriptionNotification(
+          JsonRpcResourceUpdatedNotification(
+            updatedParams: const ResourceUpdatedNotification(
+              uri: 'file:///project/other.json',
+            ),
+          ),
+        ),
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.message,
+            'message',
+            contains('not requested or acknowledged'),
+          ),
+        ),
+      );
+      expect(
+        () => extra.sendSubscriptionNotification(
+          const JsonRpcNotification(method: 'notifications/custom'),
+        ),
+        throwsA(
+          isA<McpError>().having(
+            (error) => error.message,
+            'message',
+            contains('not requested or acknowledged'),
+          ),
+        ),
       );
     });
   });


### PR DESCRIPTION
## Summary
- consolidate stateless transport enforcement, HTTP response/header behavior, removed-RPC guards, result-type validation, discovery retry, and client subscription handling
- keeps the transport behavior reviewable as one layer above the MCP 2026 feature foundation
- replaces the transport/enforcement portion of the prior micro-PR stack (#186-#208)

## Validation
- dart format --output=none --set-exit-if-changed .
- dart analyze
- git diff --check
- dart test
- dart pub global run coverage:test_with_coverage

Stacked on #267. This is a draft RC PR and should stay off `main` until the official spec release.