### PR TITLE
Consolidate MCP 2026 result semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,29 @@
 - Added client-side `subscriptions/listen` handles that correlate stream
   notifications by `io.modelcontextprotocol/subscriptionId`, validate the
   acknowledgment, and cancel long-lived streams with `notifications/cancelled`.
+- Allowed MCP 2026 tool `outputSchema` declarations to use any JSON Schema and
+  `structuredContent` results to carry any JSON value, while omitting non-object
+  structured output from stable 2025 responses.
+- Allowed MCP 2026 `prompts/get` and `resources/read` handlers to return
+  `InputRequiredResult`, and rejected MRTR input-required results on unsupported
+  request methods.
+- Rejected MCP 2026 MRTR `inputRequests` whose embedded client request type is
+  not declared in the caller's per-request client capabilities.
+- Returned version-appropriate resource-not-found errors from high-level
+  `resources/read` handlers: stable 2025 uses legacy `-32002`, while MCP 2026
+  stateless requests use `-32602` with the missing `uri` in error data.
+- Enforced MCP 2026 `_meta` key-name grammar on stateless request metadata and
+  the 2026 request metadata builder while preserving legacy metadata parsing.
+- Rejected negative cacheable-result `ttlMs` values during parsing instead of
+  clamping malformed wire values to zero.
+- Validated MRTR `inputResponses` as `CreateMessageResult`, `ListRootsResult`,
+  or `ElicitResult` instead of accepting arbitrary result objects.
+- Rejected non-integer numeric `ElicitResult.content` values to match the
+  stable and MCP 2026 schemas.
+- Rejected form elicitation schemas that provide legacy `enumNames` without the
+  required string `enum`.
+- Rejected `ElicitResult.content` when the result action is `decline` or
+  `cancel`.
 
 ## 2.2.0
 

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -46,6 +46,66 @@ List<McpIcon>? _iconsFromLegacyImage(ImageContent? image) {
   ];
 }
 
+bool _isDraft2026Request(String? protocolVersion) =>
+    protocolVersion != null && isStatelessProtocolVersion(protocolVersion);
+
+bool _isStableStructuredContentValue(Object? value) {
+  if (value is Map<String, dynamic>) {
+    return true;
+  }
+  if (value is Map) {
+    return value.keys.every((key) => key is String);
+  }
+  return false;
+}
+
+JsonSchema? _outputSchemaForProtocol(
+  JsonSchema? schema,
+  String? protocolVersion,
+) {
+  if (schema == null || _isDraft2026Request(protocolVersion)) {
+    return schema;
+  }
+
+  // MCP 2025-11-25 restricts tool output schemas to object roots. MCP 2026
+  // allows any JSON Schema, so omit non-object schemas for stable callers.
+  if (schema.toJson()['type'] == 'object') {
+    return schema;
+  }
+  return null;
+}
+
+CallToolResult _toolResultForProtocol(
+  CallToolResult result,
+  String? protocolVersion,
+) {
+  if (_isDraft2026Request(protocolVersion) ||
+      !result.hasStructuredContent ||
+      _isStableStructuredContentValue(result.structuredContent)) {
+    return result;
+  }
+
+  return CallToolResult(
+    content: result.content,
+    isError: result.isError,
+    meta: result.meta,
+    extra: result.extra,
+  );
+}
+
+McpError _resourceNotFoundErrorForProtocol(
+  String uri,
+  String? protocolVersion,
+) {
+  return McpError(
+    _isDraft2026Request(protocolVersion)
+        ? ErrorCode.invalidParams.value
+        : ErrorCode.resourceNotFound.value,
+    'Resource not found',
+    {'uri': uri},
+  );
+}
+
 /// Definition for a completable argument.
 class CompletableDef {
   /// The callback to invoke to get completion suggestions.
@@ -110,7 +170,7 @@ final class InterfaceToolCallback extends ToolCallback {
 }
 
 /// Callback signature for prompts.
-typedef PromptCallback = FutureOr<GetPromptResult> Function(
+typedef PromptCallback = FutureOr<BaseResultData> Function(
   Map<String, dynamic>? args,
   RequestHandlerExtra? extra,
 );
@@ -149,13 +209,13 @@ typedef ListResourcesCallback = FutureOr<ListResourcesResult> Function(
 );
 
 /// Callback to read a specific resource.
-typedef ReadResourceCallback = FutureOr<ReadResourceResult> Function(
+typedef ReadResourceCallback = FutureOr<BaseResultData> Function(
   Uri uri,
   RequestHandlerExtra extra,
 );
 
 /// Callback to read a resource template.
-typedef ReadResourceTemplateCallback = FutureOr<ReadResourceResult> Function(
+typedef ReadResourceTemplateCallback = FutureOr<BaseResultData> Function(
   Uri uri,
   TemplateVariables variables,
   RequestHandlerExtra extra,
@@ -219,6 +279,7 @@ CallToolResult _withRelatedTaskMeta(CallToolResult result, String taskId) {
     content: result.content,
     isError: result.isError,
     structuredContent: result.structuredContent,
+    hasStructuredContent: result.hasStructuredContent,
     meta: meta,
     extra: result.extra,
   );
@@ -516,7 +577,7 @@ abstract class RegisteredTool {
   ToolInputSchema? get inputSchema;
 
   /// The output schema for the tool.
-  ToolOutputSchema? get outputSchema;
+  JsonSchema? get outputSchema;
 
   /// Annotations for the tool.
   ToolAnnotations? get annotations;
@@ -545,7 +606,7 @@ abstract class RegisteredTool {
     String? title,
     String? description,
     ToolInputSchema? inputSchema,
-    ToolOutputSchema? outputSchema,
+    JsonSchema? outputSchema,
     ToolAnnotations? annotations,
     ToolExecution? execution,
     ToolCallback? callback,
@@ -563,7 +624,7 @@ class _RegisteredToolImpl implements RegisteredTool {
   @override
   ToolInputSchema? inputSchema;
   @override
-  ToolOutputSchema? outputSchema;
+  JsonSchema? outputSchema;
   @override
   ToolAnnotations? annotations;
   final ImageContent? icon;
@@ -596,6 +657,7 @@ class _RegisteredToolImpl implements RegisteredTool {
   Tool toTool({
     bool includeExecution = true,
     ToolInputSchema? inputSchemaOverride,
+    String? protocolVersion,
   }) {
     return Tool(
       name: name,
@@ -603,7 +665,7 @@ class _RegisteredToolImpl implements RegisteredTool {
       description: description,
       inputSchema:
           inputSchemaOverride ?? inputSchema ?? const ToolInputSchema(),
-      outputSchema: outputSchema,
+      outputSchema: _outputSchemaForProtocol(outputSchema, protocolVersion),
       annotations: annotations,
       icon: icon,
       icons: _iconsFromLegacyImage(icon),
@@ -627,7 +689,7 @@ class _RegisteredToolImpl implements RegisteredTool {
     String? title,
     String? description,
     ToolInputSchema? inputSchema,
-    ToolOutputSchema? outputSchema,
+    JsonSchema? outputSchema,
     ToolAnnotations? annotations,
     ToolExecution? execution,
     ToolCallback? callback,
@@ -785,7 +847,7 @@ class ExperimentalMcpServerTasks {
     String? title,
     String? description,
     ToolInputSchema? inputSchema,
-    ToolOutputSchema? outputSchema,
+    JsonSchema? outputSchema,
     ToolAnnotations? annotations,
     Map<String, dynamic>? meta,
     ToolExecution? execution,
@@ -1424,6 +1486,8 @@ class McpServer {
                   inputSchemaOverride: isStatelessRequest
                       ? _toolInputSchemaForStatelessList(tool)
                       : null,
+                  protocolVersion:
+                      protocolVersion is String ? protocolVersion : null,
                 ),
               )
               .toList(),
@@ -1549,6 +1613,13 @@ class McpServer {
                 );
               }
             }
+          }
+
+          if (result is CallToolResult) {
+            return _toolResultForProtocol(
+              result,
+              protocolVersion is String ? protocolVersion : null,
+            );
           }
 
           return result;
@@ -1751,9 +1822,10 @@ class McpServer {
             return await Future.value(entry.readCallback(uri, vars, extra));
           }
         }
-        throw McpError(
-          ErrorCode.invalidParams.value,
-          "Resource not found: $uriString",
+        final protocolVersion = extra.meta?[McpMetaKey.protocolVersion];
+        throw _resourceNotFoundErrorForProtocol(
+          uriString,
+          protocolVersion is String ? protocolVersion : null,
         );
       },
       (id, params, meta) => JsonRpcReadResourceRequest.fromJson({
@@ -1963,7 +2035,7 @@ class McpServer {
     String? title,
     String? description,
     ToolInputSchema? inputSchema,
-    ToolOutputSchema? outputSchema,
+    JsonSchema? outputSchema,
     ToolAnnotations? annotations,
     Map<String, dynamic>? meta,
     required ToolFunction callback,
@@ -1987,7 +2059,7 @@ class McpServer {
     String? title,
     String? description,
     ToolInputSchema? inputSchema,
-    ToolOutputSchema? outputSchema,
+    JsonSchema? outputSchema,
     ToolAnnotations? annotations,
     Map<String, dynamic>? meta,
     ToolExecution? execution,

--- a/lib/src/server/mcp_ui.dart
+++ b/lib/src/server/mcp_ui.dart
@@ -10,7 +10,7 @@ class McpUiAppToolConfig {
   final String? title;
   final String? description;
   final ToolInputSchema? inputSchema;
-  final ToolOutputSchema? outputSchema;
+  final JsonSchema? outputSchema;
   final ToolAnnotations? annotations;
   final Map<String, dynamic> meta;
 

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -4,6 +4,7 @@ import 'package:mcp_dart/src/shared/json_schema/json_schema_validator.dart';
 import 'package:mcp_dart/src/shared/logging.dart';
 import 'package:mcp_dart/src/shared/protocol.dart';
 import 'package:mcp_dart/src/types.dart';
+import 'package:mcp_dart/src/types/json_rpc.dart' as json_rpc;
 
 final _logger = Logger("mcp_dart.server");
 
@@ -75,6 +76,12 @@ class Server extends Protocol {
   static const Set<String> _statelessRemovedNotificationMethods = {
     Method.notificationsInitialized,
     Method.notificationsRootsListChanged,
+  };
+
+  static const Set<String> _inputRequiredResultMethods = {
+    Method.toolsCall,
+    Method.promptsGet,
+    Method.resourcesRead,
   };
 
   /// Callback to be notified when the server is fully initialized.
@@ -150,6 +157,16 @@ class Server extends Protocol {
 
   McpError? _validateStatelessRequestMetadata(JsonRpcRequest request) {
     final meta = request.meta;
+    try {
+      json_rpc.validateRequestMeta(meta, validateKeys: true);
+    } on FormatException catch (error) {
+      return McpError(
+        ErrorCode.invalidRequest.value,
+        'Invalid stateless request metadata.',
+        error.message,
+      );
+    }
+
     final requestedVersion = meta?[McpMetaKey.protocolVersion];
     if (requestedVersion is! String || requestedVersion.isEmpty) {
       return McpError(
@@ -236,6 +253,22 @@ class Server extends Protocol {
         'requiredCapabilities': {
           'extensions': {mcpTasksExtensionId: <String, dynamic>{}},
         },
+      },
+    );
+  }
+
+  McpError _missingInputRequestClientCapabilityError(
+    String inputRequestKey,
+    String method,
+    Map<String, dynamic> requiredCapabilities,
+  ) {
+    return McpError(
+      ErrorCode.missingRequiredClientCapability.value,
+      'Missing required client capability for input request',
+      {
+        'inputRequest': inputRequestKey,
+        'method': method,
+        'requiredCapabilities': requiredCapabilities,
       },
     );
   }
@@ -395,6 +428,80 @@ class Server extends Protocol {
     }
   }
 
+  McpError? _validateInputRequiredClientCapabilities(
+    InputRequiredResult result,
+    JsonRpcRequest request,
+  ) {
+    final inputRequests = result.inputRequests;
+    if (inputRequests == null || inputRequests.isEmpty) {
+      return null;
+    }
+
+    final parsed = _clientCapabilitiesForRequest(request);
+    if (parsed.error != null) {
+      return parsed.error;
+    }
+
+    for (final entry in inputRequests.entries) {
+      final requiredCapabilities = _missingCapabilitiesForInputRequest(
+        entry.value,
+        parsed.capabilities,
+      );
+      if (requiredCapabilities != null) {
+        return _missingInputRequestClientCapabilityError(
+          entry.key,
+          entry.value.method,
+          requiredCapabilities,
+        );
+      }
+    }
+
+    return null;
+  }
+
+  Map<String, dynamic>? _missingCapabilitiesForInputRequest(
+    InputRequest inputRequest,
+    ClientCapabilities? capabilities,
+  ) {
+    switch (inputRequest.method) {
+      case Method.elicitationCreate:
+        final elicitParams = inputRequest.elicitParams;
+        final requiredMode = elicitParams.isUrlMode ? 'url' : 'form';
+        final elicitation = capabilities?.elicitation;
+        final supportsMode = requiredMode == 'url'
+            ? elicitation?.url != null
+            : elicitation?.form != null;
+        if (!supportsMode) {
+          return {
+            'elicitation': {
+              requiredMode: <String, dynamic>{},
+            },
+          };
+        }
+        return null;
+      case Method.samplingCreateMessage:
+        final createParams = inputRequest.createMessageParams;
+        final sampling = capabilities?.sampling;
+        if (sampling == null) {
+          return {'sampling': <String, dynamic>{}};
+        }
+        if ((createParams.tools != null || createParams.toolChoice != null) &&
+            !sampling.tools) {
+          return {
+            'sampling': {'tools': <String, dynamic>{}},
+          };
+        }
+        return null;
+      case Method.rootsList:
+        if (capabilities?.roots == null) {
+          return {'roots': <String, dynamic>{}};
+        }
+        return null;
+      default:
+        return null;
+    }
+  }
+
   McpError? _validateRequestTaskSemantics(JsonRpcRequest request) {
     final removedMethodError = _validateDraftTaskMethods(request);
     if (removedMethodError != null) {
@@ -419,7 +526,7 @@ class Server extends Protocol {
     if (result is CallToolResult) {
       return true;
     }
-    if (result is InputRequiredResult && _isStatelessRequest(request)) {
+    if (_allowsInputRequiredResult(result, request)) {
       return true;
     }
     if (result is CreateTaskExtensionResult && _isStatelessRequest(request)) {
@@ -428,6 +535,55 @@ class Server extends Protocol {
     }
 
     return false;
+  }
+
+  bool _allowsPromptGetResult(BaseResultData result, JsonRpcRequest request) {
+    return result is GetPromptResult ||
+        _allowsInputRequiredResult(result, request);
+  }
+
+  bool _allowsResourceReadResult(
+    BaseResultData result,
+    JsonRpcRequest request,
+  ) {
+    return result is ReadResourceResult ||
+        _allowsInputRequiredResult(result, request);
+  }
+
+  bool _allowsInputRequiredResult(
+    BaseResultData result,
+    JsonRpcRequest request,
+  ) {
+    if (result is! InputRequiredResult ||
+        !_isStatelessRequest(request) ||
+        !_inputRequiredResultMethods.contains(request.method)) {
+      return false;
+    }
+
+    final capabilityError = _validateInputRequiredClientCapabilities(
+      result,
+      request,
+    );
+    if (capabilityError != null) {
+      throw capabilityError;
+    }
+
+    return true;
+  }
+
+  void _validateUnsupportedInputRequiredResult(
+    BaseResultData result,
+    JsonRpcRequest request,
+  ) {
+    if (result is! InputRequiredResult) {
+      return;
+    }
+
+    throw McpError(
+      ErrorCode.invalidParams.value,
+      'Invalid ${request.method} result: InputRequiredResult is only supported '
+      'by ${_inputRequiredResultMethods.join(', ')} in MCP stateless requests.',
+    );
   }
 
   bool _allowsTaskExtensionResult(
@@ -708,6 +864,38 @@ class Server extends Protocol {
       }
 
       super.setRequestHandler(method, wrappedHandler, requestFactory);
+    } else if (method == Method.promptsGet) {
+      Future<BaseResultData> wrappedHandler(
+        ReqT request,
+        RequestHandlerExtra extra,
+      ) async {
+        final result = await handler(request, extra);
+        if (!_allowsPromptGetResult(result, request)) {
+          throw McpError(
+            ErrorCode.invalidParams.value,
+            'Invalid prompts/get result: Expected GetPromptResult',
+          );
+        }
+        return result;
+      }
+
+      super.setRequestHandler(method, wrappedHandler, requestFactory);
+    } else if (method == Method.resourcesRead) {
+      Future<BaseResultData> wrappedHandler(
+        ReqT request,
+        RequestHandlerExtra extra,
+      ) async {
+        final result = await handler(request, extra);
+        if (!_allowsResourceReadResult(result, request)) {
+          throw McpError(
+            ErrorCode.invalidParams.value,
+            'Invalid resources/read result: Expected ReadResourceResult',
+          );
+        }
+        return result;
+      }
+
+      super.setRequestHandler(method, wrappedHandler, requestFactory);
     } else if (method == Method.tasksGet ||
         method == Method.tasksCancel ||
         method == Method.tasksUpdate) {
@@ -727,7 +915,16 @@ class Server extends Protocol {
 
       super.setRequestHandler(method, wrappedHandler, requestFactory);
     } else {
-      super.setRequestHandler(method, handler, requestFactory);
+      Future<BaseResultData> wrappedHandler(
+        ReqT request,
+        RequestHandlerExtra extra,
+      ) async {
+        final result = await handler(request, extra);
+        _validateUnsupportedInputRequiredResult(result, request);
+        return result;
+      }
+
+      super.setRequestHandler(method, wrappedHandler, requestFactory);
     }
   }
 

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -9,6 +9,7 @@ export 'types/json_rpc.dart'
         extractRequestMeta,
         parseProgressToken,
         parseRequestId,
+        validateMetaKeyName,
         validateRequestMeta;
 export 'types/mcp_ui.dart';
 export 'types/misc.dart';

--- a/lib/src/types/elicitation.dart
+++ b/lib/src/types/elicitation.dart
@@ -267,9 +267,16 @@ class ElicitResult implements BaseResultData {
       throw FormatException('Invalid elicitation action: $action');
     }
 
+    final content = _parseElicitResultContent(json['content']);
+    _validateElicitResultContentForAction(
+      action,
+      content,
+      formatException: true,
+    );
+
     return ElicitResult(
       action: action,
-      content: _parseElicitResultContent(json['content']),
+      content: content,
       url: json['url'] as String?,
       elicitationId: json['elicitationId'] as String?,
       meta: (json['_meta'] as Map?)?.cast<String, dynamic>(),
@@ -278,9 +285,11 @@ class ElicitResult implements BaseResultData {
 
   @override
   Map<String, dynamic> toJson() {
+    final resultAction = action;
+    _validateElicitResultContentForAction(resultAction, content);
     _validateElicitResultContent(content);
     return {
-      'action': action,
+      'action': resultAction,
       if (content != null) 'content': content,
       if (meta != null) '_meta': meta,
     };
@@ -533,6 +542,9 @@ void _validateStringOrSingleEnumSchema(
       (enumNames is! List || enumNames.any((value) => value is! String))) {
     throw FormatException('$context.enumNames must be a string array.');
   }
+  if (enumNames != null && enumValues == null) {
+    throw FormatException('$context.enumNames requires enum.');
+  }
   final format = json['format'];
   if (format != null &&
       !const {'email', 'uri', 'date', 'date-time'}.contains(format)) {
@@ -616,7 +628,7 @@ void _validateElicitResultContent(
   }
   for (final entry in content.entries) {
     final value = entry.value;
-    if (value is String || value is num || value is bool) {
+    if (value is String || value is int || value is bool) {
       continue;
     }
     if (value is List && value.every((item) => item is String)) {
@@ -624,15 +636,35 @@ void _validateElicitResultContent(
     }
     if (formatException) {
       throw FormatException(
-        'ElicitResult.content.${entry.key} must be string, number, boolean, or string[]',
+        'ElicitResult.content.${entry.key} must be string, integer, boolean, or string[]',
       );
     }
     throw ArgumentError.value(
       value,
       'content.${entry.key}',
-      'ElicitResult content values must be string, number, boolean, or string[]',
+      'ElicitResult content values must be string, integer, boolean, or string[]',
     );
   }
+}
+
+void _validateElicitResultContentForAction(
+  String action,
+  Map<String, dynamic>? content, {
+  bool formatException = false,
+}) {
+  if (content == null || action == 'accept') {
+    return;
+  }
+  if (formatException) {
+    throw const FormatException(
+      'ElicitResult.content is only allowed when action is accept.',
+    );
+  }
+  throw ArgumentError.value(
+    content,
+    'content',
+    'ElicitResult.content is only allowed when action is accept.',
+  );
 }
 
 void _validateUrlElicitations(

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -82,6 +82,7 @@ Map<String, dynamic> buildProtocolRequestMeta({
   Map<String, dynamic>? meta,
   Object? logLevel,
 }) {
+  validateRequestMeta(meta, validateKeys: true);
   return <String, dynamic>{
     ...?meta,
     McpMetaKey.protocolVersion: protocolVersion,
@@ -203,12 +204,66 @@ RequestId? _parseErrorResponseId(Map<String, dynamic> json) {
   return parseRequestId(json['id']);
 }
 
+final _metaPrefixLabelPattern = RegExp(
+  r'^[A-Za-z](?:[A-Za-z0-9-]*[A-Za-z0-9])?$',
+);
+final _metaNamePattern = RegExp(
+  r'^(?:[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?)?$',
+);
+
+/// Validates an MCP 2026 `_meta` key name.
+///
+/// MCP 2026 constrains metadata keys to an optional dot-separated prefix
+/// followed by `/`, plus a name segment. Earlier protocol versions did not
+/// define this grammar, so callers choose when to enforce it.
+void validateMetaKeyName(String key, {String fieldName = '_meta'}) {
+  final slashIndex = key.indexOf('/');
+  final prefix = slashIndex == -1 ? null : key.substring(0, slashIndex);
+  final name = slashIndex == -1 ? key : key.substring(slashIndex + 1);
+
+  if (prefix != null) {
+    if (prefix.isEmpty) {
+      throw FormatException(
+        'Invalid $fieldName key "$key": prefix must not be empty',
+      );
+    }
+    final labels = prefix.split('.');
+    for (final label in labels) {
+      if (!_metaPrefixLabelPattern.hasMatch(label)) {
+        throw FormatException(
+          'Invalid $fieldName key "$key": invalid prefix label "$label"',
+        );
+      }
+    }
+  }
+
+  if (!_metaNamePattern.hasMatch(name)) {
+    throw FormatException(
+      'Invalid $fieldName key "$key": invalid name segment "$name"',
+    );
+  }
+}
+
 /// Validates request metadata that can affect protocol behavior.
 ///
 /// `_meta.progressToken` is an MCP wire token and must be a string or integer
-/// when present. Other `_meta` fields are preserved without interpretation.
-Map<String, dynamic>? validateRequestMeta(Map<String, dynamic>? meta) {
-  if (meta != null && meta.containsKey('progressToken')) {
+/// when present. [validateKeys] opts in to the MCP 2026 `_meta` key-name
+/// grammar without changing stable/legacy request parsing.
+Map<String, dynamic>? validateRequestMeta(
+  Map<String, dynamic>? meta, {
+  bool validateKeys = false,
+}) {
+  if (meta == null) {
+    return null;
+  }
+
+  if (validateKeys) {
+    for (final key in meta.keys) {
+      validateMetaKeyName(key);
+    }
+  }
+
+  if (meta.containsKey('progressToken')) {
     parseProgressToken(
       meta['progressToken'],
       fieldName: '_meta.progressToken',
@@ -457,6 +512,9 @@ enum ErrorCode {
   /// code. [requestTimeout] is retained for older SDK behavior.
   headerMismatch(-32001),
 
+  /// Resource not found in stable MCP 2025-11-25.
+  resourceNotFound(-32002),
+
   /// Required per-request client capabilities were not declared.
   missingRequiredClientCapability(-32003),
 
@@ -700,6 +758,12 @@ class InputResponse {
   }
 
   factory InputResponse.fromJson(Map<String, dynamic> json) {
+    if (!_isValidInputResponse(json)) {
+      throw const FormatException(
+        'InputResponse must be a CreateMessageResult, ListRootsResult, '
+        'or ElicitResult',
+      );
+    }
     return InputResponse.raw(Map<String, dynamic>.from(json));
   }
 
@@ -725,6 +789,28 @@ class InputResponse {
   }
 
   Map<String, dynamic> toJson() => Map<String, dynamic>.from(value);
+}
+
+bool _isValidInputResponse(Map<String, dynamic> json) {
+  return _canParseInputResponse(CreateMessageResult.fromJson, json) ||
+      _canParseInputResponse(ListRootsResult.fromJson, json) ||
+      _canParseInputResponse(ElicitResult.fromJson, json);
+}
+
+bool _canParseInputResponse(
+  BaseResultData Function(Map<String, dynamic> json) parser,
+  Map<String, dynamic> json,
+) {
+  try {
+    parser(json);
+    return true;
+  } on FormatException {
+    return false;
+  } on ArgumentError {
+    return false;
+  } on TypeError {
+    return false;
+  }
 }
 
 /// Result returned when a request needs extra client input before retry.

--- a/lib/src/types/sampling.dart
+++ b/lib/src/types/sampling.dart
@@ -310,8 +310,11 @@ sealed class SamplingContent {
           final SamplingToolResultContent c => {
               'toolUseId': c.toolUseId,
               'content': c.contentBlocks.map((item) => item.toJson()).toList(),
-              if (c.structuredContent != null)
-                'structuredContent': c.structuredContent,
+              if (c.hasStructuredContent)
+                'structuredContent': readJsonValue(
+                  c.structuredContent,
+                  'SamplingToolResultContent.structuredContent',
+                ),
               if (c.isError != null) 'isError': c.isError,
               if (c.meta != null) '_meta': c.meta,
             },
@@ -431,7 +434,8 @@ class SamplingToolUseContent extends SamplingContent {
 class SamplingToolResultContent extends SamplingContent {
   final String toolUseId;
   final dynamic content;
-  final Map<String, dynamic>? structuredContent;
+  final Object? structuredContent;
+  final bool hasStructuredContent;
   final bool? isError;
   final Map<String, dynamic>? meta;
 
@@ -439,9 +443,12 @@ class SamplingToolResultContent extends SamplingContent {
     required this.toolUseId,
     required this.content,
     this.structuredContent,
+    bool? hasStructuredContent,
     this.isError,
     this.meta,
-  }) : super(type: 'tool_result');
+  })  : hasStructuredContent =
+            hasStructuredContent ?? structuredContent != null,
+        super(type: 'tool_result');
 
   /// Normalized content blocks for tool results.
   List<Content> get contentBlocks => _parseToolResultContent(content);
@@ -454,7 +461,13 @@ class SamplingToolResultContent extends SamplingContent {
     return SamplingToolResultContent(
       toolUseId: json['toolUseId'] as String,
       content: _parseToolResultWireContent(json['content']),
-      structuredContent: _asJsonObjectOrNull(json['structuredContent']),
+      structuredContent: json.containsKey('structuredContent')
+          ? readJsonValue(
+              json['structuredContent'],
+              'SamplingToolResultContent.structuredContent',
+            )
+          : null,
+      hasStructuredContent: json.containsKey('structuredContent'),
       isError: json['isError'] as bool?,
       meta: _asJsonObjectOrNull(json['_meta']),
     );

--- a/lib/src/types/tools.dart
+++ b/lib/src/types/tools.dart
@@ -9,7 +9,10 @@ import 'validation.dart';
 /// Legacy alias for [JsonObject] used as tool input schema.
 typedef ToolInputSchema = JsonObject;
 
-/// Legacy alias for [JsonObject] used as tool output schema.
+/// Legacy alias for object-root tool output schemas.
+///
+/// MCP 2026-07-28 allows [Tool.outputSchema] to be any JSON Schema. Use
+/// [JsonSchema] directly when the output schema root is not an object.
 typedef ToolOutputSchema = JsonObject;
 
 /// Additional properties describing a Tool to clients.
@@ -149,7 +152,7 @@ class Tool {
   /// JSON Schema defining the tool's input parameters.
   final JsonSchema inputSchema;
 
-  /// JSON Schema defining the tool's output parameters.
+  /// JSON Schema defining the tool's structured output.
   final JsonSchema? outputSchema;
 
   /// Optional additional properties describing the tool.
@@ -197,13 +200,6 @@ class Tool {
         _readOptionalJsonObject(json['outputSchema'], 'Tool.outputSchema');
     final outputSchema =
         outputSchemaJson == null ? null : JsonSchema.fromJson(outputSchemaJson);
-    if (outputSchema != null) {
-      _validateObjectRootSchema(
-        outputSchema,
-        'Tool.outputSchema',
-        formatException: true,
-      );
-    }
 
     return Tool(
       name: json['name'] as String,
@@ -231,9 +227,6 @@ class Tool {
 
   Map<String, dynamic> toJson() {
     _validateObjectRootSchema(inputSchema, 'Tool.inputSchema');
-    if (outputSchema != null) {
-      _validateObjectRootSchema(outputSchema!, 'Tool.outputSchema');
-    }
 
     return {
       'name': name,
@@ -390,7 +383,15 @@ class CallToolResult implements BaseResultData {
   final bool isError;
 
   /// Structured content returned by the tool.
-  final Map<String, dynamic>? structuredContent;
+  ///
+  /// MCP 2026-07-28 allows any JSON value: object, array, string, number,
+  /// boolean, or null.
+  final Object? structuredContent;
+
+  /// Whether [structuredContent] was explicitly present.
+  ///
+  /// This distinguishes an omitted field from an explicit JSON `null`.
+  final bool hasStructuredContent;
 
   /// Optional metadata.
   @override
@@ -403,24 +404,26 @@ class CallToolResult implements BaseResultData {
     required this.content,
     this.isError = false,
     this.structuredContent,
+    bool? hasStructuredContent,
     this.meta,
     this.extra,
-  });
+  }) : hasStructuredContent = hasStructuredContent ?? structuredContent != null;
 
   /// Creates a result from a list of content items.
   factory CallToolResult.fromContent(List<Content> content) {
     return CallToolResult(content: content);
   }
 
-  /// Creates a result from arbitrary structured data.
+  /// Creates a result from arbitrary structured JSON data.
   ///
   /// Automatically populates [content] with a JSON-serialized version of
   /// [content] for backward compatibility with clients that do not support
   /// [structuredContent].
-  factory CallToolResult.fromStructuredContent(Map<String, dynamic> content) {
+  factory CallToolResult.fromStructuredContent(Object? content) {
     return CallToolResult(
       content: [TextContent(text: jsonEncode(content))],
       structuredContent: content,
+      hasStructuredContent: true,
     );
   }
 
@@ -438,7 +441,13 @@ class CallToolResult implements BaseResultData {
           .map((e) => Content.fromJson(e as Map<String, dynamic>))
           .toList(),
       isError: json['isError'] as bool? ?? false,
-      structuredContent: json['structuredContent'] as Map<String, dynamic>?,
+      structuredContent: json.containsKey('structuredContent')
+          ? readJsonValue(
+              json['structuredContent'],
+              'CallToolResult.structuredContent',
+            )
+          : null,
+      hasStructuredContent: json.containsKey('structuredContent'),
       meta: json['_meta'] as Map<String, dynamic>?,
       extra: extra.isEmpty ? null : extra,
     );
@@ -448,7 +457,11 @@ class CallToolResult implements BaseResultData {
   Map<String, dynamic> toJson() => {
         'content': content.map((e) => e.toJson()).toList(),
         if (isError) 'isError': isError,
-        if (structuredContent != null) 'structuredContent': structuredContent,
+        if (hasStructuredContent)
+          'structuredContent': readJsonValue(
+            structuredContent,
+            'CallToolResult.structuredContent',
+          ),
         if (meta != null) '_meta': meta,
         ...?extra,
       };

--- a/lib/src/types/validation.dart
+++ b/lib/src/types/validation.dart
@@ -49,7 +49,10 @@ int? readOptionalTtlMs(Object? value, String field) {
   if (ttlMs == null) {
     return null;
   }
-  return ttlMs < 0 ? 0 : ttlMs;
+  if (ttlMs < 0) {
+    throw FormatException('$field must be greater than or equal to 0');
+  }
+  return ttlMs;
 }
 
 void validateTtlMs(int? value, String field) {
@@ -87,4 +90,32 @@ void validateCacheScope(String? value, String field) {
       'must be either "public" or "private"',
     );
   }
+}
+
+Object? readJsonValue(Object? value, String field) {
+  if (value == null || value is String || value is bool) {
+    return value;
+  }
+  if (value is num) {
+    if (!value.isFinite) {
+      throw FormatException('$field must be a finite JSON number');
+    }
+    return value;
+  }
+  if (value is List) {
+    return value.map((item) => readJsonValue(item, '$field[]')).toList();
+  }
+  if (value is Map) {
+    if (value.keys.any((key) => key is! String)) {
+      throw FormatException('$field must be a JSON object with string keys');
+    }
+    return {
+      for (final entry in value.entries)
+        entry.key as String: readJsonValue(
+          entry.value,
+          '$field.${entry.key}',
+        ),
+    };
+  }
+  throw FormatException('$field must be a JSON value');
 }

--- a/packages/templates/simple/__brick__/lib/mcp/tools/base_tool.dart
+++ b/packages/templates/simple/__brick__/lib/mcp/tools/base_tool.dart
@@ -25,8 +25,7 @@ abstract class BaseTool {
   ToolInputSchema get inputSchema;
 
   /// Optional JSON schema defining the output format.
-  /// Use [JsonSchema.object()] to create an object schema.
-  ToolOutputSchema? get outputSchema => null;
+  JsonSchema? get outputSchema => null;
 
   /// Optional tool annotations with hints about tool behavior.
   /// Includes readOnlyHint, destructiveHint, idempotentHint, etc.

--- a/packages/templates/simple/__brick__/lib/mcp/tools/calculator_tool.dart
+++ b/packages/templates/simple/__brick__/lib/mcp/tools/calculator_tool.dart
@@ -20,7 +20,7 @@ class CalculatorTool extends BaseTool {
       );
 
   @override
-  ToolOutputSchema? get outputSchema => ToolOutputSchema(
+  JsonSchema? get outputSchema => ToolOutputSchema(
         properties: {
           'result': JsonSchema.number(description: 'The sum of a and b'),
         },

--- a/test/client/client_tool_validation_test.dart
+++ b/test/client/client_tool_validation_test.dart
@@ -59,6 +59,21 @@ class MockTransport extends Transport
                 .toJson(),
           ),
         );
+      } else if (name == 'array_tool') {
+        _respond(
+          JsonRpcResponse(
+            id: message.id,
+            result: CallToolResult.fromStructuredContent(['alpha', 'beta'])
+                .toJson(),
+          ),
+        );
+      } else if (name == 'broken_array_tool') {
+        _respond(
+          JsonRpcResponse(
+            id: message.id,
+            result: CallToolResult.fromStructuredContent(['alpha', 1]).toJson(),
+          ),
+        );
       } else if (name == 'broken_tool') {
         // Returns data that violates the schema (missing 'result')
         _respond(
@@ -112,6 +127,16 @@ class MockTransport extends Transport
           },
           required: ['result'],
         ),
+      ),
+      Tool(
+        name: 'array_tool',
+        inputSchema: const ToolInputSchema(),
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
+      ),
+      Tool(
+        name: 'broken_array_tool',
+        inputSchema: const ToolInputSchema(),
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
       ),
       const Tool(
         name: 'task_required_tool',
@@ -248,7 +273,37 @@ void main() {
         const CallToolRequest(name: 'validated_tool'),
       );
 
-      expect(result.structuredContent?['result'], equals('success'));
+      final structured = result.structuredContent as Map<String, dynamic>;
+      expect(structured['result'], equals('success'));
+    });
+
+    test('validates non-object tool output schemas successfully', () async {
+      await client.connect(transport);
+      await client.listTools();
+
+      final result = await client.callTool(
+        const CallToolRequest(name: 'array_tool'),
+      );
+
+      expect(result.structuredContent, equals(['alpha', 'beta']));
+    });
+
+    test('throws when non-object tool output validation fails', () async {
+      await client.connect(transport);
+      await client.listTools();
+
+      expect(
+        () => client.callTool(
+          const CallToolRequest(name: 'broken_array_tool'),
+        ),
+        throwsA(
+          isA<McpError>().having(
+            (e) => e.message,
+            'message',
+            contains('Structured content does not match'),
+          ),
+        ),
+      );
     });
 
     test('throws when tool output validation fails', () async {

--- a/test/elicitation_test.dart
+++ b/test/elicitation_test.dart
@@ -949,6 +949,26 @@ void main() {
         () => ElicitRequestParams.fromJson(
           requestWithProperty('value', {
             'type': 'string',
+            'enumNames': ['Ok'],
+          }),
+        ),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ElicitRequestParams.form(
+          message: 'Bad enum names',
+          requestedSchema: JsonObject(
+            properties: {
+              'value': JsonString(enumNames: ['Ok']),
+            },
+          ),
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ElicitRequestParams.fromJson(
+          requestWithProperty('value', {
+            'type': 'string',
             'oneOf': [
               {'const': 'ok'},
             ],
@@ -1023,10 +1043,46 @@ void main() {
         throwsA(isA<FormatException>()),
       );
       expect(
+        () => ElicitResult.fromJson({
+          'action': 'accept',
+          'content': {
+            'ratio': 0.5,
+          },
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ElicitResult.fromJson({
+          'action': 'decline',
+          'content': {
+            'name': 'Alice',
+          },
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
         () => const ElicitResult(
           action: 'accept',
           content: {
             'values': [1, 2],
+          },
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => const ElicitResult(
+          action: 'accept',
+          content: {
+            'ratio': 0.5,
+          },
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => const ElicitResult(
+          action: 'cancel',
+          content: {
+            'name': 'Alice',
           },
         ).toJson(),
         throwsA(isA<ArgumentError>()),

--- a/test/interop/ts/src/client.ts
+++ b/test/interop/ts/src/client.ts
@@ -238,15 +238,10 @@ async function assertRawDartServerWireShapes(client: Client): Promise<void> {
       );
     }
     if (tool.outputSchema !== undefined) {
-      const outputSchema = requireRecord(
+      requireRecord(
         tool.outputSchema,
         'raw tool outputSchema'
       );
-      if (outputSchema.type !== 'object') {
-        throw new Error(
-          `tool outputSchema was not object-root: ${JSON.stringify(tool)}`
-        );
-      }
     }
   }
 

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -234,12 +234,14 @@ class CompletedTaskHandler extends CancelTaskResultHandler {
 Map<String, dynamic> _clientMeta({
   String? protocolVersion,
   ClientCapabilities clientCapabilities = const ClientCapabilities(),
+  Map<String, dynamic>? meta,
   Object? logLevel,
 }) {
   return buildProtocolRequestMeta(
     protocolVersion: protocolVersion ?? draftProtocolVersion2026_07_28,
     clientInfo: const Implementation(name: 'client', version: '1.0.0'),
     clientCapabilities: clientCapabilities,
+    meta: meta,
     logLevel: logLevel,
   );
 }
@@ -265,11 +267,15 @@ void main() {
         protocolVersion: draftProtocolVersion2026_07_28,
         clientInfo: const Implementation(name: 'client', version: '1.0.0'),
         clientCapabilities: const ClientCapabilities(),
-        meta: const {'caller': 'value'},
+        meta: const {
+          'caller': 'value',
+          'com.example.trace/id': 'trace-1',
+        },
         logLevel: 'debug',
       );
 
       expect(meta['caller'], 'value');
+      expect(meta['com.example.trace/id'], 'trace-1');
       expect(
         meta[McpMetaKey.protocolVersion],
         draftProtocolVersion2026_07_28,
@@ -280,6 +286,35 @@ void main() {
       });
       expect(meta[McpMetaKey.clientCapabilities], <String, dynamic>{});
       expect(meta[McpMetaKey.logLevel], 'debug');
+    });
+
+    test('rejects invalid 2026 request metadata keys during construction', () {
+      for (final key in [
+        '/name',
+        '1bad/name',
+        'bad prefix/value',
+        'com.example./name',
+        'com.example/name_',
+      ]) {
+        expect(
+          () => buildProtocolRequestMeta(
+            protocolVersion: draftProtocolVersion2026_07_28,
+            clientInfo: const Implementation(
+              name: 'client',
+              version: '1.0.0',
+            ),
+            clientCapabilities: const ClientCapabilities(),
+            meta: {key: 'value'},
+          ),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains(key),
+            ),
+          ),
+        );
+      }
     });
 
     test('serializes server/discover request and result', () {
@@ -378,8 +413,8 @@ void main() {
 
       expect(const ListToolsResult(tools: []).toJson(), {'tools': []});
       expect(
-        ListToolsResult.fromJson(const {'tools': [], 'ttlMs': -1}).ttlMs,
-        0,
+        () => ListToolsResult.fromJson(const {'tools': [], 'ttlMs': -1}),
+        throwsFormatException,
       );
       expect(
         () => ListToolsResult.fromJson(
@@ -564,6 +599,17 @@ void main() {
           const {
             'uri': 'file:///repo/README.md',
             'inputResponses': {'roots': []},
+          },
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => ReadResourceRequest.fromJson(
+          const {
+            'uri': 'file:///repo/README.md',
+            'inputResponses': {
+              'unknown': {'unexpected': true},
+            },
           },
         ),
         throwsFormatException,
@@ -1356,6 +1402,241 @@ void main() {
       expect(response.result['requestState'], 'retry-state');
     });
 
+    test('stateless input required requests require client capabilities',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities: ServerCapabilities(tools: ServerCapabilitiesTools()),
+        ),
+      );
+      server.setRequestHandler<JsonRpcCallToolRequest>(
+        Method.toolsCall,
+        (request, extra) async {
+          final inputRequest = switch (request.callParams.name) {
+            'needs-form' => InputRequest.elicit(
+                ElicitRequest.form(
+                  message: 'Enter name',
+                  requestedSchema: JsonSchema.object(
+                    properties: {'name': JsonSchema.string()},
+                    required: ['name'],
+                  ),
+                ),
+              ),
+            'needs-url' => InputRequest.elicit(
+                const ElicitRequest.url(
+                  message: 'Open browser',
+                  url: 'https://example.com/authorize',
+                  elicitationId: 'auth-1',
+                ),
+              ),
+            'needs-roots' => InputRequest.listRoots(),
+            'needs-sampling-tools' => InputRequest.createMessage(
+                const CreateMessageRequest(
+                  messages: [
+                    SamplingMessage(
+                      role: SamplingMessageRole.user,
+                      content: SamplingTextContent(text: 'Search'),
+                    ),
+                  ],
+                  maxTokens: 16,
+                  tools: [
+                    Tool(name: 'lookup', inputSchema: JsonObject()),
+                  ],
+                ),
+              ),
+            _ => throw StateError('Unknown tool ${request.callParams.name}'),
+          };
+
+          return InputRequiredResult(
+            inputRequests: {request.callParams.name: inputRequest},
+          );
+        },
+        (id, params, meta) => JsonRpcCallToolRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      final missingCapabilityCases = [
+        (
+          name: 'needs-form',
+          meta: _clientMeta(),
+          method: Method.elicitationCreate,
+          requiredCapabilities: {
+            'elicitation': {'form': <String, dynamic>{}},
+          },
+        ),
+        (
+          name: 'needs-url',
+          meta: _clientMeta(
+            clientCapabilities: const ClientCapabilities(
+              elicitation: ClientElicitation.formOnly(),
+            ),
+          ),
+          method: Method.elicitationCreate,
+          requiredCapabilities: {
+            'elicitation': {'url': <String, dynamic>{}},
+          },
+        ),
+        (
+          name: 'needs-roots',
+          meta: _clientMeta(),
+          method: Method.rootsList,
+          requiredCapabilities: {'roots': <String, dynamic>{}},
+        ),
+        (
+          name: 'needs-sampling-tools',
+          meta: _clientMeta(
+            clientCapabilities: const ClientCapabilities(
+              sampling: ClientCapabilitiesSampling(),
+            ),
+          ),
+          method: Method.samplingCreateMessage,
+          requiredCapabilities: {
+            'sampling': {'tools': <String, dynamic>{}},
+          },
+        ),
+      ];
+
+      for (final scenario in missingCapabilityCases) {
+        transport.sentMessages.clear();
+        transport.receive(
+          JsonRpcCallToolRequest(
+            id: scenario.name,
+            params: CallToolRequest(name: scenario.name).toJson(),
+            meta: scenario.meta,
+          ),
+        );
+        await _pump();
+
+        final response = transport.sentMessages.single as JsonRpcError;
+        expect(
+          response.error.code,
+          ErrorCode.missingRequiredClientCapability.value,
+        );
+        expect(response.error.data['inputRequest'], scenario.name);
+        expect(response.error.data['method'], scenario.method);
+        expect(
+          response.error.data['requiredCapabilities'],
+          scenario.requiredCapabilities,
+        );
+      }
+
+      transport.sentMessages.clear();
+      transport.receive(
+        JsonRpcCallToolRequest(
+          id: 'allowed-form',
+          params: const CallToolRequest(name: 'needs-form').toJson(),
+          meta: _clientMeta(
+            clientCapabilities: const ClientCapabilities(
+              elicitation: ClientElicitation.formOnly(),
+            ),
+          ),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      expect(response.result['resultType'], resultTypeInputRequired);
+      expect(
+        response.result['inputRequests']['needs-form']['method'],
+        Method.elicitationCreate,
+      );
+    });
+
+    test('stateless prompts/get permits input required results', () async {
+      final server = McpServer(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+      server.registerPrompt(
+        'needs_input',
+        callback: (args, extra) =>
+            const InputRequiredResult(requestState: 'prompt-state'),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcGetPromptRequest(
+          id: 'prompt-1',
+          getParams: const GetPromptRequest(name: 'needs_input'),
+          meta: _clientMeta(),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      expect(response.result['resultType'], resultTypeInputRequired);
+      expect(response.result['requestState'], 'prompt-state');
+    });
+
+    test('stateless resources/read permits input required results', () async {
+      final server = McpServer(
+        const Implementation(name: 'server', version: '1.0.0'),
+      );
+      server.registerResource(
+        'needs_input',
+        'memory://needs-input',
+        null,
+        (uri, extra) =>
+            const InputRequiredResult(requestState: 'resource-state'),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcReadResourceRequest(
+          id: 'resource-1',
+          readParams: const ReadResourceRequest(uri: 'memory://needs-input'),
+          meta: _clientMeta(),
+        ),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcResponse;
+      expect(response.result['resultType'], resultTypeInputRequired);
+      expect(response.result['requestState'], 'resource-state');
+    });
+
+    test('stateless unsupported methods reject input required results',
+        () async {
+      final server = Server(
+        const Implementation(name: 'server', version: '1.0.0'),
+        options: const McpServerOptions(
+          capabilities:
+              ServerCapabilities(prompts: ServerCapabilitiesPrompts()),
+        ),
+      );
+      server.setRequestHandler<JsonRpcListPromptsRequest>(
+        Method.promptsList,
+        (request, extra) async =>
+            const InputRequiredResult(requestState: 'list-state'),
+        (id, params, meta) => JsonRpcListPromptsRequest.fromJson({
+          'id': id,
+          'params': params,
+          if (meta != null) '_meta': meta,
+        }),
+      );
+      final transport = RecordingTransport();
+      await server.connect(transport);
+
+      transport.receive(
+        JsonRpcListPromptsRequest(id: 'prompts', meta: _clientMeta()),
+      );
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcError;
+      expect(response.error.code, ErrorCode.invalidParams.value);
+      expect(response.error.message, contains('InputRequiredResult'));
+      expect(response.error.message, contains(Method.promptsGet));
+      expect(response.error.message, contains(Method.resourcesRead));
+      expect(response.error.message, contains(Method.toolsCall));
+    });
+
     test('stateless required legacy task tool resolves to final result',
         () async {
       final server = McpServer(
@@ -1623,6 +1904,29 @@ void main() {
           'message',
           contains(McpMetaKey.logLevel),
         ),
+      );
+      expect(
+        validateToolRequest({
+          ..._clientMeta(),
+          'bad prefix/value': 'value',
+        }),
+        isA<McpError>()
+            .having(
+              (error) => error.code,
+              'code',
+              ErrorCode.invalidRequest.value,
+            )
+            .having(
+              (error) => error.data,
+              'data',
+              contains('bad prefix/value'),
+            ),
+      );
+      expect(
+        validateToolRequest(
+          _clientMeta(meta: const {'com.example.trace/id': 'trace-1'}),
+        ),
+        isNull,
       );
     });
 

--- a/test/server/mcp_server_test.dart
+++ b/test/server/mcp_server_test.dart
@@ -695,6 +695,63 @@ void main() {
       final contents = response.result['contents'] as List;
       expect(contents.first['text'], equals('Hello from resource'));
     });
+
+    test('legacy resource miss uses stable resource-not-found error', () async {
+      server.registerResource(
+        'Known Resource',
+        'test://known',
+        null,
+        (uri, extra) async => ReadResourceResult(
+          contents: [
+            TextResourceContents(uri: uri.toString(), text: 'known'),
+          ],
+        ),
+      );
+
+      await server.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcReadResourceRequest(
+          id: 'missing-resource',
+          readParams: const ReadResourceRequestParams(uri: 'test://missing'),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      final response = transport.sentMessages.last as JsonRpcError;
+      expect(response.error.code, ErrorCode.resourceNotFound.value);
+      expect(response.error.message, 'Resource not found');
+      expect(response.error.data, {'uri': 'test://missing'});
+    });
+
+    test('stateless resource miss uses 2026 invalid params error', () async {
+      server.registerResource(
+        'Known Resource',
+        'test://known',
+        null,
+        (uri, extra) async => ReadResourceResult(
+          contents: [
+            TextResourceContents(uri: uri.toString(), text: 'known'),
+          ],
+        ),
+      );
+
+      await server.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcReadResourceRequest(
+          id: 'missing-resource',
+          readParams: const ReadResourceRequestParams(uri: 'test://missing'),
+          meta: _statelessMeta(),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      final response = transport.sentMessages.last as JsonRpcError;
+      expect(response.error.code, ErrorCode.invalidParams.value);
+      expect(response.error.message, 'Resource not found');
+      expect(response.error.data, {'uri': 'test://missing'});
+    });
   });
 
   group('McpServer Prompt Registration', () {

--- a/test/server/output_validation_test.dart
+++ b/test/server/output_validation_test.dart
@@ -82,7 +82,137 @@ void main() {
       expect(response, isA<JsonRpcResponse>());
       final successResponse = response as JsonRpcResponse;
       final result = CallToolResult.fromJson(successResponse.result);
-      expect(result.structuredContent?['result'], equals('success'));
+      final structured = result.structuredContent as Map<String, dynamic>;
+      expect(structured['result'], equals('success'));
+    });
+
+    test('non-object output schema validates for MCP 2026 calls', () async {
+      mcpServer.registerTool(
+        'array_tool',
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
+        callback: (args, extra) async {
+          return CallToolResult.fromStructuredContent(['alpha', 'beta']);
+        },
+      );
+
+      await mcpServer.connect(transport);
+
+      final callRequest = JsonRpcCallToolRequest(
+        id: 2,
+        params: const CallToolRequest(name: 'array_tool').toJson(),
+        meta: _statelessMeta(),
+      );
+      transport.receiveMessage(callRequest);
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final response = transport.sentMessages.last;
+      expect(response, isA<JsonRpcResponse>());
+      final successResponse = response as JsonRpcResponse;
+      final result = CallToolResult.fromJson(successResponse.result);
+      expect(result.structuredContent, equals(['alpha', 'beta']));
+    });
+
+    test('non-object output schema validation failures are rejected', () async {
+      mcpServer.registerTool(
+        'invalid_array_tool',
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
+        callback: (args, extra) async {
+          return CallToolResult.fromStructuredContent(['alpha', 1]);
+        },
+      );
+
+      await mcpServer.connect(transport);
+
+      final callRequest = JsonRpcCallToolRequest(
+        id: 2,
+        params: const CallToolRequest(name: 'invalid_array_tool').toJson(),
+        meta: _statelessMeta(),
+      );
+      transport.receiveMessage(callRequest);
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final response = transport.sentMessages.last;
+      expect(response, isA<JsonRpcError>());
+      final errorResponse = response as JsonRpcError;
+      expect(errorResponse.error.code, equals(ErrorCode.invalidParams.value));
+      expect(errorResponse.error.message, contains('Output validation error'));
+    });
+
+    test('stable tools/list omits non-object output schemas', () async {
+      mcpServer.registerTool(
+        'array_tool',
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
+        callback: (args, extra) async {
+          return CallToolResult.fromStructuredContent(['alpha', 'beta']);
+        },
+      );
+
+      await mcpServer.connect(transport);
+      await _sendInit(transport);
+
+      transport.receiveMessage(const JsonRpcListToolsRequest(id: 2));
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final response = transport.sentMessages.last;
+      expect(response, isA<JsonRpcResponse>());
+      final successResponse = response as JsonRpcResponse;
+      final tools = successResponse.result['tools'] as List<dynamic>;
+      final tool = tools.single as Map<String, dynamic>;
+      expect(tool.containsKey('outputSchema'), isFalse);
+    });
+
+    test('MCP 2026 tools/list includes non-object output schemas', () async {
+      mcpServer.registerTool(
+        'array_tool',
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
+        callback: (args, extra) async {
+          return CallToolResult.fromStructuredContent(['alpha', 'beta']);
+        },
+      );
+
+      await mcpServer.connect(transport);
+
+      transport.receiveMessage(
+        JsonRpcListToolsRequest(
+          id: 2,
+          meta: _statelessMeta(),
+        ),
+      );
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final response = transport.sentMessages.last;
+      expect(response, isA<JsonRpcResponse>());
+      final successResponse = response as JsonRpcResponse;
+      final tools = successResponse.result['tools'] as List<dynamic>;
+      final tool = tools.single as Map<String, dynamic>;
+      expect(tool['outputSchema']['type'], equals('array'));
+      expect(tool['outputSchema']['items']['type'], equals('string'));
+    });
+
+    test('stable tool calls omit non-object structured content', () async {
+      mcpServer.registerTool(
+        'array_tool',
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
+        callback: (args, extra) async {
+          return CallToolResult.fromStructuredContent(['alpha', 'beta']);
+        },
+      );
+
+      await mcpServer.connect(transport);
+      await _sendInit(transport);
+
+      final callRequest = JsonRpcCallToolRequest(
+        id: 2,
+        params: const CallToolRequest(name: 'array_tool').toJson(),
+      );
+      transport.receiveMessage(callRequest);
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      final response = transport.sentMessages.last;
+      expect(response, isA<JsonRpcResponse>());
+      final successResponse = response as JsonRpcResponse;
+      expect(successResponse.result.containsKey('structuredContent'), isFalse);
+      expect(successResponse.result['content'], isA<List<dynamic>>());
     });
 
     test('invalid output fails validation', () async {
@@ -225,6 +355,13 @@ void main() {
     });
   });
 }
+
+Map<String, dynamic> _statelessMeta() => {
+      McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
+      McpMetaKey.clientInfo:
+          const Implementation(name: 'TestClient', version: '1.0.0').toJson(),
+      McpMetaKey.clientCapabilities: const ClientCapabilities().toJson(),
+    };
 
 Future<void> _sendInit(MockTransport transport) async {
   final initRequest = JsonRpcInitializeRequest(

--- a/test/tool_schema_test.dart
+++ b/test/tool_schema_test.dart
@@ -184,6 +184,54 @@ void main() {
       );
     });
 
+    test('Tool preserves non-object output schemas for MCP 2026', () {
+      final tool = Tool(
+        name: 'list_results',
+        inputSchema: const JsonObject(),
+        outputSchema: JsonSchema.array(items: JsonSchema.string()),
+      );
+
+      final json = tool.toJson();
+      expect(json['outputSchema']['type'], equals('array'));
+      expect(json['outputSchema']['items']['type'], equals('string'));
+
+      final deserialized = Tool.fromJson(json);
+      expect(
+        deserialized.outputSchema?.toJson(),
+        equals(json['outputSchema']),
+      );
+    });
+
+    test('CallToolResult preserves arbitrary JSON structured content', () {
+      final values = <Object?>[
+        {'status': 'ok'},
+        ['alpha', 'beta'],
+        'complete',
+        42,
+        true,
+      ];
+
+      for (final value in values) {
+        final result = CallToolResult.fromStructuredContent(value);
+        final json = result.toJson();
+
+        expect(json['structuredContent'], equals(value));
+
+        final parsed = CallToolResult.fromJson(json);
+        expect(parsed.hasStructuredContent, isTrue);
+        expect(parsed.structuredContent, equals(value));
+      }
+
+      final nullResult = CallToolResult.fromStructuredContent(null);
+      final nullJson = nullResult.toJson();
+      expect(nullJson.containsKey('structuredContent'), isTrue);
+      expect(nullJson['structuredContent'], isNull);
+
+      final parsedNull = CallToolResult.fromJson(nullJson);
+      expect(parsedNull.hasStructuredContent, isTrue);
+      expect(parsedNull.structuredContent, isNull);
+    });
+
     test('Tool serializes JsonEnum properties as standard enum schema', () {
       const tool = Tool(
         name: 'configure_mode',

--- a/test/types/sampling_test.dart
+++ b/test/types/sampling_test.dart
@@ -235,6 +235,30 @@ void main() {
         expect((json['content'] as List).first['type'], equals('text'));
       });
 
+      test('toJson preserves arbitrary structured JSON values', () {
+        const content = SamplingToolResultContent(
+          toolUseId: 'res1',
+          content: [
+            TextContent(text: 'array result'),
+          ],
+          structuredContent: ['alpha', 'beta'],
+        );
+        final json = content.toJson();
+        expect(json['structuredContent'], equals(['alpha', 'beta']));
+
+        const nullContent = SamplingToolResultContent(
+          toolUseId: 'res2',
+          content: [
+            TextContent(text: 'null result'),
+          ],
+          structuredContent: null,
+          hasStructuredContent: true,
+        );
+        final nullJson = nullContent.toJson();
+        expect(nullJson.containsKey('structuredContent'), isTrue);
+        expect(nullJson['structuredContent'], isNull);
+      });
+
       test('fromJson parses correctly', () {
         final json = {
           'type': 'tool_result',
@@ -253,6 +277,35 @@ void main() {
         expect(result.structuredContent, equals({'status': 'ok'}));
         expect(result.content, hasLength(1));
         expect(result.content.first, isA<TextContent>());
+      });
+
+      test('fromJson parses arbitrary structured JSON values', () {
+        final json = {
+          'type': 'tool_result',
+          'toolUseId': 'tr1',
+          'content': [
+            {'type': 'text', 'text': 'result data'},
+          ],
+          'structuredContent': ['alpha', 'beta'],
+        };
+        final content = SamplingContent.fromJson(json);
+        expect(content, isA<SamplingToolResultContent>());
+        final result = content as SamplingToolResultContent;
+        expect(result.hasStructuredContent, isTrue);
+        expect(result.structuredContent, equals(['alpha', 'beta']));
+
+        final nullJson = {
+          'type': 'tool_result',
+          'toolUseId': 'tr2',
+          'content': [
+            {'type': 'text', 'text': 'result data'},
+          ],
+          'structuredContent': null,
+        };
+        final nullContent =
+            SamplingContent.fromJson(nullJson) as SamplingToolResultContent;
+        expect(nullContent.hasStructuredContent, isTrue);
+        expect(nullContent.structuredContent, isNull);
       });
     });
   });

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -13,6 +13,7 @@ void main() {
     test('ErrorCode.fromValue finds all standard codes', () {
       expect(ErrorCode.fromValue(-32000), equals(ErrorCode.connectionClosed));
       expect(ErrorCode.fromValue(-32001), equals(ErrorCode.requestTimeout));
+      expect(ErrorCode.fromValue(-32002), equals(ErrorCode.resourceNotFound));
       expect(ErrorCode.fromValue(-32700), equals(ErrorCode.parseError));
       expect(ErrorCode.fromValue(-32600), equals(ErrorCode.invalidRequest));
       expect(ErrorCode.fromValue(-32601), equals(ErrorCode.methodNotFound));


### PR DESCRIPTION
## Summary
- consolidate structured tool output, MRTR input-required prompt/resource results, resource-not-found behavior, MCP metadata keys, cache TTL, input responses, and elicitation result validation
- isolates cross-feature result semantics from lower-level transport enforcement
- replaces the result/input semantics portion of the prior micro-PR stack (#209-#218)

## Validation
- dart format --output=none --set-exit-if-changed .
- dart analyze
- git diff --check
- dart test
- dart pub global run coverage:test_with_coverage

Stacked on #268. This is a draft RC PR and should stay off `main` until the official spec release.