### PR TITLE
Consolidate JSON-RPC metadata hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@
   request methods.
 - Rejected MCP 2026 MRTR `inputRequests` whose embedded client request type is
   not declared in the caller's per-request client capabilities.
+- Rejected non-object `experimental` and `extensions` capability entries to
+  match the stable and MCP 2026 capability schemas.
 - Returned version-appropriate resource-not-found errors from high-level
   `resources/read` handlers: stable 2025 uses legacy `-32002`, while MCP 2026
   stateless requests use `-32602` with the missing `uri` in error data.
@@ -86,12 +88,58 @@
   clamping malformed wire values to zero.
 - Validated MRTR `inputResponses` as `CreateMessageResult`, `ListRootsResult`,
   or `ElicitResult` instead of accepting arbitrary result objects.
-- Rejected non-integer numeric `ElicitResult.content` values to match the
-  stable and MCP 2026 schemas.
+- Allowed finite numeric `ElicitResult.content` values to match the stable and
+  MCP 2026 `string | number | boolean | string[]` schema.
 - Rejected form elicitation schemas that provide legacy `enumNames` without the
   required string `enum`.
 - Rejected `ElicitResult.content` when the result action is `decline` or
   `cancel`.
+- Rejected URL elicitation values that are not absolute URIs to match the stable
+  and MCP 2026 `format: uri` schemas.
+- Rejected non-finite numeric values for progress, annotation priority, model
+  priority, and sampling temperature fields so SDK-built payloads remain valid
+  JSON numbers.
+- Rejected non-JSON values in sampling JSON object fields, including
+  `tool_use.input`, sampling metadata, annotations, and `_meta` maps.
+- Rejected non-JSON values in common content/resource metadata fields and
+  `resource_link.annotations`.
+- Reused shared JSON-object validation for MRTR, task extension, subscription,
+  and tool object fields.
+- Rejected non-JSON values in JSON-RPC envelope and remaining typed result
+  metadata fields.
+- Rejected non-JSON JSON-RPC error `data` values at parse and serialize
+  boundaries.
+- Rejected JSON-RPC response envelopes that include both `result` and `error`
+  instead of silently treating them as successful responses.
+- Rejected JSON-RPC request and notification envelopes whose `method` member is
+  not a string, and validated generic request `params` as JSON objects.
+- Rejected malformed JSON-RPC `error` objects with missing or invalid `code` or
+  `message` fields instead of surfacing Dart cast errors.
+- Rejected JSON-RPC error responses that include an explicit `id: null` member
+  while continuing to allow omitted IDs for malformed-request error cases.
+- Rejected JSON-RPC request and notification envelopes that include an explicit
+  `params: null` member, since `params` must be an object when present.
+- Prevented stateless MCP 2026 clients from sending core request and
+  notification methods removed from that protocol revision.
+- Rejected server-initiated JSON-RPC requests received by stateless MCP 2026
+  clients on generic transports.
+- Rejected stateless MCP 2026 responses that omit `resultType` or required
+  cacheable-result fields.
+- Stripped caller-supplied `Mcp-Session-Id` headers case-insensitively from
+  MCP 2026 stateless Streamable HTTP requests.
+- Derived MCP 2026 stateless Streamable HTTP headers from nested
+  `params._meta` metadata for direct JSON-RPC transport sends.
+- Allowed Streamable MCP server CORS preflights for 2026 stateless routing and
+  tool parameter headers, including requested `Mcp-Param-*` headers.
+- Serialized MRTR `ElicitResult` and `ListRootsResult` input responses with the
+  MCP 2026 embedded client-result shapes that omit common Result `_meta`.
+- Accepted finite numeric JSON-RPC request IDs and progress tokens, matching
+  the stable and MCP 2026 `string | number` schema while continuing to reject
+  non-finite numbers.
+- Allowed protocol progress handlers and `RequestHandlerExtra.sendProgress` to
+  dispatch finite numeric progress tokens end-to-end.
+- Widened protocol `relatedRequestId` API parameters to preserve string and
+  finite numeric JSON-RPC request IDs through request and notification routing.
 
 ## 2.2.0
 

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -4,6 +4,7 @@ import 'package:mcp_dart/src/shared/json_schema/json_schema_validator.dart';
 import 'package:mcp_dart/src/shared/logging.dart';
 import 'package:mcp_dart/src/shared/mcp_header_validation.dart';
 import 'package:mcp_dart/src/shared/protocol.dart';
+import 'package:mcp_dart/src/shared/task_interfaces.dart';
 import 'package:mcp_dart/src/shared/transport.dart';
 import 'package:mcp_dart/src/types.dart';
 
@@ -107,6 +108,21 @@ dynamic _deepCopy(dynamic value) {
     return value;
   }
 }
+
+const Set<String> _statelessRemovedRequestMethods = {
+  Method.initialize,
+  Method.ping,
+  Method.loggingSetLevel,
+  Method.resourcesSubscribe,
+  Method.resourcesUnsubscribe,
+  Method.tasksList,
+  Method.tasksResult,
+};
+
+const Set<String> _statelessRemovedNotificationMethods = {
+  Method.notificationsInitialized,
+  Method.notificationsRootsListChanged,
+};
 
 /// An MCP client implementation built on top of a pluggable [Transport].
 ///
@@ -463,6 +479,9 @@ class McpClient extends Protocol {
           _logger.debug(
             "server/discover not available; falling back to initialize.",
           );
+          if (transport is ProtocolVersionAwareTransport) {
+            (transport as ProtocolVersionAwareTransport).protocolVersion = null;
+          }
         }
       }
 
@@ -479,8 +498,10 @@ class McpClient extends Protocol {
     JsonRpcRequest requestData,
     T Function(Map<String, dynamic> resultJson) resultFactory, [
     RequestOptions? options,
-    int? relatedRequestId,
+    RequestId? relatedRequestId,
   ]) async {
+    _assertStatelessRequestAllowed(requestData.method);
+
     final outboundRequest =
         _usesStatelessProtocol && requestData.method != Method.serverDiscover
             ? JsonRpcRequest(
@@ -537,6 +558,44 @@ class McpClient extends Protocol {
     }
   }
 
+  @override
+  Future<void> notification(
+    JsonRpcNotification notificationData, {
+    RelatedTaskMetadata? relatedTask,
+    RequestId? relatedRequestId,
+  }) async {
+    _assertStatelessNotificationAllowed(notificationData.method);
+    await super.notification(
+      notificationData,
+      relatedTask: relatedTask,
+      relatedRequestId: relatedRequestId,
+    );
+  }
+
+  void _assertStatelessRequestAllowed(String method) {
+    if (!_usesStatelessProtocol ||
+        !_statelessRemovedRequestMethods.contains(method)) {
+      return;
+    }
+
+    throw McpError(
+      ErrorCode.methodNotFound.value,
+      'MCP $_negotiatedProtocolVersion does not define $method.',
+    );
+  }
+
+  void _assertStatelessNotificationAllowed(String method) {
+    if (!_usesStatelessProtocol ||
+        !_statelessRemovedNotificationMethods.contains(method)) {
+      return;
+    }
+
+    throw McpError(
+      ErrorCode.methodNotFound.value,
+      'MCP $_negotiatedProtocolVersion does not define $method.',
+    );
+  }
+
   /// Gets the server's reported capabilities after successful initialization.
   ServerCapabilities? getServerCapabilities() => _serverCapabilities;
 
@@ -561,6 +620,14 @@ class McpClient extends Protocol {
 
   @override
   McpError? validateIncomingRequest(JsonRpcRequest request) {
+    if (_usesStatelessProtocol) {
+      return McpError(
+        ErrorCode.invalidRequest.value,
+        'Server-initiated JSON-RPC requests are not supported in stateless '
+        'MCP; return input_required with inputRequests instead.',
+      );
+    }
+
     if (_sentInitialized || request.method == Method.ping) {
       return null;
     }

--- a/lib/src/client/streamable_https.dart
+++ b/lib/src/client/streamable_https.dart
@@ -537,6 +537,19 @@ class StreamableHttpClientTransport
     return headers;
   }
 
+  void _removeHeaderCaseInsensitive(
+    Map<String, String> headers,
+    String headerName,
+  ) {
+    final normalizedHeaderName = headerName.toLowerCase();
+    final matchingKeys = headers.keys
+        .where((key) => key.toLowerCase() == normalizedHeaderName)
+        .toList();
+    for (final key in matchingKeys) {
+      headers.remove(key);
+    }
+  }
+
   Map<String, String> _headersForMessage(JsonRpcMessage message) {
     final headers = <String, String>{};
     final protocolVersion = _protocolVersion ?? _protocolVersionFrom(message);
@@ -702,11 +715,24 @@ class StreamableHttpClientTransport
   }
 
   Map<String, dynamic>? _metaFrom(JsonRpcMessage message) {
+    final Map<String, dynamic>? directMeta;
     if (message is JsonRpcRequest) {
-      return message.meta;
+      directMeta = message.meta;
+    } else if (message is JsonRpcNotification) {
+      directMeta = message.meta;
+    } else {
+      return null;
     }
-    if (message is JsonRpcNotification) {
-      return message.meta;
+    if (directMeta != null) {
+      return directMeta;
+    }
+
+    final paramsMeta = _paramsFrom(message)?['_meta'];
+    if (paramsMeta is Map<String, dynamic>) {
+      return paramsMeta;
+    }
+    if (paramsMeta is Map) {
+      return paramsMeta.cast<String, dynamic>();
     }
     return null;
   }
@@ -1218,7 +1244,7 @@ class StreamableHttpClientTransport
       final isStatelessRequest = protocolVersion != null &&
           isStatelessProtocolVersion(protocolVersion);
       if (isStatelessRequest) {
-        headers.remove('mcp-session-id');
+        _removeHeaderCaseInsensitive(headers, 'mcp-session-id');
       }
       final requestSessionId = headers['mcp-session-id'];
       headers['content-type'] = 'application/json';

--- a/lib/src/server/streamable_mcp_server.dart
+++ b/lib/src/server/streamable_mcp_server.dart
@@ -7,8 +7,22 @@ import 'package:mcp_dart/src/server/dns_rebinding_protection.dart';
 import 'package:mcp_dart/src/server/mcp_server.dart';
 import 'package:mcp_dart/src/server/streamable_https.dart';
 import 'package:mcp_dart/src/shared/logging.dart';
+import 'package:mcp_dart/src/shared/mcp_header_validation.dart';
 import 'package:mcp_dart/src/shared/uuid.dart';
 import 'package:mcp_dart/src/types.dart';
+
+const List<String> _defaultCorsAllowedHeaders = [
+  'Origin',
+  'X-Requested-With',
+  'Content-Type',
+  'Accept',
+  'mcp-session-id',
+  'Last-Event-ID',
+  'Authorization',
+  'MCP-Protocol-Version',
+  'Mcp-Method',
+  'Mcp-Name',
+];
 
 String _quoteHeaderValue(String value) {
   const backslash = '\\';
@@ -344,7 +358,7 @@ class StreamableMcpServer {
   }
 
   Future<void> _handleRequest(HttpRequest request) async {
-    _setCorsHeaders(request.response);
+    _setCorsHeaders(request, request.response);
 
     if (enableDnsRebindingProtection &&
         !isRequestAllowedByDnsRebindingProtection(
@@ -693,14 +707,6 @@ class StreamableMcpServer {
   }
 
   String? _bodyProtocolVersion(Map<String, dynamic> body) {
-    final topLevelMeta = body['_meta'];
-    if (topLevelMeta is Map) {
-      final version = topLevelMeta[McpMetaKey.protocolVersion];
-      if (version is String) {
-        return version;
-      }
-    }
-
     final params = body['params'];
     if (params is Map) {
       final meta = params['_meta'];
@@ -709,6 +715,14 @@ class StreamableMcpServer {
         if (version is String) {
           return version;
         }
+      }
+    }
+
+    final topLevelMeta = body['_meta'];
+    if (topLevelMeta is Map) {
+      final version = topLevelMeta[McpMetaKey.protocolVersion];
+      if (version is String) {
+        return version;
       }
     }
 
@@ -899,13 +913,46 @@ class StreamableMcpServer {
     await response.close();
   }
 
-  void _setCorsHeaders(HttpResponse response) {
+  String _corsAllowedHeaders(HttpRequest request) {
+    final allowedHeaders = <String>[];
+    final seenHeaders = <String>{};
+
+    void addAllowedHeader(String headerName) {
+      final normalized = headerName.toLowerCase();
+      if (seenHeaders.add(normalized)) {
+        allowedHeaders.add(headerName);
+      }
+    }
+
+    for (final headerName in _defaultCorsAllowedHeaders) {
+      addAllowedHeader(headerName);
+    }
+
+    final requestedHeaders =
+        request.headers.value('access-control-request-headers');
+    if (requestedHeaders == null) {
+      return allowedHeaders.join(', ');
+    }
+
+    for (final rawHeaderName in requestedHeaders.split(',')) {
+      final headerName = rawHeaderName.trim();
+      if (headerName.isEmpty ||
+          !headerName.codeUnits.every(isHttpFieldNameTokenChar)) {
+        continue;
+      }
+      addAllowedHeader(headerName);
+    }
+
+    return allowedHeaders.join(', ');
+  }
+
+  void _setCorsHeaders(HttpRequest request, HttpResponse response) {
     response.headers.set('Access-Control-Allow-Origin', '*');
     response.headers
         .set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
     response.headers.set(
       'Access-Control-Allow-Headers',
-      'Origin, X-Requested-With, Content-Type, Accept, mcp-session-id, Last-Event-ID, Authorization, MCP-Protocol-Version',
+      _corsAllowedHeaders(request),
     );
     response.headers.set('Access-Control-Allow-Credentials', 'true');
     response.headers.set('Access-Control-Max-Age', defaultCorsMaxAgeSeconds);

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -9,7 +9,18 @@ import 'transport.dart';
 
 final _logger = Logger("mcp_dart.shared.protocol");
 
-bool _isProgressToken(Object? token) => token is int || token is String;
+bool _isProgressToken(Object? token) =>
+    token is String ||
+    token is int ||
+    (token is double && token.isFinite && token == token.truncateToDouble());
+
+const Set<String> _statelessCacheableResultMethods = {
+  Method.toolsList,
+  Method.promptsList,
+  Method.resourcesList,
+  Method.resourcesTemplatesList,
+  Method.resourcesRead,
+};
 
 final _lastProgressByExtra = Expando<double>();
 final _subscriptionStateByExtra = Expando<_SubscriptionStreamState>();
@@ -192,10 +203,10 @@ class RequestHandlerExtra {
       return;
     }
 
-    // progressToken can be int or string
-    if (progressToken is! int && progressToken is! String) {
+    if (!_isProgressToken(progressToken)) {
       _logger.warn(
-        "Invalid progressToken type: ${progressToken.runtimeType}. Expected int or String.",
+        "Invalid progressToken type: ${progressToken.runtimeType}. "
+        "Expected string or integer.",
       );
       return;
     }
@@ -508,13 +519,41 @@ abstract class Protocol {
 
     final resultType = resultJson['resultType'];
     if (resultType == null) {
-      return;
+      throw const FormatException(
+        'MCP stateless responses must include resultType',
+      );
     }
     if (resultType is! String) {
       throw const FormatException('MCP resultType must be a string');
     }
     if (!isRecognizedResultType(resultType)) {
       throw FormatException('Unrecognized MCP resultType "$resultType"');
+    }
+
+    if (resultType == resultTypeComplete &&
+        _statelessCacheableResultMethods.contains(request.method)) {
+      _validateStatelessCacheableResult(request, resultJson);
+    }
+  }
+
+  void _validateStatelessCacheableResult(
+    JsonRpcRequest request,
+    Map<String, dynamic> resultJson,
+  ) {
+    final ttlMs = resultJson['ttlMs'];
+    if (ttlMs is! int || ttlMs < 0) {
+      throw FormatException(
+        'MCP stateless ${request.method} responses must include '
+        'a non-negative integer ttlMs',
+      );
+    }
+
+    final cacheScope = resultJson['cacheScope'];
+    if (cacheScope != CacheScope.private && cacheScope != CacheScope.public) {
+      throw FormatException(
+        'MCP stateless ${request.method} responses must include '
+        'cacheScope "private" or "public"',
+      );
     }
   }
 
@@ -1390,7 +1429,8 @@ abstract class Protocol {
     if (!_isProgressToken(progressToken)) {
       _onerror(
         ArgumentError(
-          "Received invalid progressToken: $progressToken. Expected int or String.",
+          "Received invalid progressToken: $progressToken. "
+          "Expected string or integer.",
         ),
       );
       return;
@@ -1536,7 +1576,7 @@ abstract class Protocol {
     JsonRpcRequest requestData,
     T Function(Map<String, dynamic> resultJson) resultFactory, [
     RequestOptions? options,
-    int? relatedRequestId,
+    RequestId? relatedRequestId,
   ]) {
     return _requestWithRequestId(
       requestData,
@@ -1612,7 +1652,8 @@ abstract class Protocol {
         if (!_isProgressToken(requestedProgressToken)) {
           return Future.error(
             ArgumentError(
-              'progressToken must be an int or String when onprogress is set.',
+              'progressToken must be a string or integer when '
+              'onprogress is set.',
             ),
           );
         }
@@ -1922,7 +1963,7 @@ abstract class Protocol {
   Future<void> notification(
     JsonRpcNotification notificationData, {
     RelatedTaskMetadata? relatedTask,
-    int? relatedRequestId,
+    RequestId? relatedRequestId,
   }) {
     return _notificationWithRequestId(
       notificationData,

--- a/lib/src/shared/transport.dart
+++ b/lib/src/shared/transport.dart
@@ -45,7 +45,8 @@ abstract class Transport {
 }
 
 /// Optional capability for transports that can preserve JSON-RPC request IDs
-/// with their full MCP shape (string or integer) for request/stream correlation.
+/// with their full MCP shape (string or integer) for request/stream
+/// correlation.
 ///
 /// Existing custom transports can keep implementing [Transport.send] with
 /// `int? relatedRequestId`. Transports that need to route messages by string
@@ -59,7 +60,7 @@ abstract class RequestIdAwareTransport {
 }
 
 extension RequestIdAwareTransportSend on Transport {
-  /// Sends [message] while preserving string request IDs when the transport
+  /// Sends [message] while preserving non-integer request IDs when the transport
   /// supports [RequestIdAwareTransport].
   ///
   /// Legacy transports receive only integer IDs, matching the existing public

--- a/lib/src/types/completion.dart
+++ b/lib/src/types/completion.dart
@@ -1,4 +1,5 @@
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// Sealed class representing a reference for autocompletion targets.
 sealed class Reference {
@@ -236,7 +237,7 @@ class CompleteResult implements BaseResultData {
   const CompleteResult({required this.completion, this.meta});
 
   factory CompleteResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(json['_meta'], 'CompleteResult._meta');
     return CompleteResult(
       completion: CompletionResultData.fromJson(
         json['completion'] as Map<String, dynamic>,
@@ -248,7 +249,7 @@ class CompleteResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         'completion': completion.toJson(),
-        if (meta != null) '_meta': meta,
+        if (meta != null) '_meta': readJsonObject(meta, 'CompleteResult._meta'),
       };
 }
 

--- a/lib/src/types/content.dart
+++ b/lib/src/types/content.dart
@@ -1,25 +1,22 @@
 import 'validation.dart';
 
-Map<String, dynamic>? _asJsonObjectOrNull(dynamic value) {
+Map<String, dynamic>? _asJsonObjectOrNull(
+  dynamic value, [
+  String field = 'object',
+]) {
   if (value == null) {
     return null;
   }
-
-  if (value is Map<String, dynamic>) {
-    return value;
-  }
-
-  if (value is Map) {
-    return value.cast<String, dynamic>();
-  }
-
-  throw FormatException('Expected object, got ${value.runtimeType}');
+  return readJsonObject(value, field);
 }
 
-Map<String, dynamic> _asJsonObject(dynamic value) {
-  final map = _asJsonObjectOrNull(value);
+Map<String, dynamic> _asJsonObject(
+  dynamic value, [
+  String field = 'object',
+]) {
+  final map = _asJsonObjectOrNull(value, field);
   if (map == null) {
-    throw const FormatException('Expected object, got null');
+    throw FormatException('$field must be a JSON object');
   }
   return map;
 }
@@ -93,7 +90,10 @@ sealed class ResourceContents {
   factory ResourceContents.fromJson(Map<String, dynamic> json) {
     final uri = json['uri'] as String;
     final mimeType = json['mimeType'] as String?;
-    final meta = _asJsonObjectOrNull(json['_meta']);
+    final meta = _asJsonObjectOrNull(
+      json['_meta'],
+      'ResourceContents._meta',
+    );
     final extra = Map<String, dynamic>.from(json)
       ..removeWhere(
         (key, value) =>
@@ -104,7 +104,8 @@ sealed class ResourceContents {
             key == '_meta',
       );
 
-    final passthrough = extra.isEmpty ? null : extra;
+    final passthrough =
+        extra.isEmpty ? null : readJsonObject(extra, 'ResourceContents.extra');
 
     if (json.containsKey('text')) {
       return TextResourceContents(
@@ -141,8 +142,9 @@ sealed class ResourceContents {
           final BlobResourceContents c => {'blob': c.blob},
           UnknownResourceContents _ => {},
         },
-        if (meta != null) '_meta': meta,
-        ...?extra,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'ResourceContents._meta'),
+        if (extra != null) ...readJsonObject(extra, 'ResourceContents.extra'),
       };
 }
 
@@ -259,20 +261,23 @@ sealed class Content {
           final TextContent c => {
               'text': c.text,
               if (c.annotations != null) 'annotations': c.annotations!.toJson(),
-              if (c.meta != null) '_meta': c.meta,
+              if (c.meta != null)
+                '_meta': readJsonObject(c.meta, 'TextContent._meta'),
             },
           final ImageContent c => {
               'data': c.data,
               'mimeType': c.mimeType,
               if (c.theme != null) 'theme': c.theme,
               if (c.annotations != null) 'annotations': c.annotations!.toJson(),
-              if (c.meta != null) '_meta': c.meta,
+              if (c.meta != null)
+                '_meta': readJsonObject(c.meta, 'ImageContent._meta'),
             },
           final AudioContent c => {
               'data': c.data,
               'mimeType': c.mimeType,
               if (c.annotations != null) 'annotations': c.annotations!.toJson(),
-              if (c.meta != null) '_meta': c.meta,
+              if (c.meta != null)
+                '_meta': readJsonObject(c.meta, 'AudioContent._meta'),
             },
           final ResourceLink c => {
               'uri': c.uri,
@@ -283,13 +288,19 @@ sealed class Content {
               if (c.size != null) 'size': c.size,
               if (c.icons != null)
                 'icons': c.icons!.map((icon) => icon.toJson()).toList(),
-              if (c.annotations != null) 'annotations': c.annotations,
-              if (c.meta != null) '_meta': c.meta,
+              if (c.annotations != null)
+                'annotations': readJsonObject(
+                  c.annotations,
+                  'ResourceLink.annotations',
+                ),
+              if (c.meta != null)
+                '_meta': readJsonObject(c.meta, 'ResourceLink._meta'),
             },
           final EmbeddedResource c => {
               'resource': c.resource.toJson(),
               if (c.annotations != null) 'annotations': c.annotations!.toJson(),
-              if (c.meta != null) '_meta': c.meta,
+              if (c.meta != null)
+                '_meta': readJsonObject(c.meta, 'EmbeddedResource._meta'),
             },
           UnknownContent _ => {},
         },
@@ -318,8 +329,10 @@ class TextContent extends Content {
       text: json['text'] as String,
       annotations: json['annotations'] == null
           ? null
-          : Annotations.fromJson(_asJsonObject(json['annotations'])),
-      meta: _asJsonObjectOrNull(json['_meta']),
+          : Annotations.fromJson(
+              _asJsonObject(json['annotations'], 'TextContent.annotations'),
+            ),
+      meta: _asJsonObjectOrNull(json['_meta'], 'TextContent._meta'),
     );
   }
 }
@@ -356,8 +369,10 @@ class ImageContent extends Content {
       theme: json['theme'] as String?,
       annotations: json['annotations'] == null
           ? null
-          : Annotations.fromJson(_asJsonObject(json['annotations'])),
-      meta: _asJsonObjectOrNull(json['_meta']),
+          : Annotations.fromJson(
+              _asJsonObject(json['annotations'], 'ImageContent.annotations'),
+            ),
+      meta: _asJsonObjectOrNull(json['_meta'], 'ImageContent._meta'),
     );
   }
 }
@@ -388,8 +403,10 @@ class AudioContent extends Content {
       mimeType: json['mimeType'] as String,
       annotations: json['annotations'] == null
           ? null
-          : Annotations.fromJson(_asJsonObject(json['annotations'])),
-      meta: _asJsonObjectOrNull(json['_meta']),
+          : Annotations.fromJson(
+              _asJsonObject(json['annotations'], 'AudioContent.annotations'),
+            ),
+      meta: _asJsonObjectOrNull(json['_meta'], 'AudioContent._meta'),
     );
   }
 }
@@ -414,12 +431,17 @@ class EmbeddedResource extends Content {
   factory EmbeddedResource.fromJson(Map<String, dynamic> json) {
     return EmbeddedResource(
       resource: ResourceContents.fromJson(
-        _asJsonObject(json['resource']),
+        _asJsonObject(json['resource'], 'EmbeddedResource.resource'),
       ),
       annotations: json['annotations'] == null
           ? null
-          : Annotations.fromJson(_asJsonObject(json['annotations'])),
-      meta: _asJsonObjectOrNull(json['_meta']),
+          : Annotations.fromJson(
+              _asJsonObject(
+                json['annotations'],
+                'EmbeddedResource.annotations',
+              ),
+            ),
+      meta: _asJsonObjectOrNull(json['_meta'], 'EmbeddedResource._meta'),
     );
   }
 }
@@ -480,8 +502,11 @@ class ResourceLink extends Content {
       icons: (json['icons'] as List<dynamic>?)
           ?.map((icon) => McpIcon.fromJson(_asJsonObject(icon)))
           .toList(),
-      annotations: _asJsonObjectOrNull(json['annotations']),
-      meta: _asJsonObjectOrNull(json['_meta']),
+      annotations: _asJsonObjectOrNull(
+        json['annotations'],
+        'ResourceLink.annotations',
+      ),
+      meta: _asJsonObjectOrNull(json['_meta'], 'ResourceLink._meta'),
     );
   }
 }

--- a/lib/src/types/elicitation.dart
+++ b/lib/src/types/elicitation.dart
@@ -1,5 +1,6 @@
 import '../shared/json_schema/json_schema.dart';
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// Legacy alias for [JsonSchema] used in elicitation requests.
 typedef ElicitationInputSchema = JsonSchema;
@@ -114,6 +115,7 @@ class ElicitRequest {
       if (url is! String) {
         throw const FormatException('URL elicitation requires url.');
       }
+      _validateUrlElicitationUri(url, formatException: true);
       if (elicitationId is! String) {
         throw const FormatException('URL elicitation requires elicitationId.');
       }
@@ -159,6 +161,7 @@ class ElicitRequest {
       if (url == null) {
         throw ArgumentError('URL elicitation requires url.');
       }
+      _validateUrlElicitationUri(url!);
       if (elicitationId == null) {
         throw ArgumentError('URL elicitation requires elicitationId.');
       }
@@ -279,7 +282,7 @@ class ElicitResult implements BaseResultData {
       content: content,
       url: json['url'] as String?,
       elicitationId: json['elicitationId'] as String?,
-      meta: (json['_meta'] as Map?)?.cast<String, dynamic>(),
+      meta: readOptionalJsonObject(json['_meta'], 'ElicitResult._meta'),
     );
   }
 
@@ -291,7 +294,7 @@ class ElicitResult implements BaseResultData {
     return {
       'action': resultAction,
       if (content != null) 'content': content,
-      if (meta != null) '_meta': meta,
+      if (meta != null) '_meta': readJsonObject(meta, 'ElicitResult._meta'),
     };
   }
 
@@ -366,7 +369,10 @@ class JsonRpcElicitationCompleteNotification extends JsonRpcNotification {
         "Missing params for elicitation complete notification",
       );
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      paramsMap['_meta'],
+      'JsonRpcElicitationCompleteNotification._meta',
+    );
     return JsonRpcElicitationCompleteNotification(
       completeParams: ElicitationCompleteNotification.fromJson(paramsMap),
       meta: meta,
@@ -628,7 +634,10 @@ void _validateElicitResultContent(
   }
   for (final entry in content.entries) {
     final value = entry.value;
-    if (value is String || value is int || value is bool) {
+    if (value is String || value is bool) {
+      continue;
+    }
+    if (value is num && value.isFinite) {
       continue;
     }
     if (value is List && value.every((item) => item is String)) {
@@ -636,13 +645,13 @@ void _validateElicitResultContent(
     }
     if (formatException) {
       throw FormatException(
-        'ElicitResult.content.${entry.key} must be string, integer, boolean, or string[]',
+        'ElicitResult.content.${entry.key} must be string, finite number, boolean, or string[]',
       );
     }
     throw ArgumentError.value(
       value,
       'content.${entry.key}',
-      'ElicitResult content values must be string, integer, boolean, or string[]',
+      'ElicitResult content values must be string, finite number, boolean, or string[]',
     );
   }
 }
@@ -685,4 +694,24 @@ void _validateUrlElicitations(
       );
     }
   }
+}
+
+void _validateUrlElicitationUri(
+  String url, {
+  bool formatException = false,
+}) {
+  final uri = Uri.tryParse(url);
+  if (uri != null && uri.hasScheme) {
+    return;
+  }
+  if (formatException) {
+    throw const FormatException(
+      'URL elicitation url must be an absolute URI.',
+    );
+  }
+  throw ArgumentError.value(
+    url,
+    'url',
+    'URL elicitation url must be an absolute URI.',
+  );
 }

--- a/lib/src/types/initialization.dart
+++ b/lib/src/types/initialization.dart
@@ -1,5 +1,6 @@
 import 'content.dart';
 import 'json_rpc.dart';
+import 'validation.dart';
 
 Map<String, dynamic>? _asJsonObject(dynamic value) {
   if (value == null) {
@@ -15,6 +16,74 @@ Map<String, dynamic>? _asJsonObject(dynamic value) {
     return value ? <String, dynamic>{} : null;
   }
   throw FormatException('Expected object capability, got ${value.runtimeType}');
+}
+
+Map<String, dynamic>? _asStrictJsonObject(Object? value, String field) {
+  if (value == null) {
+    return null;
+  }
+  if (value is Map<String, dynamic>) {
+    return value;
+  }
+  if (value is Map) {
+    if (value.keys.any((key) => key is! String)) {
+      throw FormatException('$field must be an object with string keys');
+    }
+    return value.cast<String, dynamic>();
+  }
+  throw FormatException('$field must be an object');
+}
+
+Map<String, dynamic>? _asJsonObjectMap(Object? value, String field) {
+  final map = _asStrictJsonObject(value, field);
+  if (map == null) {
+    return null;
+  }
+
+  return map.map((key, item) {
+    final object = _asStrictJsonObject(item, '$field.$key');
+    if (object == null) {
+      throw FormatException('$field.$key must be an object');
+    }
+    return MapEntry(key, object);
+  });
+}
+
+Map<String, dynamic>? _serializeJsonObjectMap(
+  Map<String, dynamic>? value,
+  String field,
+) {
+  if (value == null) {
+    return null;
+  }
+
+  return value.map((key, item) {
+    final object = _asStrictJsonObject(item, '$field.$key');
+    if (object == null) {
+      throw ArgumentError.value(item, '$field.$key', 'must be an object');
+    }
+    return MapEntry(key, object);
+  });
+}
+
+Map<String, Map<String, dynamic>>? _asExtensionMap(
+  Object? value,
+  String field,
+) {
+  final map = _asJsonObjectMap(value, field);
+  return map?.map(
+    (key, value) => MapEntry(key, value.cast<String, dynamic>()),
+  );
+}
+
+Map<String, Map<String, dynamic>>? _serializeExtensionMap(
+  Map<String, Map<String, dynamic>>? value,
+  String field,
+) {
+  final map = _serializeJsonObjectMap(value, field);
+  return map?.map(
+    (key, value) => MapEntry(key, value.cast<String, dynamic>()),
+  );
 }
 
 bool? _capabilityDeclared(dynamic value) {
@@ -380,6 +449,9 @@ class ClientCapabilitiesTasks {
 /// Capabilities a client may support.
 class ClientCapabilities {
   /// Experimental, non-standard capabilities.
+  ///
+  /// Each capability value must be a JSON object. Use an empty object to
+  /// advertise support without settings.
   final Map<String, dynamic>? experimental;
 
   /// Present if the client supports sampling (`sampling/createMessage`).
@@ -414,10 +486,16 @@ class ClientCapabilities {
     final elicitationMap = _asJsonObject(json['elicitation']);
     final tasksMap = _asJsonObject(json['tasks']);
     final samplingMap = _asJsonObject(json['sampling']);
-    final extensionsMap = _asJsonObject(json['extensions']);
+    final extensionsMap = _asExtensionMap(
+      json['extensions'],
+      'ClientCapabilities.extensions',
+    );
 
     return ClientCapabilities(
-      experimental: json['experimental'] as Map<String, dynamic>?,
+      experimental: _asJsonObjectMap(
+        json['experimental'],
+        'ClientCapabilities.experimental',
+      ),
       sampling: samplingMap == null
           ? null
           : ClientCapabilitiesSampling.fromJson(samplingMap),
@@ -428,19 +506,25 @@ class ClientCapabilities {
           : ClientElicitation.fromJson(elicitationMap),
       tasks:
           tasksMap == null ? null : ClientCapabilitiesTasks.fromJson(tasksMap),
-      extensions: extensionsMap?.map(
-        (key, value) => MapEntry(key, Map<String, dynamic>.from(value as Map)),
-      ),
+      extensions: extensionsMap,
     );
   }
 
   Map<String, dynamic> toJson() => {
-        if (experimental != null) 'experimental': experimental,
+        if (experimental != null)
+          'experimental': _serializeJsonObjectMap(
+            experimental,
+            'ClientCapabilities.experimental',
+          ),
         if (sampling != null) 'sampling': sampling!.toJson(),
         if (roots != null) 'roots': roots!.toJson(),
         if (elicitation != null) 'elicitation': elicitation!.toJson(),
         if (tasks != null) 'tasks': tasks!.toJson(),
-        if (extensions != null) 'extensions': extensions,
+        if (extensions != null)
+          'extensions': _serializeExtensionMap(
+            extensions,
+            'ClientCapabilities.extensions',
+          ),
       };
 
   /// Whether the MCP Tasks extension is declared.
@@ -516,10 +600,43 @@ class JsonRpcServerDiscoverRequest extends JsonRpcRequest {
   }) : super(method: Method.serverDiscover);
 
   factory JsonRpcServerDiscoverRequest.fromJson(Map<String, dynamic> json) {
+    final params = readJsonObject(
+      json['params'],
+      'JsonRpcServerDiscoverRequest.params',
+    );
+    final meta = validateRequestMeta(
+      readJsonObject(
+        params['_meta'],
+        'JsonRpcServerDiscoverRequest.params._meta',
+      ),
+      validateKeys: true,
+    )!;
+
     return JsonRpcServerDiscoverRequest(
       id: parseRequestId(json['id']),
-      meta: extractRequestMeta(json),
+      meta: meta,
     );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    final meta = this.meta;
+    if (meta == null) {
+      throw const FormatException(
+        'JsonRpcServerDiscoverRequest.params._meta is required',
+      );
+    }
+    return {
+      'jsonrpc': jsonrpc,
+      'id': parseRequestId(id, fieldName: 'JsonRpcServerDiscoverRequest.id'),
+      'method': method,
+      'params': <String, dynamic>{
+        '_meta': readJsonObject(
+          validateRequestMeta(meta, validateKeys: true),
+          'JsonRpcServerDiscoverRequest.params._meta',
+        ),
+      },
+    };
   }
 }
 
@@ -778,6 +895,9 @@ class ServerCapabilitiesTasks {
 /// Capabilities a server may support.
 class ServerCapabilities {
   /// Experimental, non-standard capabilities.
+  ///
+  /// Each capability value must be a JSON object. Use an empty object to
+  /// advertise support without settings.
   final Map<String, dynamic>? experimental;
 
   /// Present if the server supports sending log messages (`notifications/message`).
@@ -829,10 +949,16 @@ class ServerCapabilities {
     final tMap = _asJsonObject(json['tools']);
     final tasksMap = _asJsonObject(json['tasks']);
     final elicitationMap = _asJsonObject(json['elicitation']);
-    final extensionsMap = _asJsonObject(json['extensions']);
+    final extensionsMap = _asExtensionMap(
+      json['extensions'],
+      'ServerCapabilities.extensions',
+    );
 
     return ServerCapabilities(
-      experimental: json['experimental'] as Map<String, dynamic>?,
+      experimental: _asJsonObjectMap(
+        json['experimental'],
+        'ServerCapabilities.experimental',
+      ),
       logging: json['logging'] as Map<String, dynamic>?,
       prompts: pMap == null ? null : ServerCapabilitiesPrompts.fromJson(pMap),
       resources:
@@ -845,21 +971,27 @@ class ServerCapabilities {
       elicitation: elicitationMap == null
           ? null
           : ServerCapabilitiesElicitation.fromJson(elicitationMap),
-      extensions: extensionsMap?.map(
-        (key, value) => MapEntry(key, Map<String, dynamic>.from(value as Map)),
-      ),
+      extensions: extensionsMap,
     );
   }
 
   Map<String, dynamic> toJson() => {
-        if (experimental != null) 'experimental': experimental,
+        if (experimental != null)
+          'experimental': _serializeJsonObjectMap(
+            experimental,
+            'ServerCapabilities.experimental',
+          ),
         if (logging != null) 'logging': logging,
         if (prompts != null) 'prompts': prompts!.toJson(),
         if (resources != null) 'resources': resources!.toJson(),
         if (tools != null) 'tools': tools!.toJson(),
         if (completions != null) 'completions': completions!.toJson(),
         if (tasks != null) 'tasks': tasks!.toJson(),
-        if (extensions != null) 'extensions': extensions,
+        if (extensions != null)
+          'extensions': _serializeExtensionMap(
+            extensions,
+            'ServerCapabilities.extensions',
+          ),
       };
 
   /// Whether the MCP Tasks extension is declared.
@@ -894,7 +1026,8 @@ class InitializeResult implements BaseResultData {
   });
 
   factory InitializeResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta =
+        readOptionalJsonObject(json['_meta'], 'InitializeResult._meta');
     return InitializeResult(
       protocolVersion: json['protocolVersion'] as String,
       capabilities: ServerCapabilities.fromJson(
@@ -914,7 +1047,8 @@ class InitializeResult implements BaseResultData {
         'capabilities': capabilities.toJson(),
         'serverInfo': serverInfo.toJson(),
         if (instructions != null) 'instructions': instructions,
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'InitializeResult._meta'),
       };
 }
 
@@ -966,7 +1100,7 @@ class DiscoverResult implements BaseResultData {
         json['serverInfo'] as Map<String, dynamic>,
       ),
       instructions: json['instructions'] as String?,
-      meta: json['_meta'] as Map<String, dynamic>?,
+      meta: readOptionalJsonObject(json['_meta'], 'DiscoverResult._meta'),
     );
   }
 
@@ -977,7 +1111,7 @@ class DiscoverResult implements BaseResultData {
         'capabilities': capabilities.toJson(),
         'serverInfo': serverInfo.toJson(),
         if (instructions != null) 'instructions': instructions,
-        if (meta != null) '_meta': meta,
+        if (meta != null) '_meta': readJsonObject(meta, 'DiscoverResult._meta'),
       };
 }
 

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -165,11 +165,16 @@ ProgressToken parseProgressToken(
   Object? value, {
   String fieldName = 'progressToken',
 }) {
-  if (value is String || value is int) {
+  if (value is String) {
     return value;
   }
+  final integer = readOptionalInteger(value, fieldName);
+  if (integer != null) {
+    return integer;
+  }
   throw FormatException(
-    'Invalid $fieldName: expected string or integer, got ${value.runtimeType}',
+    'Invalid $fieldName: expected string or integer, '
+    'got ${value.runtimeType}',
   );
 }
 
@@ -185,12 +190,42 @@ typedef RequestId = dynamic;
 /// boundaries. Notifications omit the `id` member entirely, and responses may
 /// omit the `id` member for JSON-RPC error cases.
 RequestId parseRequestId(Object? value, {String fieldName = 'id'}) {
-  if (value is String || value is int) {
+  if (value is String) {
+    return value;
+  }
+  final integer = readOptionalInteger(value, fieldName);
+  if (integer != null) {
+    return integer;
+  }
+  throw FormatException(
+    'Invalid $fieldName: expected string or integer, '
+    'got ${value.runtimeType}',
+  );
+}
+
+String _parseMethod(Object? value) {
+  if (value is String) {
     return value;
   }
   throw FormatException(
-    'Invalid $fieldName: expected string or integer, got ${value.runtimeType}',
+    'Invalid method: expected string, got ${value.runtimeType}',
   );
+}
+
+int _parseErrorCode(Object? value) {
+  final code = readOptionalInteger(value, 'JsonRpcErrorData.code');
+  if (code == null) {
+    throw const FormatException('JsonRpcErrorData.code is required');
+  }
+  return code;
+}
+
+String _parseErrorMessage(Object? value) {
+  final message = readOptionalString(value, 'JsonRpcErrorData.message');
+  if (message == null) {
+    throw const FormatException('JsonRpcErrorData.message is required');
+  }
+  return message;
 }
 
 RequestId _parseResultResponseId(Object? value) {
@@ -198,10 +233,24 @@ RequestId _parseResultResponseId(Object? value) {
 }
 
 RequestId? _parseErrorResponseId(Map<String, dynamic> json) {
-  if (!json.containsKey('id') || json['id'] == null) {
+  if (!json.containsKey('id')) {
     return null;
   }
   return parseRequestId(json['id']);
+}
+
+Map<String, dynamic>? _parseOptionalParamsObject(
+  Map<String, dynamic> json,
+  String fieldName,
+) {
+  if (!json.containsKey('params')) {
+    return null;
+  }
+  return readJsonObject(json['params'], fieldName);
+}
+
+Object _requestIdToJson(RequestId id, String fieldName) {
+  return parseRequestId(id, fieldName: fieldName);
 }
 
 final _metaPrefixLabelPattern = RegExp(
@@ -247,8 +296,8 @@ void validateMetaKeyName(String key, {String fieldName = '_meta'}) {
 /// Validates request metadata that can affect protocol behavior.
 ///
 /// `_meta.progressToken` is an MCP wire token and must be a string or integer
-/// when present. [validateKeys] opts in to the MCP 2026 `_meta` key-name
-/// grammar without changing stable/legacy request parsing.
+/// when present. [validateKeys] opts in to the MCP 2026 `_meta`
+/// key-name grammar without changing stable/legacy request parsing.
 Map<String, dynamic>? validateRequestMeta(
   Map<String, dynamic>? meta, {
   bool validateKeys = false,
@@ -276,23 +325,15 @@ Map<String, dynamic>? _parseRequestMeta(Object? value) {
   if (value == null) {
     return null;
   }
-  if (value is! Map) {
-    throw FormatException(
-      'Invalid _meta: expected object, got ${value.runtimeType}',
-    );
-  }
-  if (value.keys.any((key) => key is! String)) {
-    throw const FormatException('Invalid _meta: expected string keys');
-  }
-  return validateRequestMeta(Map<String, dynamic>.from(value));
+  return validateRequestMeta(readJsonObject(value, '_meta'));
 }
 
-/// Extracts request metadata from either top-level or params-nested `_meta`.
+/// Extracts request metadata, preferring spec-defined params-nested `_meta`.
 Map<String, dynamic>? extractRequestMeta(Map<String, dynamic> json) {
   final topLevelMeta = _parseRequestMeta(json['_meta']);
   final params = json['params'];
   final paramsMeta = params is Map ? _parseRequestMeta(params['_meta']) : null;
-  return topLevelMeta ?? paramsMeta;
+  return paramsMeta ?? topLevelMeta;
 }
 
 /// Base class for all JSON-RPC messages (requests, notifications, responses, errors).
@@ -309,9 +350,16 @@ sealed class JsonRpcMessage {
       throw FormatException('Invalid JSON-RPC version: ${json['jsonrpc']}');
     }
 
+    final hasResult = json.containsKey('result');
+    final hasError = json.containsKey('error');
+
     if (json.containsKey('method')) {
-      final method = json['method'] as String;
+      final method = _parseMethod(json['method']);
       final hasId = json.containsKey('id');
+      final params = _parseOptionalParamsObject(
+        json,
+        hasId ? 'JsonRpcRequest.params' : 'JsonRpcNotification.params',
+      );
 
       if (hasId) {
         return switch (method) {
@@ -346,7 +394,7 @@ sealed class JsonRpcMessage {
           _ => JsonRpcRequest(
               id: parseRequestId(json['id']),
               method: method,
-              params: json['params'] as Map<String, dynamic>?,
+              params: params,
               meta: extractRequestMeta(json),
             ),
         };
@@ -386,21 +434,27 @@ sealed class JsonRpcMessage {
             JsonRpcElicitationCompleteNotification.fromJson(json),
           _ => JsonRpcNotification(
               method: method,
-              params: json['params'] as Map<String, dynamic>?,
-              meta: json['_meta'] as Map<String, dynamic>? ??
-                  (json['params'] as Map<String, dynamic>?)?['_meta']
-                      as Map<String, dynamic>?,
+              params: params,
+              meta: extractRequestMeta(json),
             ),
         };
       }
-    } else if (json.containsKey('result')) {
+    } else if (hasResult && hasError) {
+      throw const FormatException(
+        'Invalid JSON-RPC response: result and error are mutually exclusive',
+      );
+    } else if (hasResult) {
       final id = _parseResultResponseId(json['id']);
-      final resultData = json['result'] as Map<String, dynamic>;
-      final meta = resultData['_meta'] as Map<String, dynamic>?;
+      final resultData =
+          readJsonObject(json['result'], 'JsonRpcResponse.result');
+      final meta = readOptionalJsonObject(
+        resultData['_meta'],
+        'JsonRpcResponse._meta',
+      );
       final actualResult = Map<String, dynamic>.from(resultData)
         ..remove('_meta');
       return JsonRpcResponse(id: id, result: actualResult, meta: meta);
-    } else if (json.containsKey('error')) {
+    } else if (hasError) {
       return JsonRpcError.fromJson(json);
     } else {
       throw FormatException('Invalid JSON-RPC message format: $json');
@@ -442,12 +496,17 @@ class JsonRpcRequest extends JsonRpcMessage {
   @override
   Map<String, dynamic> toJson() => {
         'jsonrpc': jsonrpc,
-        'id': id,
+        'id': _requestIdToJson(id, 'JsonRpcRequest.id'),
         'method': method,
         if (params != null || meta != null)
           'params': <String, dynamic>{
-            ...?params,
-            if (meta != null) '_meta': meta,
+            if (params != null)
+              ...readJsonObject(params, 'JsonRpcRequest.params'),
+            if (meta != null)
+              '_meta': readJsonObject(
+                validateRequestMeta(meta),
+                'JsonRpcRequest._meta',
+              ),
           },
       };
 }
@@ -472,8 +531,10 @@ class JsonRpcNotification extends JsonRpcMessage {
         'method': method,
         if (params != null || meta != null)
           'params': <String, dynamic>{
-            ...?params,
-            if (meta != null) '_meta': meta,
+            if (params != null)
+              ...readJsonObject(params, 'JsonRpcNotification.params'),
+            if (meta != null)
+              '_meta': readJsonObject(meta, 'JsonRpcNotification._meta'),
           },
       };
 }
@@ -495,8 +556,12 @@ class JsonRpcResponse extends JsonRpcMessage {
   @override
   Map<String, dynamic> toJson() => {
         'jsonrpc': jsonrpc,
-        'id': id,
-        'result': <String, dynamic>{...result, if (meta != null) '_meta': meta},
+        'id': _requestIdToJson(id, 'JsonRpcResponse.id'),
+        'result': <String, dynamic>{
+          ...readJsonObject(result, 'JsonRpcResponse.result'),
+          if (meta != null)
+            '_meta': readJsonObject(meta, 'JsonRpcResponse._meta'),
+        },
       };
 }
 // --- JSON-RPC Error ---
@@ -554,15 +619,17 @@ class JsonRpcErrorData {
 
   factory JsonRpcErrorData.fromJson(Map<String, dynamic> json) =>
       JsonRpcErrorData(
-        code: json['code'] as int,
-        message: json['message'] as String,
-        data: json['data'],
+        code: _parseErrorCode(json['code']),
+        message: _parseErrorMessage(json['message']),
+        data: json.containsKey('data')
+            ? readJsonValue(json['data'], 'JsonRpcErrorData.data')
+            : null,
       );
 
   Map<String, dynamic> toJson() => {
         'code': code,
         'message': message,
-        if (data != null) 'data': data,
+        if (data != null) 'data': readJsonValue(data, 'JsonRpcErrorData.data'),
       };
 }
 
@@ -575,13 +642,15 @@ class JsonRpcError extends JsonRpcMessage {
 
   factory JsonRpcError.fromJson(Map<String, dynamic> json) => JsonRpcError(
         id: _parseErrorResponseId(json),
-        error: JsonRpcErrorData.fromJson(json['error'] as Map<String, dynamic>),
+        error: JsonRpcErrorData.fromJson(
+          readJsonObject(json['error'], 'JsonRpcError.error'),
+        ),
       );
 
   @override
   Map<String, dynamic> toJson() => {
         'jsonrpc': jsonrpc,
-        if (id != null) 'id': id,
+        if (id != null) 'id': _requestIdToJson(id, 'JsonRpcError.id'),
         'error': error.toJson(),
       };
 }
@@ -741,7 +810,8 @@ class InputRequest {
 
   Map<String, dynamic> toJson() => {
         'method': method,
-        if (params != null) 'params': params,
+        if (params != null)
+          'params': readJsonObject(params, 'InputRequest.params'),
       };
 }
 
@@ -754,17 +824,13 @@ class InputResponse {
 
   /// Creates an input response from a typed MCP result.
   factory InputResponse.fromResult(BaseResultData result) {
-    return InputResponse.raw(result.toJson());
+    return InputResponse.raw(_inputResponseJsonForResult(result));
   }
 
   factory InputResponse.fromJson(Map<String, dynamic> json) {
-    if (!_isValidInputResponse(json)) {
-      throw const FormatException(
-        'InputResponse must be a CreateMessageResult, ListRootsResult, '
-        'or ElicitResult',
-      );
-    }
-    return InputResponse.raw(Map<String, dynamic>.from(json));
+    final value = Map<String, dynamic>.from(json);
+    _validateInputResponse(value);
+    return InputResponse.raw(value);
   }
 
   /// Parses an input response map.
@@ -788,13 +854,49 @@ class InputResponse {
     );
   }
 
-  Map<String, dynamic> toJson() => Map<String, dynamic>.from(value);
+  Map<String, dynamic> toJson() {
+    final json = readJsonObject(value, 'InputResponse');
+    _validateInputResponse(json);
+    return json;
+  }
 }
 
-bool _isValidInputResponse(Map<String, dynamic> json) {
-  return _canParseInputResponse(CreateMessageResult.fromJson, json) ||
-      _canParseInputResponse(ListRootsResult.fromJson, json) ||
-      _canParseInputResponse(ElicitResult.fromJson, json);
+Map<String, dynamic> _inputResponseJsonForResult(BaseResultData result) {
+  final json = Map<String, dynamic>.from(result.toJson());
+  if (result is ElicitResult || result is ListRootsResult) {
+    json.remove('_meta');
+  }
+  _validateInputResponse(json);
+  return json;
+}
+
+void _validateInputResponse(Map<String, dynamic> json) {
+  if (_canParseInputResponse(CreateMessageResult.fromJson, json)) {
+    return;
+  }
+
+  if (_canParseInputResponse(ListRootsResult.fromJson, json)) {
+    _rejectInputResponseMeta(json, 'ListRootsResult');
+    return;
+  }
+
+  if (_canParseInputResponse(ElicitResult.fromJson, json)) {
+    _rejectInputResponseMeta(json, 'ElicitResult');
+    return;
+  }
+
+  throw const FormatException(
+    'InputResponse must be a CreateMessageResult, ListRootsResult, '
+    'or ElicitResult',
+  );
+}
+
+void _rejectInputResponseMeta(Map<String, dynamic> json, String resultName) {
+  if (json.containsKey('_meta')) {
+    throw FormatException(
+      'InputResponse $resultName must not include _meta in MCP 2026',
+    );
+  }
 }
 
 bool _canParseInputResponse(
@@ -875,22 +977,14 @@ class InputRequiredResult implements BaseResultData {
       if (inputRequests != null)
         'inputRequests': InputRequest.mapToJson(inputRequests!),
       if (requestState != null) 'requestState': requestState,
-      if (meta != null) '_meta': meta,
+      if (meta != null)
+        '_meta': readJsonObject(meta, 'InputRequiredResult._meta'),
     };
   }
 }
 
 Map<String, dynamic> _readRequiredJsonObject(Object? value, String field) {
-  if (value is Map<String, dynamic>) {
-    return value;
-  }
-  if (value is Map) {
-    if (value.keys.any((key) => key is! String)) {
-      throw FormatException('$field must be an object with string keys');
-    }
-    return value.cast<String, dynamic>();
-  }
-  throw FormatException('$field must be an object');
+  return readJsonObject(value, field);
 }
 
 Map<String, dynamic>? _readOptionalJsonObject(Object? value, String field) {

--- a/lib/src/types/logging.dart
+++ b/lib/src/types/logging.dart
@@ -1,4 +1,5 @@
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// Severity levels for log messages (syslog levels).
 enum LoggingLevel {
@@ -102,7 +103,10 @@ class JsonRpcLoggingMessageNotification extends JsonRpcNotification {
         "Missing params for logging message notification",
       );
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      paramsMap['_meta'],
+      'JsonRpcLoggingMessageNotification._meta',
+    );
     return JsonRpcLoggingMessageNotification(
       logParams: LoggingMessageNotification.fromJson(paramsMap),
       meta: meta,

--- a/lib/src/types/misc.dart
+++ b/lib/src/types/misc.dart
@@ -1,4 +1,5 @@
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// A response that indicates success but carries no specific data.
 class EmptyResult implements BaseResultData {
@@ -9,7 +10,7 @@ class EmptyResult implements BaseResultData {
 
   @override
   Map<String, dynamic> toJson() => {
-        if (meta != null) '_meta': meta,
+        if (meta != null) '_meta': readJsonObject(meta, 'EmptyResult._meta'),
       };
 }
 
@@ -30,7 +31,7 @@ class CancelledNotification {
       );
 
   Map<String, dynamic> toJson() => {
-        'requestId': requestId,
+        'requestId': parseRequestId(requestId, fieldName: 'requestId'),
         if (reason != null) 'reason': reason,
       };
 }
@@ -51,7 +52,10 @@ class JsonRpcCancelledNotification extends JsonRpcNotification {
     if (paramsMap == null) {
       throw const FormatException("Missing params for cancelled notification");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      paramsMap['_meta'],
+      'JsonRpcCancelledNotification._meta',
+    );
     return JsonRpcCancelledNotification(
       cancelParams: CancelledNotification.fromJson(paramsMap),
       meta: meta,
@@ -91,17 +95,21 @@ class Progress {
 
   factory Progress.fromJson(Map<String, dynamic> json) {
     return Progress(
-      progress: json['progress'] as num,
-      total: json['total'] as num?,
+      progress: readFiniteNumber(json['progress'], 'Progress.progress'),
+      total: readOptionalFiniteNumber(json['total'], 'Progress.total'),
       message: json['message'] as String?,
     );
   }
 
-  Map<String, dynamic> toJson() => {
-        'progress': progress,
-        if (total != null) 'total': total,
-        if (message != null) 'message': message,
-      };
+  Map<String, dynamic> toJson() {
+    validateFiniteNumber(progress, 'Progress.progress');
+    validateOptionalFiniteNumber(total, 'Progress.total');
+    return {
+      'progress': progress,
+      if (total != null) 'total': total,
+      if (message != null) 'message': message,
+    };
+  }
 }
 
 /// Parameters for the `notifications/progress` notification.
@@ -140,7 +148,7 @@ class ProgressNotification implements Progress {
 
   @override
   Map<String, dynamic> toJson() => {
-        'progressToken': progressToken,
+        'progressToken': parseProgressToken(progressToken),
         ...Progress(
           progress: progress,
           total: total,
@@ -167,7 +175,10 @@ class JsonRpcProgressNotification extends JsonRpcNotification {
     if (paramsMap == null) {
       throw const FormatException("Missing params for progress notification");
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      paramsMap['_meta'],
+      'JsonRpcProgressNotification._meta',
+    );
     return JsonRpcProgressNotification(
       progressParams: ProgressNotification.fromJson(paramsMap),
       meta: meta,

--- a/lib/src/types/prompts.dart
+++ b/lib/src/types/prompts.dart
@@ -90,7 +90,7 @@ class Prompt {
       icons: (json['icons'] as List<dynamic>?)
           ?.map((e) => McpIcon.fromJson(e as Map<String, dynamic>))
           .toList(),
-      meta: (json['_meta'] as Map?)?.cast<String, dynamic>(),
+      meta: readOptionalJsonObject(json['_meta'], 'Prompt._meta'),
     );
   }
 
@@ -102,7 +102,7 @@ class Prompt {
           'arguments': arguments!.map((a) => a.toJson()).toList(),
         if (icons != null)
           'icons': icons!.map((icon) => icon.toJson()).toList(),
-        if (meta != null) '_meta': meta,
+        if (meta != null) '_meta': readJsonObject(meta, 'Prompt._meta'),
       };
 }
 
@@ -171,7 +171,8 @@ class ListPromptsResult implements CacheableResultData {
   });
 
   factory ListPromptsResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta =
+        readOptionalJsonObject(json['_meta'], 'ListPromptsResult._meta');
     final prompts = json['prompts'];
     if (prompts is! List) {
       throw const FormatException('ListPromptsResult.prompts is required');
@@ -199,7 +200,8 @@ class ListPromptsResult implements CacheableResultData {
       if (nextCursor != null) 'nextCursor': nextCursor,
       if (ttlMs != null) 'ttlMs': ttlMs,
       if (cacheScope != null) 'cacheScope': cacheScope,
-      if (meta != null) '_meta': meta,
+      if (meta != null)
+        '_meta': readJsonObject(meta, 'ListPromptsResult._meta'),
     };
   }
 }
@@ -319,7 +321,7 @@ class GetPromptResult implements BaseResultData {
   const GetPromptResult({this.description, required this.messages, this.meta});
 
   factory GetPromptResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(json['_meta'], 'GetPromptResult._meta');
     final messages = json['messages'];
     if (messages is! List) {
       throw const FormatException('GetPromptResult.messages is required');
@@ -337,7 +339,8 @@ class GetPromptResult implements BaseResultData {
   Map<String, dynamic> toJson() => {
         if (description != null) 'description': description,
         'messages': messages.map((m) => m.toJson()).toList(),
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'GetPromptResult._meta'),
       };
 }
 

--- a/lib/src/types/resources.dart
+++ b/lib/src/types/resources.dart
@@ -117,7 +117,7 @@ class Resource {
               json['annotations'] as Map<String, dynamic>,
             )
           : null,
-      meta: (json['_meta'] as Map?)?.cast<String, dynamic>(),
+      meta: readOptionalJsonObject(json['_meta'], 'Resource._meta'),
     );
   }
 
@@ -132,7 +132,7 @@ class Resource {
           'icons': icons!.map((icon) => icon.toJson()).toList(),
         if (size != null) 'size': size,
         if (annotations != null) 'annotations': annotations!.toJson(),
-        if (meta != null) '_meta': meta,
+        if (meta != null) '_meta': readJsonObject(meta, 'Resource._meta'),
       };
 }
 
@@ -200,7 +200,7 @@ class ResourceTemplate {
               json['annotations'] as Map<String, dynamic>,
             )
           : null,
-      meta: (json['_meta'] as Map?)?.cast<String, dynamic>(),
+      meta: readOptionalJsonObject(json['_meta'], 'ResourceTemplate._meta'),
     );
   }
 
@@ -214,7 +214,8 @@ class ResourceTemplate {
         if (icons != null)
           'icons': icons!.map((icon) => icon.toJson()).toList(),
         if (annotations != null) 'annotations': annotations!.toJson(),
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'ResourceTemplate._meta'),
       };
 }
 
@@ -291,7 +292,10 @@ class ListResourcesResult implements CacheableResultData {
 
   /// Creates from JSON.
   factory ListResourcesResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      json['_meta'],
+      'ListResourcesResult._meta',
+    );
     final resources = json['resources'];
     if (resources is! List) {
       throw const FormatException('ListResourcesResult.resources is required');
@@ -320,7 +324,8 @@ class ListResourcesResult implements CacheableResultData {
       if (nextCursor != null) 'nextCursor': nextCursor,
       if (ttlMs != null) 'ttlMs': ttlMs,
       if (cacheScope != null) 'cacheScope': cacheScope,
-      if (meta != null) '_meta': meta,
+      if (meta != null)
+        '_meta': readJsonObject(meta, 'ListResourcesResult._meta'),
     };
   }
 }
@@ -395,7 +400,10 @@ class ListResourceTemplatesResult implements CacheableResultData {
   });
 
   factory ListResourceTemplatesResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      json['_meta'],
+      'ListResourceTemplatesResult._meta',
+    );
     final resourceTemplates = json['resourceTemplates'];
     if (resourceTemplates is! List) {
       throw const FormatException(
@@ -428,7 +436,8 @@ class ListResourceTemplatesResult implements CacheableResultData {
       if (nextCursor != null) 'nextCursor': nextCursor,
       if (ttlMs != null) 'ttlMs': ttlMs,
       if (cacheScope != null) 'cacheScope': cacheScope,
-      if (meta != null) '_meta': meta,
+      if (meta != null)
+        '_meta': readJsonObject(meta, 'ListResourceTemplatesResult._meta'),
     };
   }
 }
@@ -520,7 +529,10 @@ class ReadResourceResult implements CacheableResultData {
   });
 
   factory ReadResourceResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      json['_meta'],
+      'ReadResourceResult._meta',
+    );
     final contents = json['contents'];
     if (contents is! List) {
       throw const FormatException('ReadResourceResult.contents is required');
@@ -546,7 +558,8 @@ class ReadResourceResult implements CacheableResultData {
       'contents': contents.map((c) => c.toJson()).toList(),
       if (ttlMs != null) 'ttlMs': ttlMs,
       if (cacheScope != null) 'cacheScope': cacheScope,
-      if (meta != null) '_meta': meta,
+      if (meta != null)
+        '_meta': readJsonObject(meta, 'ReadResourceResult._meta'),
     };
   }
 }
@@ -673,7 +686,10 @@ class JsonRpcResourceUpdatedNotification extends JsonRpcNotification {
         "Missing params for resource updated notification",
       );
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(
+      paramsMap['_meta'],
+      'JsonRpcResourceUpdatedNotification._meta',
+    );
     return JsonRpcResourceUpdatedNotification(
       updatedParams: ResourceUpdatedNotification.fromJson(paramsMap),
       meta: meta,

--- a/lib/src/types/roots.dart
+++ b/lib/src/types/roots.dart
@@ -1,4 +1,5 @@
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// Represents a root directory or file the server can operate on.
 class Root {
@@ -25,14 +26,14 @@ class Root {
     return Root(
       uri: json['uri'] as String,
       name: json['name'] as String?,
-      meta: (json['_meta'] as Map?)?.cast<String, dynamic>(),
+      meta: readOptionalJsonObject(json['_meta'], 'Root._meta'),
     );
   }
 
   Map<String, dynamic> toJson() => {
         'uri': uri,
         if (name != null) 'name': name,
-        if (meta != null) '_meta': meta,
+        if (meta != null) '_meta': readJsonObject(meta, 'Root._meta'),
       };
 }
 
@@ -61,7 +62,7 @@ class ListRootsResult implements BaseResultData {
   const ListRootsResult({required this.roots, this.meta});
 
   factory ListRootsResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(json['_meta'], 'ListRootsResult._meta');
     final roots = json['roots'];
     if (roots is! List) {
       throw const FormatException('ListRootsResult.roots is required');
@@ -76,7 +77,8 @@ class ListRootsResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         'roots': roots.map((r) => r.toJson()).toList(),
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'ListRootsResult._meta'),
       };
 }
 

--- a/lib/src/types/sampling.dart
+++ b/lib/src/types/sampling.dart
@@ -4,23 +4,23 @@ import 'tasks.dart';
 import 'tools.dart';
 import 'validation.dart';
 
-Map<String, dynamic>? _asJsonObjectOrNull(dynamic value) {
+Map<String, dynamic>? _asJsonObjectOrNull(
+  dynamic value, [
+  String field = 'object',
+]) {
   if (value == null) {
     return null;
   }
-  if (value is Map<String, dynamic>) {
-    return value;
-  }
-  if (value is Map) {
-    return value.cast<String, dynamic>();
-  }
-  throw FormatException('Expected object, got ${value.runtimeType}');
+  return readJsonObject(value, field);
 }
 
-Map<String, dynamic> _asJsonObject(dynamic value) {
-  final map = _asJsonObjectOrNull(value);
+Map<String, dynamic> _asJsonObject(
+  dynamic value, [
+  String field = 'object',
+]) {
+  final map = _asJsonObjectOrNull(value, field);
   if (map == null) {
-    throw const FormatException('Expected object, got null');
+    throw FormatException('$field must be a JSON object');
   }
   return map;
 }
@@ -286,26 +286,45 @@ sealed class SamplingContent {
         ...switch (this) {
           final SamplingTextContent c => {
               'text': c.text,
-              if (c.annotations != null) 'annotations': c.annotations,
-              if (c.meta != null) '_meta': c.meta,
+              if (c.annotations != null)
+                'annotations': readJsonObject(
+                  c.annotations,
+                  'SamplingTextContent.annotations',
+                ),
+              if (c.meta != null)
+                '_meta': readJsonObject(c.meta, 'SamplingTextContent._meta'),
             },
           final SamplingImageContent c => {
               'data': c.data,
               'mimeType': c.mimeType,
-              if (c.annotations != null) 'annotations': c.annotations,
-              if (c.meta != null) '_meta': c.meta,
+              if (c.annotations != null)
+                'annotations': readJsonObject(
+                  c.annotations,
+                  'SamplingImageContent.annotations',
+                ),
+              if (c.meta != null)
+                '_meta': readJsonObject(c.meta, 'SamplingImageContent._meta'),
             },
           final SamplingAudioContent c => {
               'data': c.data,
               'mimeType': c.mimeType,
-              if (c.annotations != null) 'annotations': c.annotations,
-              if (c.meta != null) '_meta': c.meta,
+              if (c.annotations != null)
+                'annotations': readJsonObject(
+                  c.annotations,
+                  'SamplingAudioContent.annotations',
+                ),
+              if (c.meta != null)
+                '_meta': readJsonObject(c.meta, 'SamplingAudioContent._meta'),
             },
           final SamplingToolUseContent c => {
               'id': c.id,
               'name': c.name,
-              'input': c.input,
-              if (c.meta != null) '_meta': c.meta,
+              'input': readJsonObject(
+                c.input,
+                'SamplingToolUseContent.input',
+              ),
+              if (c.meta != null)
+                '_meta': readJsonObject(c.meta, 'SamplingToolUseContent._meta'),
             },
           final SamplingToolResultContent c => {
               'toolUseId': c.toolUseId,
@@ -316,7 +335,11 @@ sealed class SamplingContent {
                   'SamplingToolResultContent.structuredContent',
                 ),
               if (c.isError != null) 'isError': c.isError,
-              if (c.meta != null) '_meta': c.meta,
+              if (c.meta != null)
+                '_meta': readJsonObject(
+                  c.meta,
+                  'SamplingToolResultContent._meta',
+                ),
             },
         },
       };
@@ -342,8 +365,11 @@ class SamplingTextContent extends SamplingContent {
   factory SamplingTextContent.fromJson(Map<String, dynamic> json) =>
       SamplingTextContent(
         text: json['text'] as String,
-        annotations: _asJsonObjectOrNull(json['annotations']),
-        meta: _asJsonObjectOrNull(json['_meta']),
+        annotations: _asJsonObjectOrNull(
+          json['annotations'],
+          'SamplingTextContent.annotations',
+        ),
+        meta: _asJsonObjectOrNull(json['_meta'], 'SamplingTextContent._meta'),
       );
 }
 
@@ -372,8 +398,11 @@ class SamplingImageContent extends SamplingContent {
       SamplingImageContent(
         data: json['data'] as String,
         mimeType: json['mimeType'] as String,
-        annotations: _asJsonObjectOrNull(json['annotations']),
-        meta: _asJsonObjectOrNull(json['_meta']),
+        annotations: _asJsonObjectOrNull(
+          json['annotations'],
+          'SamplingImageContent.annotations',
+        ),
+        meta: _asJsonObjectOrNull(json['_meta'], 'SamplingImageContent._meta'),
       );
 }
 
@@ -402,8 +431,11 @@ class SamplingAudioContent extends SamplingContent {
       SamplingAudioContent(
         data: json['data'] as String,
         mimeType: json['mimeType'] as String,
-        annotations: _asJsonObjectOrNull(json['annotations']),
-        meta: _asJsonObjectOrNull(json['_meta']),
+        annotations: _asJsonObjectOrNull(
+          json['annotations'],
+          'SamplingAudioContent.annotations',
+        ),
+        meta: _asJsonObjectOrNull(json['_meta'], 'SamplingAudioContent._meta'),
       );
 }
 
@@ -425,8 +457,9 @@ class SamplingToolUseContent extends SamplingContent {
       SamplingToolUseContent(
         id: json['id'] as String,
         name: json['name'] as String,
-        input: _asJsonObject(json['input']),
-        meta: _asJsonObjectOrNull(json['_meta']),
+        input: _asJsonObject(json['input'], 'SamplingToolUseContent.input'),
+        meta:
+            _asJsonObjectOrNull(json['_meta'], 'SamplingToolUseContent._meta'),
       );
 }
 
@@ -469,7 +502,8 @@ class SamplingToolResultContent extends SamplingContent {
           : null,
       hasStructuredContent: json.containsKey('structuredContent'),
       isError: json['isError'] as bool?,
-      meta: _asJsonObjectOrNull(json['_meta']),
+      meta:
+          _asJsonObjectOrNull(json['_meta'], 'SamplingToolResultContent._meta'),
     );
   }
 }
@@ -508,7 +542,7 @@ class SamplingMessage {
     return SamplingMessage(
       role: SamplingMessageRole.values.byName(json['role'] as String),
       content: _parseSamplingMessageContent(json['content']),
-      meta: _asJsonObjectOrNull(json['_meta']),
+      meta: _asJsonObjectOrNull(json['_meta'], 'SamplingMessage._meta'),
     );
   }
 
@@ -516,7 +550,8 @@ class SamplingMessage {
   Map<String, dynamic> toJson() => {
         'role': role.name,
         'content': _samplingMessageContentToJson(content),
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'SamplingMessage._meta'),
       };
 }
 
@@ -625,10 +660,16 @@ class CreateMessageRequest {
       systemPrompt: json['systemPrompt'] as String?,
       includeContext:
           ctxStr == null ? null : IncludeContext.values.byName(ctxStr),
-      temperature: (json['temperature'] as num?)?.toDouble(),
+      temperature: readOptionalFiniteDouble(
+        json['temperature'],
+        'CreateMessageRequest.temperature',
+      ),
       maxTokens: json['maxTokens'] as int,
       stopSequences: (json['stopSequences'] as List<dynamic>?)?.cast<String>(),
-      metadata: _asJsonObjectOrNull(json['metadata']),
+      metadata: _asJsonObjectOrNull(
+        json['metadata'],
+        'CreateMessageRequest.metadata',
+      ),
       modelPreferences: json['modelPreferences'] == null
           ? null
           : ModelPreferences.fromJson(
@@ -642,20 +683,30 @@ class CreateMessageRequest {
   }
 
   /// Converts to JSON.
-  Map<String, dynamic> toJson() => {
-        'messages': messages.map((m) => m.toJson()).toList(),
-        if (task != null) 'task': task!.toJson(),
-        if (systemPrompt != null) 'systemPrompt': systemPrompt,
-        if (includeContext != null) 'includeContext': includeContext!.name,
-        if (temperature != null) 'temperature': temperature,
-        'maxTokens': maxTokens,
-        if (stopSequences != null) 'stopSequences': stopSequences,
-        if (metadata != null) 'metadata': metadata,
-        if (modelPreferences != null)
-          'modelPreferences': modelPreferences!.toJson(),
-        if (tools != null) 'tools': tools!.map((t) => t.toJson()).toList(),
-        if (toolChoiceConfig != null) 'toolChoice': toolChoiceConfig!.toJson(),
-      };
+  Map<String, dynamic> toJson() {
+    validateOptionalFiniteNumber(
+      temperature,
+      'CreateMessageRequest.temperature',
+    );
+    return {
+      'messages': messages.map((m) => m.toJson()).toList(),
+      if (task != null) 'task': task!.toJson(),
+      if (systemPrompt != null) 'systemPrompt': systemPrompt,
+      if (includeContext != null) 'includeContext': includeContext!.name,
+      if (temperature != null) 'temperature': temperature,
+      'maxTokens': maxTokens,
+      if (stopSequences != null) 'stopSequences': stopSequences,
+      if (metadata != null)
+        'metadata': readJsonObject(
+          metadata,
+          'CreateMessageRequest.metadata',
+        ),
+      if (modelPreferences != null)
+        'modelPreferences': modelPreferences!.toJson(),
+      if (tools != null) 'tools': tools!.map((t) => t.toJson()).toList(),
+      if (toolChoiceConfig != null) 'toolChoice': toolChoiceConfig!.toJson(),
+    };
+  }
 }
 
 /// Request sent from server to client to sample an LLM.
@@ -729,7 +780,8 @@ class CreateMessageResult implements BaseResultData {
   }
 
   factory CreateMessageResult.fromJson(Map<String, dynamic> json) {
-    final meta = _asJsonObjectOrNull(json['_meta']);
+    final meta =
+        _asJsonObjectOrNull(json['_meta'], 'CreateMessageResult._meta');
     dynamic reason = json['stopReason'];
     if (reason is String) {
       try {
@@ -765,7 +817,8 @@ class CreateMessageResult implements BaseResultData {
         'stopReason': reason is StopReason ? reason.name : reason,
       'role': role.name,
       'content': _samplingMessageContentToJson(content),
-      if (meta != null) '_meta': meta,
+      if (meta != null)
+        '_meta': readJsonObject(meta, 'CreateMessageResult._meta'),
     };
   }
 }

--- a/lib/src/types/subscriptions.dart
+++ b/lib/src/types/subscriptions.dart
@@ -1,5 +1,6 @@
 import 'initialization.dart';
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// Notification filter requested by `subscriptions/listen`.
 class SubscriptionFilter {
@@ -292,14 +293,5 @@ Map<String, dynamic>? _readOptionalJsonObject(Object? value, String field) {
   if (value == null) {
     return null;
   }
-  if (value is Map<String, dynamic>) {
-    return value;
-  }
-  if (value is Map) {
-    if (value.keys.any((key) => key is! String)) {
-      throw FormatException('$field must be an object with string keys');
-    }
-    return value.cast<String, dynamic>();
-  }
-  throw FormatException('$field must be an object');
+  return readJsonObject(value, field);
 }

--- a/lib/src/types/tasks.dart
+++ b/lib/src/types/tasks.dart
@@ -1,5 +1,6 @@
 import '../types.dart';
 import 'json_rpc.dart';
+import 'validation.dart';
 
 /// The current state of a task execution.
 enum TaskStatus {
@@ -98,7 +99,7 @@ class Task implements BaseResultData {
     final createdAt = _readRequiredTaskString(json, 'createdAt');
     final lastUpdatedAt = _readRequiredTaskString(json, 'lastUpdatedAt');
 
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(json['_meta'], 'Task._meta');
     return Task(
       taskId: _readRequiredTaskString(json, 'taskId'),
       status: TaskStatusName.fromString(
@@ -122,7 +123,8 @@ class Task implements BaseResultData {
         if (pollInterval != null) 'pollInterval': pollInterval,
         'createdAt': createdAt,
         'lastUpdatedAt': lastUpdatedAt,
-        if (includeMeta && meta != null) '_meta': meta,
+        if (includeMeta && meta != null)
+          '_meta': readJsonObject(meta, 'Task._meta'),
       };
 
   /// Serializes this task where MCP expects the bare `Task` schema.
@@ -231,7 +233,7 @@ class ListTasksResult implements BaseResultData {
   const ListTasksResult({required this.tasks, this.nextCursor, this.meta});
 
   factory ListTasksResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta = readOptionalJsonObject(json['_meta'], 'ListTasksResult._meta');
     final tasks = json['tasks'];
     if (tasks is! List) {
       throw const FormatException('ListTasksResult.tasks is required');
@@ -248,7 +250,8 @@ class ListTasksResult implements BaseResultData {
   Map<String, dynamic> toJson() => {
         'tasks': tasks.map((t) => t.toBareJson()).toList(),
         if (nextCursor != null) 'nextCursor': nextCursor,
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'ListTasksResult._meta'),
       };
 }
 
@@ -458,7 +461,8 @@ class CreateTaskResult implements BaseResultData {
   const CreateTaskResult({required this.task, this.meta});
 
   factory CreateTaskResult.fromJson(Map<String, dynamic> json) {
-    final meta = json['_meta'] as Map<String, dynamic>?;
+    final meta =
+        readOptionalJsonObject(json['_meta'], 'CreateTaskResult._meta');
     return CreateTaskResult(
       task: Task.fromJson(json['task'] as Map<String, dynamic>),
       meta: meta,
@@ -468,7 +472,8 @@ class CreateTaskResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         'task': task.toBareJson(),
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'CreateTaskResult._meta'),
       };
 }
 
@@ -609,7 +614,8 @@ class TaskExtensionTask {
         if (pollIntervalMs != null) 'pollIntervalMs': pollIntervalMs,
         if (inputRequests != null)
           'inputRequests': InputRequest.mapToJson(inputRequests!),
-        if (result != null) 'result': result,
+        if (result != null)
+          'result': readJsonObject(result, 'TaskExtensionTask.result'),
         if (error != null) 'error': error!.toJson(),
       };
 }
@@ -643,7 +649,8 @@ class CreateTaskExtensionResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         ...task.toJson(resultType: resultTypeTask),
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'CreateTaskExtensionResult._meta'),
       };
 }
 
@@ -676,7 +683,8 @@ class GetTaskExtensionResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         ...task.toJson(resultType: resultTypeComplete),
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(meta, 'GetTaskExtensionResult._meta'),
       };
 }
 
@@ -707,7 +715,11 @@ class TaskExtensionAcknowledgementResult implements BaseResultData {
   @override
   Map<String, dynamic> toJson() => {
         'resultType': resultTypeComplete,
-        if (meta != null) '_meta': meta,
+        if (meta != null)
+          '_meta': readJsonObject(
+            meta,
+            'TaskExtensionAcknowledgementResult._meta',
+          ),
       };
 }
 
@@ -838,7 +850,10 @@ class JsonRpcTaskStatusNotification extends JsonRpcNotification {
         "Missing params for task status notification",
       );
     }
-    final meta = paramsMap['_meta'] as Map<String, dynamic>?;
+    final meta = _readOptionalJsonObject(
+      paramsMap['_meta'],
+      'JsonRpcTaskStatusNotification._meta',
+    );
     return JsonRpcTaskStatusNotification(
       statusParams: TaskStatusNotification.fromJson(paramsMap),
       meta: meta,
@@ -870,16 +885,7 @@ class JsonRpcTaskNotification extends JsonRpcNotification {
 }
 
 Map<String, dynamic> _readRequiredJsonObject(Object? value, String field) {
-  if (value is Map<String, dynamic>) {
-    return value;
-  }
-  if (value is Map) {
-    if (value.keys.any((key) => key is! String)) {
-      throw FormatException('$field must be an object with string keys');
-    }
-    return value.cast<String, dynamic>();
-  }
-  throw FormatException('$field must be an object');
+  return readJsonObject(value, field);
 }
 
 Map<String, dynamic>? _readOptionalJsonObject(Object? value, String field) {

--- a/lib/src/types/tools.dart
+++ b/lib/src/types/tools.dart
@@ -212,7 +212,7 @@ class Tool {
               json['annotations'] as Map<String, dynamic>,
             )
           : null,
-      meta: json['_meta'] as Map<String, dynamic>?,
+      meta: readOptionalJsonObject(json['_meta'], 'Tool._meta'),
       execution: json['execution'] != null
           ? ToolExecution.fromJson(json['execution'] as Map<String, dynamic>)
           : null,
@@ -235,7 +235,7 @@ class Tool {
       'inputSchema': inputSchema.toJson(),
       if (outputSchema != null) 'outputSchema': outputSchema!.toJson(),
       if (annotations != null) 'annotations': annotations!.toJson(),
-      if (meta != null) '_meta': meta,
+      if (meta != null) '_meta': readJsonObject(meta, 'Tool._meta'),
       if (execution != null) 'execution': execution!.toJson(),
       if (icons != null) 'icons': icons!.map((icon) => icon.toJson()).toList(),
     };
@@ -305,7 +305,7 @@ class ListToolsResult implements CacheableResultData {
         json['cacheScope'],
         'ListToolsResult.cacheScope',
       ),
-      meta: json['_meta'] as Map<String, dynamic>?,
+      meta: readOptionalJsonObject(json['_meta'], 'ListToolsResult._meta'),
     );
   }
 
@@ -318,7 +318,7 @@ class ListToolsResult implements CacheableResultData {
       if (nextCursor != null) 'nextCursor': nextCursor,
       if (ttlMs != null) 'ttlMs': ttlMs,
       if (cacheScope != null) 'cacheScope': cacheScope,
-      if (meta != null) '_meta': meta,
+      if (meta != null) '_meta': readJsonObject(meta, 'ListToolsResult._meta'),
     };
   }
 }
@@ -353,7 +353,7 @@ class CallToolRequest {
       name: json['name'] as String,
       arguments: arguments == null
           ? const {}
-          : (arguments as Map).cast<String, dynamic>(),
+          : _readJsonObject(arguments, 'CallToolRequest.arguments'),
       inputResponses: InputResponse.mapFromJson(
         json['inputResponses'],
         'CallToolRequest.inputResponses',
@@ -367,7 +367,7 @@ class CallToolRequest {
 
   Map<String, dynamic> toJson() => {
         'name': name,
-        'arguments': arguments,
+        'arguments': readJsonObject(arguments, 'CallToolRequest.arguments'),
         if (inputResponses != null)
           'inputResponses': InputResponse.mapToJson(inputResponses!),
         if (requestState != null) 'requestState': requestState,
@@ -448,8 +448,9 @@ class CallToolResult implements BaseResultData {
             )
           : null,
       hasStructuredContent: json.containsKey('structuredContent'),
-      meta: json['_meta'] as Map<String, dynamic>?,
-      extra: extra.isEmpty ? null : extra,
+      meta: readOptionalJsonObject(json['_meta'], 'CallToolResult._meta'),
+      extra:
+          extra.isEmpty ? null : readJsonObject(extra, 'CallToolResult.extra'),
     );
   }
 
@@ -462,8 +463,8 @@ class CallToolResult implements BaseResultData {
             structuredContent,
             'CallToolResult.structuredContent',
           ),
-        if (meta != null) '_meta': meta,
-        ...?extra,
+        if (meta != null) '_meta': readJsonObject(meta, 'CallToolResult._meta'),
+        if (extra != null) ...readJsonObject(extra, 'CallToolResult.extra'),
       };
 }
 
@@ -511,14 +512,5 @@ Map<String, dynamic>? _readOptionalJsonObject(Object? value, String field) {
 }
 
 Map<String, dynamic> _readJsonObject(Object? value, String field) {
-  if (value is Map<String, dynamic>) {
-    return value;
-  }
-  if (value is Map) {
-    if (value.keys.any((key) => key is! String)) {
-      throw FormatException('$field must be an object with string keys');
-    }
-    return value.cast<String, dynamic>();
-  }
-  throw FormatException('$field must be an object');
+  return readJsonObject(value, field);
 }

--- a/lib/src/types/validation.dart
+++ b/lib/src/types/validation.dart
@@ -1,11 +1,9 @@
 double? readUnitDouble(Object? value, String field) {
-  if (value == null) {
+  final number = readOptionalFiniteNumber(value, field);
+  final result = number?.toDouble();
+  if (result == null) {
     return null;
   }
-  if (value is! num) {
-    throw FormatException('$field must be a number between 0 and 1');
-  }
-  final result = value.toDouble();
   if (result < 0 || result > 1) {
     throw FormatException('$field must be between 0 and 1');
   }
@@ -16,9 +14,40 @@ void validateUnitDouble(double? value, String field) {
   if (value == null) {
     return;
   }
-  if (value < 0 || value > 1) {
+  if (!value.isFinite || value < 0 || value > 1) {
     throw ArgumentError.value(value, field, 'must be between 0 and 1');
   }
+}
+
+num readFiniteNumber(Object? value, String field) {
+  if (value is num && value.isFinite) {
+    return value;
+  }
+  throw FormatException('$field must be a finite JSON number');
+}
+
+num? readOptionalFiniteNumber(Object? value, String field) {
+  if (value == null) {
+    return null;
+  }
+  return readFiniteNumber(value, field);
+}
+
+double? readOptionalFiniteDouble(Object? value, String field) {
+  return readOptionalFiniteNumber(value, field)?.toDouble();
+}
+
+void validateFiniteNumber(num value, String field) {
+  if (!value.isFinite) {
+    throw ArgumentError.value(value, field, 'must be a finite JSON number');
+  }
+}
+
+void validateOptionalFiniteNumber(num? value, String field) {
+  if (value == null) {
+    return;
+  }
+  validateFiniteNumber(value, field);
 }
 
 int? readOptionalInteger(Object? value, String field) {
@@ -118,4 +147,18 @@ Object? readJsonValue(Object? value, String field) {
     };
   }
   throw FormatException('$field must be a JSON value');
+}
+
+Map<String, dynamic> readJsonObject(Object? value, String field) {
+  if (value is! Map) {
+    throw FormatException('$field must be a JSON object');
+  }
+  return (readJsonValue(value, field) as Map).cast<String, dynamic>();
+}
+
+Map<String, dynamic>? readOptionalJsonObject(Object? value, String field) {
+  if (value == null) {
+    return null;
+  }
+  return readJsonObject(value, field);
 }

--- a/packages/mcp_dart_cli/README.md
+++ b/packages/mcp_dart_cli/README.md
@@ -353,10 +353,11 @@ mcp_dart call-tool search --url http://localhost:3000/mcp --json-args '{"q":"mcp
 
 Run built-in fixture checks, MCP 2025-11-25 spec-critical checks, and
 deterministic fuzz checks for protocol edge cases in this Dart SDK/CLI package.
-The fixture suite covers JSON-RPC malformed-message handling, string request
-IDs, string progress tokens, and advertised protocol-version support. The spec
-suite covers raw-wire lifecycle, capability, elicitation, task-metadata, and
-progress-token negative cases.
+The fixture suite covers JSON-RPC malformed-message handling, string and
+integer request IDs, string and integer progress tokens, fractional ID/token
+rejection, and advertised protocol-version support. The spec suite covers
+raw-wire lifecycle, capability, elicitation, task-metadata, progress-token
+dispatch, and negative cases.
 
 This command is useful as a regression gate for the Dart SDK and CLI, but it is
 not a live compliance scanner for arbitrary MCP servers or clients. For external

--- a/packages/mcp_dart_cli/lib/src/conformance_runner.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_runner.dart
@@ -6,6 +6,13 @@ import 'package:mcp_dart/mcp_dart.dart';
 const String _fixtureSuite = 'fixture';
 const String _specSuite = 'spec';
 const String _allSuites = 'all';
+const String _serverDiscoverMethod = 'server/discover';
+const String _draftProtocolVersion2026_07_28 = '2026-07-28';
+const String _protocolVersionMetaKey =
+    'io.modelcontextprotocol/protocolVersion';
+const String _clientInfoMetaKey = 'io.modelcontextprotocol/clientInfo';
+const String _clientCapabilitiesMetaKey =
+    'io.modelcontextprotocol/clientCapabilities';
 
 const List<String> conformanceSuiteNames = <String>[
   _fixtureSuite,
@@ -98,6 +105,41 @@ class ConformanceRunner {
           ),
           _ConformanceCase(
             suite: _fixtureSuite,
+            name: 'jsonrpc.rejects-non-string-method',
+            description:
+                'Rejects JSON-RPC requests whose method member is not a string.',
+            check: _rejectsNonStringJsonRpcMethod,
+          ),
+          _ConformanceCase(
+            suite: _fixtureSuite,
+            name: 'jsonrpc.rejects-result-error-response',
+            description:
+                'Rejects JSON-RPC responses that include both result and error members.',
+            check: _rejectsResultErrorJsonRpcResponse,
+          ),
+          _ConformanceCase(
+            suite: _fixtureSuite,
+            name: 'jsonrpc.rejects-malformed-error-object',
+            description:
+                'Rejects JSON-RPC error responses whose error member is malformed.',
+            check: _rejectsMalformedJsonRpcErrorObject,
+          ),
+          _ConformanceCase(
+            suite: _fixtureSuite,
+            name: 'jsonrpc.rejects-null-error-response-id',
+            description:
+                'Rejects JSON-RPC error responses whose id member is explicitly null.',
+            check: _rejectsNullJsonRpcErrorResponseId,
+          ),
+          _ConformanceCase(
+            suite: _fixtureSuite,
+            name: 'jsonrpc.rejects-null-params-member',
+            description:
+                'Rejects JSON-RPC request and notification envelopes whose params member is null.',
+            check: _rejectsNullJsonRpcParamsMember,
+          ),
+          _ConformanceCase(
+            suite: _fixtureSuite,
             name: 'jsonrpc.preserves-string-response-id',
             description:
                 'Parses and serializes successful responses with string JSON-RPC IDs.',
@@ -105,10 +147,31 @@ class ConformanceRunner {
           ),
           _ConformanceCase(
             suite: _fixtureSuite,
+            name: 'jsonrpc.preserves-integer-response-id',
+            description:
+                'Parses and serializes successful responses with integer JSON-RPC IDs.',
+            check: _preservesIntegerResponseId,
+          ),
+          _ConformanceCase(
+            suite: _fixtureSuite,
             name: 'jsonrpc.preserves-string-progress-token',
             description:
                 'Parses and serializes progress notifications with string progress tokens.',
             check: _preservesStringProgressToken,
+          ),
+          _ConformanceCase(
+            suite: _fixtureSuite,
+            name: 'jsonrpc.preserves-integer-progress-token',
+            description:
+                'Parses and serializes progress notifications with integer progress tokens.',
+            check: _preservesIntegerProgressToken,
+          ),
+          _ConformanceCase(
+            suite: _fixtureSuite,
+            name: 'jsonrpc.rejects-fractional-ids-and-progress-tokens',
+            description:
+                'Rejects fractional JSON-RPC request IDs, response IDs, and progress tokens.',
+            check: _rejectsFractionalIdsAndProgressTokens,
           ),
           _ConformanceCase(
             suite: _fixtureSuite,
@@ -125,6 +188,13 @@ class ConformanceRunner {
             description:
                 'Rejects operation requests before the initialize handshake.',
             check: _rejectsPreInitializeRequest,
+          ),
+          _ConformanceCase(
+            suite: _specSuite,
+            name: 'server-discover.requires-request-meta',
+            description:
+                'Rejects server/discover requests that omit params._meta request metadata.',
+            check: _serverDiscoverRequiresRequestMeta,
           ),
           _ConformanceCase(
             suite: _specSuite,
@@ -153,6 +223,13 @@ class ConformanceRunner {
             description:
                 'Rejects progress notifications whose progressToken is not a string or integer.',
             check: _rejectsMalformedProgressToken,
+          ),
+          _ConformanceCase(
+            suite: _specSuite,
+            name: 'progress.dispatches-integer-progress-token',
+            description:
+                'Dispatches progress notifications for integer progress tokens.',
+            check: _dispatchesIntegerProgressToken,
           ),
         ];
 
@@ -282,9 +359,9 @@ class _GeneratedJsonRpcFixture {
 }
 
 _GeneratedJsonRpcFixture _generatedJsonRpcFixture(Random random, int index) {
-  final numericId = random.nextInt(1000000);
+  final integerId = random.nextInt(1000000);
   final stringId = 'req-${random.nextInt(1000000)}';
-  final progressToken = random.nextBool() ? numericId : 'progress-$numericId';
+  final progressToken = random.nextBool() ? integerId : 'progress-$integerId';
 
   return switch (random.nextInt(6)) {
     0 => _GeneratedJsonRpcFixture(
@@ -293,7 +370,7 @@ _GeneratedJsonRpcFixture _generatedJsonRpcFixture(Random random, int index) {
             'Generated request with an invalid JSON-RPC version is rejected.',
         message: <String, dynamic>{
           'jsonrpc': '2.${random.nextInt(9) + 1}',
-          'id': random.nextBool() ? numericId : stringId,
+          'id': random.nextBool() ? integerId : stringId,
           'method': Method.ping,
         },
         expectation: _expectFormatExceptionForPayload,
@@ -304,7 +381,7 @@ _GeneratedJsonRpcFixture _generatedJsonRpcFixture(Random random, int index) {
             'Generated JSON-RPC envelope without request/response members is rejected.',
         message: <String, dynamic>{
           'jsonrpc': jsonRpcVersion,
-          'id': random.nextBool() ? numericId : stringId,
+          'id': random.nextBool() ? integerId : stringId,
           'params': <String, dynamic>{'noise': random.nextInt(100)},
         },
         expectation: _expectFormatExceptionForPayload,
@@ -314,7 +391,7 @@ _GeneratedJsonRpcFixture _generatedJsonRpcFixture(Random random, int index) {
         description: 'Generated requests preserve string-or-integer IDs.',
         message: <String, dynamic>{
           'jsonrpc': jsonRpcVersion,
-          'id': random.nextBool() ? numericId : stringId,
+          'id': random.nextBool() ? integerId : stringId,
           'method': Method.ping,
         },
         expectation: _expectRequestIdRoundTrip,
@@ -324,7 +401,7 @@ _GeneratedJsonRpcFixture _generatedJsonRpcFixture(Random random, int index) {
         description: 'Generated responses preserve string-or-integer IDs.',
         message: <String, dynamic>{
           'jsonrpc': jsonRpcVersion,
-          'id': random.nextBool() ? numericId : stringId,
+          'id': random.nextBool() ? integerId : stringId,
           'result': <String, dynamic>{},
         },
         expectation: _expectResponseIdRoundTrip,
@@ -350,7 +427,7 @@ _GeneratedJsonRpcFixture _generatedJsonRpcFixture(Random random, int index) {
             'Generated error responses preserve string-or-integer IDs.',
         message: <String, dynamic>{
           'jsonrpc': jsonRpcVersion,
-          'id': random.nextBool() ? numericId : stringId,
+          'id': random.nextBool() ? integerId : stringId,
           'error': <String, dynamic>{
             'code': ErrorCode.invalidRequest.value,
             'message': 'generated invalid request',
@@ -490,6 +567,57 @@ Future<void> _rejectsPreInitializeRequest() async {
   await server.close();
 }
 
+Future<void> _serverDiscoverRequiresRequestMeta() async {
+  for (final message in [
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 'discover-1',
+      'method': _serverDiscoverMethod,
+    },
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 'discover-1',
+      'method': _serverDiscoverMethod,
+      '_meta': <String, dynamic>{
+        _protocolVersionMetaKey: _draftProtocolVersion2026_07_28,
+      },
+    },
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 'discover-1',
+      'method': _serverDiscoverMethod,
+      'params': <String, dynamic>{},
+    },
+  ]) {
+    _expectThrowsFormatException(() => JsonRpcMessage.fromJson(message));
+  }
+
+  final parsed = JsonRpcMessage.fromJson(<String, dynamic>{
+    'jsonrpc': jsonRpcVersion,
+    'id': 'discover-1',
+    'method': _serverDiscoverMethod,
+    'params': <String, dynamic>{
+      '_meta': <String, dynamic>{
+        _protocolVersionMetaKey: _draftProtocolVersion2026_07_28,
+        _clientInfoMetaKey: <String, dynamic>{
+          'name': 'client',
+          'version': '1.0.0',
+        },
+        _clientCapabilitiesMetaKey: <String, dynamic>{},
+      },
+    },
+  });
+  if (parsed is! JsonRpcRequest) {
+    throw StateError(
+      'Expected JsonRpcRequest, got ${parsed.runtimeType}.',
+    );
+  }
+  if (parsed.meta?[_protocolVersionMetaKey] !=
+      _draftProtocolVersion2026_07_28) {
+    throw StateError('Expected server/discover metadata to be preserved.');
+  }
+}
+
 Future<void> _rejectsUnnegotiatedSamplingTools() async {
   final transport = _ConformanceTransport();
   final client = McpClient(
@@ -625,6 +753,64 @@ Future<void> _rejectsMalformedProgressToken() async {
   );
 }
 
+Future<void> _dispatchesIntegerProgressToken() async {
+  final transport = _ConformanceTransport();
+  final server = McpServer(
+    const Implementation(name: 'server', version: '1.0.0'),
+    options: const McpServerOptions(
+      capabilities: ServerCapabilities(tools: ServerCapabilitiesTools()),
+    ),
+  );
+  server.registerTool(
+    'progress_probe',
+    callback: (args, extra) async {
+      await extra.sendProgress(1, total: 2, message: 'halfway');
+      return const CallToolResult(
+        content: <Content>[TextContent(text: 'ok')],
+      );
+    },
+  );
+
+  await _initializeMcpServer(server, transport);
+  transport.emit(
+    const JsonRpcCallToolRequest(
+      id: 104,
+      params: <String, dynamic>{
+        'name': 'progress_probe',
+        'arguments': <String, dynamic>{},
+        '_meta': <String, dynamic>{
+          'progressToken': 15,
+        },
+      },
+    ),
+  );
+  await _settle();
+
+  final progressMessages = transport.sentMessages
+      .whereType<JsonRpcNotification>()
+      .where((message) => message.method == Method.notificationsProgress)
+      .toList();
+  if (progressMessages.length != 1) {
+    throw StateError(
+      'Expected one progress notification, got ${progressMessages.length}.',
+    );
+  }
+  final progress = ProgressNotification.fromJson(
+    progressMessages.single.params ?? const <String, dynamic>{},
+  );
+  if (progress.progressToken != 15) {
+    throw StateError('Expected integer progress token to be preserved.');
+  }
+  if (progress.progress != 1 || progress.total != 2) {
+    throw StateError('Expected progress values to be preserved.');
+  }
+
+  final responses =
+      transport.sentMessages.whereType<JsonRpcResponse>().toList();
+  _expectSingleErrorFreeResponse(responses, id: 104);
+  await server.close();
+}
+
 Future<void> _rejectsInvalidJsonRpcVersion() async {
   _expectThrowsFormatException(
     () => JsonRpcMessage.fromJson(const <String, dynamic>{
@@ -644,6 +830,115 @@ Future<void> _rejectsMalformedJsonRpcMessage() async {
   );
 }
 
+Future<void> _rejectsNonStringJsonRpcMethod() async {
+  _expectThrowsFormatException(
+    () => JsonRpcMessage.fromJson(const <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 1,
+      'method': 1,
+    }),
+  );
+}
+
+Future<void> _rejectsResultErrorJsonRpcResponse() async {
+  _expectThrowsFormatException(
+    () => JsonRpcMessage.fromJson(<String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 1,
+      'result': <String, dynamic>{},
+      'error': <String, dynamic>{
+        'code': ErrorCode.internalError.value,
+        'message': 'Internal error',
+      },
+    }),
+  );
+}
+
+Future<void> _rejectsMalformedJsonRpcErrorObject() async {
+  _expectThrowsFormatException(
+    () => JsonRpcMessage.fromJson(const <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 1,
+      'error': <String, dynamic>{
+        'code': 'not-a-number',
+        'message': 'Invalid request',
+      },
+    }),
+  );
+}
+
+Future<void> _rejectsNullJsonRpcErrorResponseId() async {
+  _expectThrowsFormatException(
+    () => JsonRpcMessage.fromJson(const <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': null,
+      'error': <String, dynamic>{
+        'code': -32600,
+        'message': 'Invalid request',
+      },
+    }),
+  );
+}
+
+Future<void> _rejectsNullJsonRpcParamsMember() async {
+  for (final message in const [
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 1,
+      'method': Method.ping,
+      'params': null,
+    },
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'method': Method.notificationsInitialized,
+      'params': null,
+    },
+  ]) {
+    _expectThrowsFormatException(() => JsonRpcMessage.fromJson(message));
+  }
+}
+
+Future<void> _rejectsFractionalIdsAndProgressTokens() async {
+  for (final message in const [
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 1.5,
+      'method': Method.ping,
+    },
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 1.5,
+      'result': <String, dynamic>{},
+    },
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 1.5,
+      'error': <String, dynamic>{
+        'code': -32600,
+        'message': 'Invalid request',
+      },
+    },
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'id': 1,
+      'method': Method.ping,
+      'params': <String, dynamic>{
+        '_meta': <String, dynamic>{'progressToken': 1.5},
+      },
+    },
+    <String, dynamic>{
+      'jsonrpc': jsonRpcVersion,
+      'method': Method.notificationsProgress,
+      'params': <String, dynamic>{
+        'progressToken': 1.5,
+        'progress': 1,
+      },
+    },
+  ]) {
+    _expectThrowsFormatException(() => JsonRpcMessage.fromJson(message));
+  }
+}
+
 Future<void> _preservesStringResponseId() async {
   final message = JsonRpcMessage.fromJson(const <String, dynamic>{
     'jsonrpc': jsonRpcVersion,
@@ -659,6 +954,24 @@ Future<void> _preservesStringResponseId() async {
   }
   if (message.toJson()['id'] != 'request-1') {
     throw StateError('Expected serialized response ID to stay a string.');
+  }
+}
+
+Future<void> _preservesIntegerResponseId() async {
+  final message = JsonRpcMessage.fromJson(const <String, dynamic>{
+    'jsonrpc': jsonRpcVersion,
+    'id': 15,
+    'result': <String, dynamic>{},
+  });
+
+  if (message is! JsonRpcResponse) {
+    throw StateError('Expected JsonRpcResponse, got ${message.runtimeType}.');
+  }
+  if (message.id != 15) {
+    throw StateError('Expected integer response ID to be preserved.');
+  }
+  if (message.toJson()['id'] != 15) {
+    throw StateError('Expected serialized response ID to stay an integer.');
   }
 }
 
@@ -728,6 +1041,30 @@ Future<void> _preservesStringProgressToken() async {
   }
   if (message.toJson()['params']['progressToken'] != 'progress-1') {
     throw StateError('Expected serialized progress token to stay a string.');
+  }
+}
+
+Future<void> _preservesIntegerProgressToken() async {
+  final message = JsonRpcMessage.fromJson(const <String, dynamic>{
+    'jsonrpc': jsonRpcVersion,
+    'method': Method.notificationsProgress,
+    'params': <String, dynamic>{
+      'progressToken': 15,
+      'progress': 1,
+      'total': 2,
+    },
+  });
+
+  if (message is! JsonRpcProgressNotification) {
+    throw StateError(
+      'Expected JsonRpcProgressNotification, got ${message.runtimeType}.',
+    );
+  }
+  if (message.progressParams.progressToken != 15) {
+    throw StateError('Expected integer progress token to be preserved.');
+  }
+  if (message.toJson()['params']['progressToken'] != 15) {
+    throw StateError('Expected serialized progress token to stay an integer.');
   }
 }
 

--- a/packages/mcp_dart_cli/test/src/conformance_command_test.dart
+++ b/packages/mcp_dart_cli/test/src/conformance_command_test.dart
@@ -20,8 +20,16 @@ void main() {
         containsAll(<String>[
           'jsonrpc.rejects-invalid-version',
           'jsonrpc.rejects-malformed-message',
+          'jsonrpc.rejects-non-string-method',
+          'jsonrpc.rejects-result-error-response',
+          'jsonrpc.rejects-malformed-error-object',
+          'jsonrpc.rejects-null-error-response-id',
+          'jsonrpc.rejects-null-params-member',
           'jsonrpc.preserves-string-response-id',
+          'jsonrpc.preserves-integer-response-id',
           'jsonrpc.preserves-string-progress-token',
+          'jsonrpc.preserves-integer-progress-token',
+          'jsonrpc.rejects-fractional-ids-and-progress-tokens',
           'protocol-version.advertises-latest-2025-11-25',
         ]),
       );
@@ -36,10 +44,12 @@ void main() {
         result.caseNames,
         containsAll(<String>[
           'lifecycle.rejects-pre-initialize-request',
+          'server-discover.requires-request-meta',
           'capabilities.rejects-unnegotiated-sampling-tools',
           'elicitation.rejects-invalid-form-url-union',
           'tasks.strips-unnegotiated-related-task-metadata',
           'progress.rejects-malformed-progress-token',
+          'progress.dispatches-integer-progress-token',
         ]),
       );
       expect(

--- a/test/client/client_test.dart
+++ b/test/client/client_test.dart
@@ -56,14 +56,14 @@ void main() {
 
     test('registerCapabilities merges capabilities', () {
       final initialCapabilities =
-          const ClientCapabilities(experimental: {'feature1': true});
+          const ClientCapabilities(experimental: {'feature1': {}});
       client = Client(
         clientInfo,
         options: McpClientOptions(capabilities: initialCapabilities),
       );
 
       final additionalCapabilities = const ClientCapabilities(
-        experimental: {'feature2': true},
+        experimental: {'feature2': {}},
         roots: ClientCapabilitiesRoots(listChanged: true),
       );
 

--- a/test/client/streamable_https_test.dart
+++ b/test/client/streamable_https_test.dart
@@ -1089,6 +1089,11 @@ void main() {
       transport = StreamableHttpClientTransport(
         Uri.parse('http://localhost:${server.port}/mcp'),
         opts: const StreamableHttpClientTransportOptions(
+          requestInit: {
+            'headers': {
+              'Mcp-Session-Id': 'custom-session',
+            },
+          },
           sessionId: 'legacy-session',
         ),
       )..protocolVersion = draftProtocolVersion2026_07_28;
@@ -1117,6 +1122,68 @@ void main() {
       expect(capturedHeaders['name'], 'echo');
       expect(capturedHeaders['session'], isNull);
       expect(transport.sessionId, 'legacy-session');
+    });
+
+    test('send derives 2026 stateless HTTP headers from nested metadata',
+        () async {
+      final capturedHeaders = <String, String?>{};
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        capturedHeaders['protocolVersion'] =
+            request.headers.value('mcp-protocol-version');
+        capturedHeaders['method'] = request.headers.value('mcp-method');
+        capturedHeaders['name'] = request.headers.value('mcp-name');
+        capturedHeaders['session'] = request.headers.value('mcp-session-id');
+        final body = jsonDecode(await utf8.decodeStream(request))
+            as Map<String, dynamic>;
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(
+            jsonEncode(
+              JsonRpcResponse(
+                id: body['id'],
+                result: const {'content': []},
+              ).toJson(),
+            ),
+          );
+        await request.response.close();
+      });
+
+      transport = StreamableHttpClientTransport(
+        Uri.parse('http://localhost:${server.port}/mcp'),
+        opts: const StreamableHttpClientTransportOptions(
+          sessionId: 'legacy-session',
+        ),
+      );
+      await transport.start();
+
+      final completer = Completer<JsonRpcMessage>();
+      transport.onmessage = completer.complete;
+
+      await transport.send(
+        const JsonRpcRequest(
+          id: 1,
+          method: Method.toolsCall,
+          params: {
+            'name': 'echo',
+            'arguments': {'message': 'hello'},
+            '_meta': {
+              McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
+            },
+          },
+        ),
+      );
+      await completer.future.timeout(const Duration(seconds: 5));
+
+      expect(
+        capturedHeaders['protocolVersion'],
+        draftProtocolVersion2026_07_28,
+      );
+      expect(capturedHeaders['method'], Method.toolsCall);
+      expect(capturedHeaders['name'], 'echo');
+      expect(capturedHeaders['session'], isNull);
     });
 
     test('send maps 2026 stateless headers for standard request types',

--- a/test/client/task_client_test.dart
+++ b/test/client/task_client_test.dart
@@ -29,7 +29,7 @@ class MockClient implements McpClient {
     JsonRpcRequest request,
     T Function(Map<String, dynamic> json) parser, [
     RequestOptions? options,
-    int? relatedRequestId,
+    RequestId? relatedRequestId,
   ]) async {
     requests.add(request);
 

--- a/test/elicitation_test.dart
+++ b/test/elicitation_test.dart
@@ -746,6 +746,23 @@ void main() {
         () => ElicitRequestParams.fromJson({
           'mode': 'url',
           'message': 'Please authenticate',
+          'url': 'relative/callback',
+          'elicitationId': 'oauth-123',
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ElicitRequestParams.url(
+          message: 'Please authenticate',
+          url: 'relative/callback',
+          elicitationId: 'oauth-123',
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => ElicitRequestParams.fromJson({
+          'mode': 'url',
+          'message': 'Please authenticate',
           'url': 'https://oauth.example.com/authorize',
           'elicitationId': 'oauth-123',
           'requestedSchema': {
@@ -1043,13 +1060,13 @@ void main() {
         throwsA(isA<FormatException>()),
       );
       expect(
-        () => ElicitResult.fromJson({
+        ElicitResult.fromJson({
           'action': 'accept',
           'content': {
             'ratio': 0.5,
           },
-        }),
-        throwsA(isA<FormatException>()),
+        }).content?['ratio'],
+        0.5,
       );
       expect(
         () => ElicitResult.fromJson({
@@ -1070,13 +1087,13 @@ void main() {
         throwsA(isA<ArgumentError>()),
       );
       expect(
-        () => const ElicitResult(
+        const ElicitResult(
           action: 'accept',
           content: {
             'ratio': 0.5,
           },
-        ).toJson(),
-        throwsA(isA<ArgumentError>()),
+        ).toJson()['content'],
+        containsPair('ratio', 0.5),
       );
       expect(
         () => const ElicitResult(

--- a/test/integration/completions_capability_test.dart
+++ b/test/integration/completions_capability_test.dart
@@ -92,7 +92,7 @@ void main() {
     test('Completions capability survives serialization round-trip', () {
       final originalCaps = const ServerCapabilities(
         completions: ServerCapabilitiesCompletions(listChanged: true),
-        experimental: {'test': true},
+        experimental: {'test': {}},
       );
 
       final json = originalCaps.toJson();
@@ -100,7 +100,7 @@ void main() {
 
       expect(deserializedCaps.completions, isNotNull);
       expect(json['completions'], isEmpty);
-      expect(deserializedCaps.experimental?['test'], equals(true));
+      expect(deserializedCaps.experimental?['test'], isEmpty);
     });
 
     test('legacy completions listChanged payload still parses', () {

--- a/test/mcp_2025_11_25_test.dart
+++ b/test/mcp_2025_11_25_test.dart
@@ -253,6 +253,26 @@ void main() {
       expect(deserialized.elicitationId, 'ui-123');
     });
 
+    test('Elicitation URL must be absolute URI', () {
+      expect(
+        () => ElicitRequestParams.fromJson({
+          'mode': 'url',
+          'message': 'test',
+          'url': '/relative/ui',
+          'elicitationId': 'ui-123',
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ElicitRequestParams.url(
+          message: 'test',
+          url: '/relative/ui',
+          elicitationId: 'ui-123',
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
     test('JsonEnum SEP-1330', () {
       final schema = const JsonEnum(
         [
@@ -306,14 +326,17 @@ void main() {
         action: 'accept',
         content: {
           'text': 'answer',
+          'confidence': 0.75,
           'selection': ['a', 'b'], // List<String>
         },
       );
+      expect(result.content?['confidence'], 0.75);
       expect(result.content?['selection'], isA<List>());
       expect((result.content?['selection'] as List).first, 'a');
 
       final json = result.toJson();
       final deserialized = ElicitResult.fromJson(json);
+      expect(deserialized.content?['confidence'], 0.75);
       expect((deserialized.content?['selection'] as List).last, 'b');
     });
 
@@ -496,6 +519,129 @@ void main() {
       final json = result.toJson();
       expect(json['stopReason'], 'toolUse');
       expect((json['content'] as List).single['type'], 'tool_use');
+    });
+
+    test('Sampling JSON object fields reject non-JSON Dart maps', () {
+      expect(
+        () => SamplingToolUseContent.fromJson({
+          'type': 'tool_use',
+          'id': 'call-1',
+          'name': 'calculator',
+          'input': {'expr': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => SamplingMessage.fromJson({
+          'role': 'user',
+          'content': {'type': 'text', 'text': 'Hello'},
+          '_meta': {'provider': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => CreateMessageResult.fromJson({
+          'role': 'assistant',
+          'content': {'type': 'text', 'text': 'Hello'},
+          'model': 'model-x',
+          '_meta': {'provider': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => CreateMessageRequestParams.fromJson({
+          'messages': [
+            {
+              'role': 'user',
+              'content': {'type': 'text', 'text': 'Hello'},
+            },
+          ],
+          'maxTokens': 100,
+          'metadata': {'provider': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('Content JSON object fields reject non-JSON Dart maps', () {
+      expect(
+        () => TextContent.fromJson({
+          'type': 'text',
+          'text': 'Hello',
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ResourceContents.fromJson({
+          'uri': 'file:///docs/readme.md',
+          'text': 'README body',
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ResourceLink.fromJson({
+          'type': 'resource_link',
+          'uri': 'file:///docs/readme.md',
+          'name': 'readme',
+          'annotations': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('Tool JSON object fields reject non-JSON Dart maps', () {
+      expect(
+        () => Tool.fromJson({
+          'name': 'search',
+          'inputSchema': {'type': 'object'},
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => CallToolRequest.fromJson({
+          'name': 'search',
+          'arguments': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => CallToolResult.fromJson({
+          'content': <Map<String, dynamic>>[],
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('Result metadata fields reject non-JSON Dart maps', () {
+      expect(
+        () => Root.fromJson({
+          'uri': 'file:///repo',
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ListResourcesResult.fromJson({
+          'resources': [],
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => JsonRpcMessage.fromJson({
+          'jsonrpc': jsonRpcVersion,
+          'id': 1,
+          'result': {
+            'ok': true,
+            '_meta': {'bad': Object()},
+          },
+        }),
+        throwsA(isA<FormatException>()),
+      );
     });
 
     group('Tasks API Types', () {
@@ -1080,6 +1226,26 @@ void main() {
         );
       });
 
+      test('request parsing prefers params metadata over top-level metadata',
+          () {
+        final parsed = JsonRpcMessage.fromJson(
+          const {
+            'jsonrpc': jsonRpcVersion,
+            'id': 'tools',
+            'method': Method.toolsList,
+            '_meta': {'progressToken': 'top-level'},
+            'params': {
+              '_meta': {'progressToken': 'params-nested'},
+            },
+          },
+        );
+
+        expect(parsed, isA<JsonRpcListToolsRequest>());
+        final request = parsed as JsonRpcListToolsRequest;
+        expect(request.meta, {'progressToken': 'params-nested'});
+        expect(request.progressToken, 'params-nested');
+      });
+
       test('server capabilities omit non-stable fields while parsing legacy',
           () {
         final capabilities = const ServerCapabilities(
@@ -1165,7 +1331,7 @@ void main() {
             isA<FormatException>().having(
               (error) => error.message,
               'message',
-              contains('Tool.inputSchema must be an object'),
+              contains('Tool.inputSchema must be a JSON object'),
             ),
           ),
         );
@@ -1179,7 +1345,7 @@ void main() {
             isA<FormatException>().having(
               (error) => error.message,
               'message',
-              contains('Tool.outputSchema must be an object'),
+              contains('Tool.outputSchema must be a JSON object'),
             ),
           ),
         );
@@ -1241,6 +1407,14 @@ void main() {
         );
         expect(
           () => Annotations.fromJson({'priority': -0.1}),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => Annotations(priority: double.nan).toJson(),
+          throwsA(anyOf(isA<AssertionError>(), isA<ArgumentError>())),
+        );
+        expect(
+          () => Annotations.fromJson({'priority': double.infinity}),
           throwsA(isA<FormatException>()),
         );
         expect(

--- a/test/mcp_2026_07_28_test.dart
+++ b/test/mcp_2026_07_28_test.dart
@@ -47,7 +47,12 @@ class DiscoveringClientTransport extends Transport
     this.capabilities = const ServerCapabilities(
       tools: ServerCapabilitiesTools(),
     ),
-    this.toolsListResult = const {'tools': []},
+    this.toolsListResult = const {
+      'resultType': resultTypeComplete,
+      'tools': [],
+      'ttlMs': 0,
+      'cacheScope': CacheScope.private,
+    },
   });
 
   final List<String> discoverVersions;
@@ -317,6 +322,218 @@ void main() {
       }
     });
 
+    test('request parsing does not let top-level metadata override params', () {
+      final parsed = JsonRpcMessage.fromJson({
+        'jsonrpc': jsonRpcVersion,
+        'id': 'tools',
+        'method': Method.toolsList,
+        '_meta': {
+          McpMetaKey.protocolVersion: latestProtocolVersion,
+        },
+        'params': {
+          '_meta': _clientMeta(),
+        },
+      });
+
+      expect(parsed, isA<JsonRpcListToolsRequest>());
+      final request = parsed as JsonRpcListToolsRequest;
+      expect(
+        request.meta?[McpMetaKey.protocolVersion],
+        draftProtocolVersion2026_07_28,
+      );
+      expect(request.meta?[McpMetaKey.clientInfo], {
+        'name': 'client',
+        'version': '1.0.0',
+      });
+    });
+
+    test('preserves integer request ids and progress tokens', () {
+      final message = JsonRpcMessage.fromJson(
+        const {
+          'jsonrpc': jsonRpcVersion,
+          'id': 1,
+          'method': Method.toolsList,
+          'params': {
+            '_meta': {'progressToken': 2},
+          },
+        },
+      );
+
+      expect(message, isA<JsonRpcListToolsRequest>());
+      final request = message as JsonRpcListToolsRequest;
+      expect(request.id, 1);
+      expect(request.progressToken, 2);
+      expect(request.toJson()['id'], 1);
+      expect(request.toJson()['params']['_meta']['progressToken'], 2);
+    });
+
+    test('rejects URL elicitation relative URI values', () {
+      expect(
+        () => ElicitRequestParams.fromJson({
+          'mode': 'url',
+          'message': 'Open browser',
+          'url': 'authorize/callback',
+          'elicitationId': 'auth-1',
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ElicitRequestParams.url(
+          message: 'Open browser',
+          url: 'authorize/callback',
+          elicitationId: 'auth-1',
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects non-finite JSON numbers', () {
+      expect(
+        () => ProgressNotification.fromJson({
+          'progressToken': 'progress-1',
+          'progress': double.nan,
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ProgressNotification(
+          progressToken: 'progress-1',
+          progress: double.infinity,
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => CreateMessageRequest.fromJson({
+          'messages': [
+            {
+              'role': 'user',
+              'content': {'type': 'text', 'text': 'Hello'},
+            },
+          ],
+          'maxTokens': 16,
+          'temperature': double.nan,
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ElicitResult.fromJson({
+          'action': 'accept',
+          'content': {'score': double.infinity},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ElicitResult(
+          action: 'accept',
+          content: {'score': double.nan},
+        ).toJson(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects non-JSON sampling object values', () {
+      expect(
+        () => SamplingToolUseContent.fromJson({
+          'type': 'tool_use',
+          'id': 'call-1',
+          'name': 'lookup',
+          'input': {'query': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => SamplingMessage.fromJson({
+          'role': 'user',
+          'content': {'type': 'text', 'text': 'Hello'},
+          '_meta': {'provider': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => CreateMessageResult.fromJson({
+          'role': 'assistant',
+          'content': {'type': 'text', 'text': 'Hello'},
+          'model': 'model-x',
+          '_meta': {'provider': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => CreateMessageRequest.fromJson({
+          'messages': [
+            {
+              'role': 'user',
+              'content': {'type': 'text', 'text': 'Hello'},
+            },
+          ],
+          'maxTokens': 16,
+          'metadata': {'provider': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects non-JSON content object values', () {
+      expect(
+        () => TextContent.fromJson({
+          'type': 'text',
+          'text': 'Hello',
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ResourceContents.fromJson({
+          'uri': 'file:///docs/readme.md',
+          'text': 'README body',
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ResourceLink.fromJson({
+          'type': 'resource_link',
+          'uri': 'file:///docs/readme.md',
+          'name': 'readme',
+          'annotations': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects non-JSON result metadata values', () {
+      expect(
+        () => DiscoverResult.fromJson({
+          'resultType': 'complete',
+          'supportedVersions': [draftProtocolVersion2026_07_28],
+          'capabilities': <String, dynamic>{},
+          'serverInfo': {'name': 'server', 'version': '1.0.0'},
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const DiscoverResult(
+          supportedVersions: [draftProtocolVersion2026_07_28],
+          capabilities: ServerCapabilities(),
+          serverInfo: Implementation(name: 'server', version: '1.0.0'),
+          meta: {'bad': Object()},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => JsonRpcMessage.fromJson({
+          'jsonrpc': jsonRpcVersion,
+          'id': 1,
+          'result': {
+            'resultType': 'complete',
+            '_meta': {'bad': Object()},
+          },
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
     test('serializes server/discover request and result', () {
       final request = JsonRpcServerDiscoverRequest(
         id: 'discover-1',
@@ -347,6 +564,63 @@ void main() {
       expect(
         DiscoverResult.fromJson(resultJson).instructions,
         'Use the tools.',
+      );
+    });
+
+    test('requires server/discover request metadata in params', () {
+      expect(
+        () => JsonRpcServerDiscoverRequest(id: 'discover-1').toJson(),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('params._meta'),
+          ),
+        ),
+      );
+
+      for (final message in [
+        {
+          'jsonrpc': jsonRpcVersion,
+          'id': 'discover-1',
+          'method': Method.serverDiscover,
+        },
+        {
+          'jsonrpc': jsonRpcVersion,
+          'id': 'discover-1',
+          'method': Method.serverDiscover,
+          '_meta': _clientMeta(),
+        },
+        {
+          'jsonrpc': jsonRpcVersion,
+          'id': 'discover-1',
+          'method': Method.serverDiscover,
+          'params': <String, dynamic>{},
+        },
+      ]) {
+        expect(
+          () => JsonRpcMessage.fromJson(message),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              anyOf(contains('params'), contains('params._meta')),
+            ),
+          ),
+        );
+      }
+
+      final parsed = JsonRpcMessage.fromJson({
+        'jsonrpc': jsonRpcVersion,
+        'id': 'discover-1',
+        'method': Method.serverDiscover,
+        'params': {'_meta': _clientMeta()},
+      });
+      expect(parsed, isA<JsonRpcServerDiscoverRequest>());
+      expect(
+        (parsed as JsonRpcServerDiscoverRequest)
+            .meta?[McpMetaKey.protocolVersion],
+        draftProtocolVersion2026_07_28,
       );
     });
 
@@ -499,10 +773,22 @@ void main() {
           const ElicitResult(
             action: 'accept',
             content: {'name': 'octocat'},
+            meta: {'stable': true},
           ),
         ),
         'roots': InputResponse.fromResult(
-          ListRootsResult(roots: [Root(uri: 'file:///repo')]),
+          ListRootsResult(
+            roots: [Root(uri: 'file:///repo')],
+            meta: const {'stable': true},
+          ),
+        ),
+        'capital_of_france': InputResponse.fromResult(
+          const CreateMessageResult(
+            model: 'model',
+            role: SamplingMessageRole.assistant,
+            content: SamplingTextContent(text: 'Paris'),
+            meta: {'preserved': true},
+          ),
         ),
       };
 
@@ -514,6 +800,14 @@ void main() {
       );
       final toolJson = toolRequest.toJson();
       expect(toolJson['inputResponses']['github_login']['action'], 'accept');
+      expect(
+        toolJson['inputResponses']['github_login'],
+        isNot(contains('_meta')),
+      );
+      expect(toolJson['inputResponses']['roots'], isNot(contains('_meta')));
+      expect(toolJson['inputResponses']['capital_of_france']['_meta'], {
+        'preserved': true,
+      });
       expect(toolJson['requestState'], 'opaque-state');
 
       final parsedToolRequest = CallToolRequest.fromJson(toolJson);
@@ -578,6 +872,21 @@ void main() {
         throwsFormatException,
       );
       expect(
+        () => InputRequiredResult.fromJson({
+          'resultType': resultTypeInputRequired,
+          'requestState': 'state',
+          '_meta': {'bad': Object()},
+        }),
+        throwsFormatException,
+      );
+      expect(
+        () => const InputRequiredResult(
+          requestState: 'state',
+          meta: {'bad': Object()},
+        ).toJson(),
+        throwsFormatException,
+      );
+      expect(
         () => InputRequiredResult.fromJson(
           const {
             'resultType': resultTypeInputRequired,
@@ -592,6 +901,20 @@ void main() {
         () => CallToolRequest.fromJson(
           const {'name': 'deploy', 'requestState': 1},
         ),
+        throwsFormatException,
+      );
+      expect(
+        () => CallToolRequest.fromJson({
+          'name': 'deploy',
+          'arguments': {'bad': Object()},
+        }),
+        throwsFormatException,
+      );
+      expect(
+        () => const CallToolRequest(
+          name: 'deploy',
+          arguments: {'bad': Object()},
+        ).toJson(),
         throwsFormatException,
       );
       expect(
@@ -612,6 +935,27 @@ void main() {
             },
           },
         ),
+        throwsFormatException,
+      );
+      expect(
+        () => ReadResourceRequest.fromJson(
+          const {
+            'uri': 'file:///repo/README.md',
+            'inputResponses': {
+              'roots': {
+                'roots': [],
+                '_meta': {'trace': 'not-in-draft-client-result'},
+              },
+            },
+          },
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => const InputResponse.raw({
+          'action': 'accept',
+          '_meta': {'trace': 'not-in-draft-client-result'},
+        }).toJson(),
         throwsFormatException,
       );
     });
@@ -1898,6 +2242,23 @@ void main() {
         ),
       );
       expect(
+        validateToolRequest({
+          McpMetaKey.protocolVersion: draftProtocolVersion2026_07_28,
+          McpMetaKey.clientInfo: {
+            'name': 'client',
+            'version': '1.0.0',
+          },
+          McpMetaKey.clientCapabilities: {
+            'experimental': {'feature': true},
+          },
+        }),
+        isA<McpError>().having(
+          (error) => error.message,
+          'message',
+          contains('Invalid stateless request metadata.'),
+        ),
+      );
+      expect(
         validateToolRequest(_clientMeta(logLevel: 'verbose')),
         isA<McpError>().having(
           (error) => error.message,
@@ -2154,6 +2515,159 @@ void main() {
         'version': '1.0.0',
       });
       expect(listRequest.meta?[McpMetaKey.clientCapabilities], {});
+    });
+
+    test('stateless client rejects removed request methods before send',
+        () async {
+      final transport = DiscoveringClientTransport();
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+      transport.sentMessages.clear();
+
+      final removedRequests = <({String method, Future<void> Function() call})>[
+        (
+          method: Method.ping,
+          call: () async {
+            await client.ping();
+          },
+        ),
+        (
+          method: Method.loggingSetLevel,
+          call: () async {
+            await client.setLoggingLevel(LoggingLevel.debug);
+          },
+        ),
+        (
+          method: Method.resourcesSubscribe,
+          call: () async {
+            await client.subscribeResource(
+              const SubscribeRequest(uri: 'file:///tmp/example.txt'),
+            );
+          },
+        ),
+        (
+          method: Method.resourcesUnsubscribe,
+          call: () async {
+            await client.unsubscribeResource(
+              const UnsubscribeRequest(uri: 'file:///tmp/example.txt'),
+            );
+          },
+        ),
+        (
+          method: Method.tasksList,
+          call: () async {
+            await client.request<ListTasksResult>(
+              JsonRpcListTasksRequest(id: -1),
+              ListTasksResult.fromJson,
+            );
+          },
+        ),
+        (
+          method: Method.tasksResult,
+          call: () async {
+            await client.request<CallToolResult>(
+              JsonRpcTaskResultRequest(
+                id: -1,
+                resultParams: const TaskResultRequest(taskId: 'task-1'),
+              ),
+              CallToolResult.fromJson,
+            );
+          },
+        ),
+      ];
+
+      for (final scenario in removedRequests) {
+        await expectLater(
+          scenario.call(),
+          throwsA(
+            isA<McpError>()
+                .having(
+                  (error) => error.code,
+                  'code',
+                  ErrorCode.methodNotFound.value,
+                )
+                .having(
+                  (error) => error.message,
+                  'message',
+                  contains(scenario.method),
+                ),
+          ),
+        );
+      }
+
+      expect(transport.sentMessages, isEmpty);
+    });
+
+    test('stateless client rejects removed notifications before send',
+        () async {
+      final transport = DiscoveringClientTransport();
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+      await client.connect(transport);
+      transport.sentMessages.clear();
+
+      final removedNotifications =
+          <({String method, Future<void> Function() call})>[
+        (
+          method: Method.notificationsInitialized,
+          call: () => client.notification(
+                const JsonRpcInitializedNotification(),
+              ),
+        ),
+        (
+          method: Method.notificationsRootsListChanged,
+          call: client.sendRootsListChanged,
+        ),
+      ];
+
+      for (final scenario in removedNotifications) {
+        await expectLater(
+          scenario.call(),
+          throwsA(
+            isA<McpError>()
+                .having(
+                  (error) => error.code,
+                  'code',
+                  ErrorCode.methodNotFound.value,
+                )
+                .having(
+                  (error) => error.message,
+                  'message',
+                  contains(scenario.method),
+                ),
+          ),
+        );
+      }
+
+      expect(transport.sentMessages, isEmpty);
+    });
+
+    test('stateless client rejects server-initiated requests on transport',
+        () async {
+      final transport = DiscoveringClientTransport();
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(
+          capabilities: ClientCapabilities(roots: ClientCapabilitiesRoots()),
+          useServerDiscover: true,
+        ),
+      );
+      await client.connect(transport);
+      transport.sentMessages.clear();
+
+      transport.onmessage?.call(const JsonRpcListRootsRequest(id: 'roots-1'));
+      await _pump();
+
+      final response = transport.sentMessages.single as JsonRpcError;
+      expect(response.id, 'roots-1');
+      expect(response.error.code, ErrorCode.invalidRequest.value);
+      expect(response.error.message, contains('input_required'));
+      expect(response.error.message, contains('inputRequests'));
     });
 
     test('client listenSubscriptions requires a connected transport', () {
@@ -2576,12 +3090,45 @@ void main() {
       transport.onmessage?.call(
         JsonRpcResponse(
           id: subscription.id,
-          result: const EmptyResult().toJson(),
+          result: const {'resultType': resultTypeComplete},
         ),
       );
 
       await acknowledgedExpectation;
       await doneExpectation;
+    });
+
+    test('client rejects missing stateless resultType values', () async {
+      final transport = DiscoveringClientTransport(
+        toolsListResult: const {
+          'tools': [],
+          'ttlMs': 0,
+          'cacheScope': CacheScope.private,
+        },
+      );
+      final client = McpClient(
+        const Implementation(name: 'client', version: '1.0.0'),
+        options: const McpClientOptions(useServerDiscover: true),
+      );
+
+      await client.connect(transport);
+
+      await expectLater(
+        client.listTools(),
+        throwsA(
+          isA<McpError>()
+              .having(
+                (error) => error.code,
+                'code',
+                ErrorCode.internalError.value,
+              )
+              .having(
+                (error) => error.data.toString(),
+                'data',
+                contains('must include resultType'),
+              ),
+        ),
+      );
     });
 
     test('client rejects unrecognized stateless resultType values', () async {
@@ -2652,6 +3199,77 @@ void main() {
         ),
       );
     });
+
+    for (final scenario in [
+      (
+        name: 'missing ttlMs',
+        result: const {
+          'resultType': resultTypeComplete,
+          'tools': [],
+          'cacheScope': CacheScope.private,
+        },
+        message: 'ttlMs',
+      ),
+      (
+        name: 'missing cacheScope',
+        result: const {
+          'resultType': resultTypeComplete,
+          'tools': [],
+          'ttlMs': 0,
+        },
+        message: 'cacheScope',
+      ),
+      (
+        name: 'negative ttlMs',
+        result: const {
+          'resultType': resultTypeComplete,
+          'tools': [],
+          'ttlMs': -1,
+          'cacheScope': CacheScope.private,
+        },
+        message: 'ttlMs',
+      ),
+      (
+        name: 'invalid cacheScope',
+        result: const {
+          'resultType': resultTypeComplete,
+          'tools': [],
+          'ttlMs': 0,
+          'cacheScope': 'shared',
+        },
+        message: 'cacheScope',
+      ),
+    ]) {
+      test('client rejects stateless cacheable result ${scenario.name}',
+          () async {
+        final transport = DiscoveringClientTransport(
+          toolsListResult: scenario.result,
+        );
+        final client = McpClient(
+          const Implementation(name: 'client', version: '1.0.0'),
+          options: const McpClientOptions(useServerDiscover: true),
+        );
+
+        await client.connect(transport);
+
+        await expectLater(
+          client.listTools(),
+          throwsA(
+            isA<McpError>()
+                .having(
+                  (error) => error.code,
+                  'code',
+                  ErrorCode.internalError.value,
+                )
+                .having(
+                  (error) => error.data.toString(),
+                  'data',
+                  contains(scenario.message),
+                ),
+          ),
+        );
+      });
+    }
 
     test('client accepts advertised task extension resultType values',
         () async {

--- a/test/server/stdio_test.dart
+++ b/test/server/stdio_test.dart
@@ -347,8 +347,29 @@ void main() {
           field: 'id',
           message: {
             'jsonrpc': '2.0',
+            'id': 1.5,
+            'method': 'ping',
+          },
+        ),
+        (
+          field: 'id',
+          message: {
+            'jsonrpc': '2.0',
             'id': null,
             'method': 'ping',
+          },
+        ),
+        (
+          field: 'progressToken',
+          message: {
+            'jsonrpc': '2.0',
+            'id': 'with-bad-meta',
+            'method': 'ping',
+            'params': {
+              '_meta': {
+                'progressToken': 1.5,
+              },
+            },
           },
         ),
         (
@@ -381,6 +402,17 @@ void main() {
             'jsonrpc': '2.0',
             'method': 'notifications/progress',
             'params': {
+              'progressToken': 1.5,
+              'progress': 0,
+            },
+          },
+        ),
+        (
+          field: 'progressToken',
+          message: {
+            'jsonrpc': '2.0',
+            'method': 'notifications/progress',
+            'params': {
               'progressToken': <Object>[],
               'progress': 0,
             },
@@ -402,6 +434,17 @@ void main() {
             'jsonrpc': '2.0',
             'id': false,
             'result': <String, dynamic>{},
+          },
+        ),
+        (
+          field: 'id',
+          message: {
+            'jsonrpc': '2.0',
+            'id': null,
+            'error': {
+              'code': -32600,
+              'message': 'Invalid request',
+            },
           },
         ),
         (

--- a/test/server/streamable_mcp_server_test.dart
+++ b/test/server/streamable_mcp_server_test.dart
@@ -227,6 +227,28 @@ void main() {
       }
     });
 
+    test('CORS preflight allows stateless routing and parameter headers',
+        () async {
+      final client = http.Client();
+      try {
+        final req = http.Request('OPTIONS', Uri.parse(baseUrl))
+          ..headers['Access-Control-Request-Method'] = 'POST'
+          ..headers['Access-Control-Request-Headers'] =
+              'Mcp-Method, Mcp-Name, Mcp-Param-Region';
+        final streamedRes = await client.send(req);
+        final res = await http.Response.fromStream(streamedRes);
+        final allowedHeaders =
+            res.headers['access-control-allow-headers']!.toLowerCase();
+
+        expect(res.statusCode, HttpStatus.ok);
+        expect(allowedHeaders, contains('mcp-method'));
+        expect(allowedHeaders, contains('mcp-name'));
+        expect(allowedHeaders, contains('mcp-param-region'));
+      } finally {
+        client.close();
+      }
+    });
+
     test('initialize session flow', () async {
       final initRequest = JsonRpcRequest(
         id: 1,
@@ -326,6 +348,51 @@ void main() {
         body: jsonEncode(
           JsonRpcListToolsRequest(id: 1, meta: statelessMeta()).toJson(),
         ),
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json, text/event-stream',
+          'MCP-Protocol-Version': draftProtocolVersion2026_07_28,
+          'Mcp-Method': Method.toolsList,
+        },
+      );
+
+      expect(response.statusCode, HttpStatus.ok);
+      expect(response.headers['mcp-session-id'], isNull);
+      final messages = _decodeSseJsonMessages(response.body);
+      expect(messages.single['result']['tools'][0]['name'], 'echo');
+    });
+
+    test('detects stateless requests from nested metadata before top-level',
+        () async {
+      await server.stop();
+      server = StreamableMcpServer(
+        serverFactory: (sessionId) {
+          final mcpServer = McpServer(
+            const Implementation(name: 'StatelessServer', version: '1.0.0'),
+          );
+          mcpServer.registerTool(
+            'echo',
+            inputSchema: const ToolInputSchema(),
+            callback: (args, extra) async => const CallToolResult(content: []),
+          );
+          return mcpServer;
+        },
+        host: host,
+        port: port,
+      );
+      await server.start();
+
+      final request = JsonRpcListToolsRequest(
+        id: 11,
+        meta: statelessMeta(),
+      ).toJson()
+        ..['_meta'] = const {
+          McpMetaKey.protocolVersion: latestProtocolVersion,
+        };
+
+      final response = await http.post(
+        Uri.parse(baseUrl),
+        body: jsonEncode(request),
         headers: {
           'Content-Type': 'application/json',
           'Accept': 'application/json, text/event-stream',

--- a/test/shared/progress_test.dart
+++ b/test/shared/progress_test.dart
@@ -264,6 +264,92 @@ void main() {
       expect(msg3, isA<JsonRpcResponse>());
     });
 
+    test('Server sends progress with integer progress token', () async {
+      protocol.setRequestHandler<JsonRpcRequest>(
+        'test/integer-token-task',
+        (request, extra) async {
+          await extra.sendProgress(10, total: 100, message: 'Starting');
+          return TestResult(value: 'success');
+        },
+        (id, params, meta) => JsonRpcRequest(
+          id: id,
+          method: 'test/integer-token-task',
+          params: params,
+          meta: meta,
+        ),
+      );
+
+      const progressToken = 12345;
+      transport.receiveMessage(
+        const JsonRpcRequest(
+          id: 99,
+          method: 'test/integer-token-task',
+          meta: {'progressToken': progressToken},
+        ),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(transport.sentMessages.length, 2);
+
+      final msg1 = transport.sentMessages[0];
+      expect(msg1, isA<JsonRpcNotification>());
+      expect((msg1 as JsonRpcNotification).method, 'notifications/progress');
+      expect(msg1.params, isNotNull);
+      expect(msg1.params!['progressToken'], progressToken);
+      expect(msg1.params!['progress'], 10);
+      expect(msg1.params!['message'], 'Starting');
+
+      final msg2 = transport.sentMessages[1];
+      expect(msg2, isA<JsonRpcResponse>());
+    });
+
+    test('RequestHandlerExtra ignores malformed progress token', () async {
+      final sentNotifications = <JsonRpcNotification>[];
+      final extra = RequestHandlerExtra(
+        signal: BasicAbortController().signal,
+        requestId: 101,
+        meta: const {'progressToken': double.nan},
+        sendNotification: (notification, {relatedTask}) async {
+          sentNotifications.add(notification);
+        },
+        sendRequest: <T extends BaseResultData>(
+          JsonRpcRequest request,
+          T Function(Map<String, dynamic>) resultFactory,
+          RequestOptions options,
+        ) async {
+          return resultFactory({});
+        },
+      );
+
+      await extra.sendProgress(10);
+
+      expect(sentNotifications, isEmpty);
+    });
+
+    test('RequestHandlerExtra ignores fractional progress token', () async {
+      final sentNotifications = <JsonRpcNotification>[];
+      final extra = RequestHandlerExtra(
+        signal: BasicAbortController().signal,
+        requestId: 101,
+        meta: const {'progressToken': 123.5},
+        sendNotification: (notification, {relatedTask}) async {
+          sentNotifications.add(notification);
+        },
+        sendRequest: <T extends BaseResultData>(
+          JsonRpcRequest request,
+          T Function(Map<String, dynamic>) resultFactory,
+          RequestOptions options,
+        ) async {
+          return resultFactory({});
+        },
+      );
+
+      await extra.sendProgress(10);
+
+      expect(sentNotifications, isEmpty);
+    });
+
     test('RequestHandlerExtra rejects non-increasing progress', () async {
       final sentNotifications = <JsonRpcNotification>[];
       final extra = RequestHandlerExtra(

--- a/test/shared/protocol_advanced_scenarios_test.dart
+++ b/test/shared/protocol_advanced_scenarios_test.dart
@@ -103,12 +103,13 @@ void main() {
 
       // Send progress notification with an invalid progressToken type.
       transport.receiveMessage(
-        JsonRpcProgressNotification(
-          progressParams: const ProgressNotificationParams(
-            progressToken: false,
-            progress: 50,
-            total: 100,
-          ),
+        const JsonRpcNotification(
+          method: Method.notificationsProgress,
+          params: {
+            'progressToken': false,
+            'progress': 50,
+            'total': 100,
+          },
         ),
       );
 

--- a/test/shared/protocol_test.dart
+++ b/test/shared/protocol_test.dart
@@ -477,6 +477,46 @@ void main() {
       expect(response.result['value'], 'nested-ok');
     });
 
+    test('public request preserves string relatedRequestId', () async {
+      await protocol.connect(transport);
+
+      final requestFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(id: 0, method: 'test/method'),
+            (json) => TestResult(value: json['value'] as String),
+            const RequestOptions(timeout: Duration(seconds: 1)),
+            'parent-req-1',
+          )
+          .timeout(const Duration(seconds: 5));
+
+      await waitForSentMessages(transport, 1);
+
+      expect(transport.sentMessages[0], isA<JsonRpcRequest>());
+      expect(transport.relatedRequestIds[0], 'parent-req-1');
+
+      final request = transport.sentMessages[0] as JsonRpcRequest;
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: request.id,
+          result: {'value': 'ok'},
+        ),
+      );
+
+      expect((await requestFuture).value, 'ok');
+    });
+
+    test('public notification preserves integer relatedRequestId', () async {
+      await protocol.connect(transport);
+
+      await protocol.notification(
+        const JsonRpcNotification(method: 'test/notification'),
+        relatedRequestId: 15,
+      );
+
+      expect(transport.sentMessages.single, isA<JsonRpcNotification>());
+      expect(transport.relatedRequestIds.single, 15);
+    });
+
     test('routes nested cancellation notifications for string request IDs',
         () async {
       await protocol.connect(transport);
@@ -592,6 +632,58 @@ void main() {
         JsonRpcProgressNotification(
           progressParams: const ProgressNotification(
             progressToken: 'progress-token-1',
+            progress: 50,
+            total: 100,
+            message: 'halfway',
+          ),
+        ),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(progressUpdates, hasLength(1));
+      expect(progressUpdates.single.progress, 50);
+      expect(progressUpdates.single.total, 100);
+      expect(progressUpdates.single.message, 'halfway');
+
+      transport.receiveMessage(
+        JsonRpcResponse(
+          id: sentRequest.id,
+          result: {'value': 'response-data'},
+        ),
+      );
+
+      final result = await requestFuture;
+      expect(result.value, 'response-data');
+    });
+
+    test('dispatches integer progress tokens from request metadata', () async {
+      await protocol.connect(transport);
+
+      final progressUpdates = <Progress>[];
+      final requestFuture = protocol
+          .request<TestResult>(
+            const JsonRpcRequest(
+              id: 0,
+              method: 'test/method',
+              meta: {'progressToken': 15},
+            ),
+            (json) => TestResult(value: json['value'] as String),
+            RequestOptions(
+              onprogress: progressUpdates.add,
+              timeout: const Duration(seconds: 1),
+            ),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      expect(transport.sentMessages, hasLength(1));
+      final sentRequest = transport.sentMessages.single as JsonRpcRequest;
+      expect(sentRequest.meta?['progressToken'], 15);
+
+      transport.receiveMessage(
+        JsonRpcProgressNotification(
+          progressParams: const ProgressNotification(
+            progressToken: 15,
             progress: 50,
             total: 100,
             message: 'halfway',
@@ -1136,6 +1228,48 @@ void main() {
             id: 0,
             method: 'test/method',
             meta: {'progressToken': false},
+          ),
+          (json) => TestResult(value: json['value'] as String),
+          RequestOptions(onprogress: (_) {}),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      expect(transport.sentMessages, isEmpty);
+    });
+
+    test(
+        'rejects non-finite request progress tokens when progress handler is set',
+        () async {
+      await protocol.connect(transport);
+
+      await expectLater(
+        protocol.request<TestResult>(
+          const JsonRpcRequest(
+            id: 0,
+            method: 'test/method',
+            meta: {'progressToken': double.nan},
+          ),
+          (json) => TestResult(value: json['value'] as String),
+          RequestOptions(onprogress: (_) {}),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      expect(transport.sentMessages, isEmpty);
+    });
+
+    test(
+        'rejects fractional request progress tokens when progress handler is set',
+        () async {
+      await protocol.connect(transport);
+
+      await expectLater(
+        protocol.request<TestResult>(
+          const JsonRpcRequest(
+            id: 0,
+            method: 'test/method',
+            meta: {'progressToken': 1.5},
           ),
           (json) => TestResult(value: json['value'] as String),
           RequestOptions(onprogress: (_) {}),

--- a/test/shared/transport_api_compatibility_test.dart
+++ b/test/shared/transport_api_compatibility_test.dart
@@ -30,7 +30,7 @@ class LegacyTransport implements Transport {
   Future<void> start() async {}
 }
 
-class StringAwareTransport extends LegacyTransport
+class FullRequestIdAwareTransport extends LegacyTransport
     implements RequestIdAwareTransport {
   RequestId? lastRequestIdAwareRelatedRequestId;
 
@@ -59,9 +59,10 @@ void main() {
       expect(transport.lastRelatedRequestId, isNull);
     });
 
-    test('request-id-aware transports preserve string relatedRequestId',
+    test(
+        'request-id-aware transports preserve string and integer relatedRequestId',
         () async {
-      final transport = StringAwareTransport();
+      final transport = FullRequestIdAwareTransport();
 
       await transport.sendPreservingRequestId(
         const JsonRpcNotification(method: 'test/notification'),
@@ -71,6 +72,13 @@ void main() {
       expect(transport.lastMessage, isA<JsonRpcNotification>());
       expect(transport.lastRelatedRequestId, isNull);
       expect(transport.lastRequestIdAwareRelatedRequestId, 'client-req-1');
+
+      await transport.sendPreservingRequestId(
+        const JsonRpcNotification(method: 'test/notification'),
+        relatedRequestId: 15,
+      );
+
+      expect(transport.lastRequestIdAwareRelatedRequestId, 15);
     });
   });
 }

--- a/test/tool_schema_test.dart
+++ b/test/tool_schema_test.dart
@@ -232,6 +232,60 @@ void main() {
       expect(parsedNull.structuredContent, isNull);
     });
 
+    test('Tool JSON object fields reject non-JSON Dart map values', () {
+      expect(
+        () => Tool.fromJson({
+          'name': 'search',
+          'inputSchema': {'type': 'object'},
+          '_meta': {'bad': Object()},
+        }),
+        throwsFormatException,
+      );
+      expect(
+        () => const Tool(
+          name: 'search',
+          inputSchema: JsonObject(),
+          meta: {'bad': Object()},
+        ).toJson(),
+        throwsFormatException,
+      );
+      expect(
+        () => CallToolRequest.fromJson({
+          'name': 'search',
+          'arguments': {'bad': Object()},
+        }),
+        throwsFormatException,
+      );
+      expect(
+        () => const CallToolRequest(
+          name: 'search',
+          arguments: {'bad': Object()},
+        ).toJson(),
+        throwsFormatException,
+      );
+      expect(
+        () => CallToolResult.fromJson({
+          'content': <Map<String, dynamic>>[],
+          '_meta': {'bad': Object()},
+        }),
+        throwsFormatException,
+      );
+      expect(
+        () => const CallToolResult(
+          content: [],
+          meta: {'bad': Object()},
+        ).toJson(),
+        throwsFormatException,
+      );
+      expect(
+        () => CallToolResult.fromJson({
+          'content': <Map<String, dynamic>>[],
+          'x-extra': Object(),
+        }),
+        throwsFormatException,
+      );
+    });
+
     test('Tool serializes JsonEnum properties as standard enum schema', () {
       const tool = Tool(
         name: 'configure_mode',

--- a/test/types/sampling_test.dart
+++ b/test/types/sampling_test.dart
@@ -76,6 +76,19 @@ void main() {
       expect(prefs.hints, isNull);
       expect(prefs.costPriority, isNull);
     });
+
+    test('rejects non-finite priorities', () {
+      for (final value in [double.nan, double.infinity]) {
+        expect(
+          () => ModelPreferences.fromJson({'costPriority': value}),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => ModelPreferences(costPriority: value).toJson(),
+          throwsA(anyOf(isA<AssertionError>(), isA<ArgumentError>())),
+        );
+      }
+    });
   });
 
   group('SamplingContent', () {
@@ -203,6 +216,26 @@ void main() {
         final tool = content as SamplingToolUseContent;
         expect(tool.name, equals('fetch'));
         expect(tool.id, equals('tu1'));
+      });
+
+      test('rejects non-JSON input objects', () {
+        expect(
+          () => SamplingContent.fromJson({
+            'type': 'tool_use',
+            'id': 'tu1',
+            'name': 'fetch',
+            'input': {1: 'bad'},
+          }),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => const SamplingToolUseContent(
+            id: 'tu1',
+            name: 'fetch',
+            input: {'bad': Object()},
+          ).toJson(),
+          throwsA(isA<FormatException>()),
+        );
       });
     });
 
@@ -354,6 +387,25 @@ void main() {
       expect(msg.contentBlocks, hasLength(2));
       expect(msg.toJson()['content'], isA<List>());
     });
+
+    test('rejects non-JSON metadata objects', () {
+      expect(
+        () => SamplingMessage.fromJson({
+          'role': 'user',
+          'content': {'type': 'text', 'text': 'Hello'},
+          '_meta': {1: 'bad'},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const SamplingMessage(
+          role: SamplingMessageRole.user,
+          content: SamplingTextContent(text: 'Hello'),
+          meta: {'bad': Object()},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+    });
   });
 
   group('CreateMessageRequestParams', () {
@@ -441,6 +493,68 @@ void main() {
       expect(params.maxTokens, equals(200));
       expect(params.includeContext, equals(IncludeContext.allServers));
     });
+
+    test('rejects non-finite temperature values', () {
+      final messages = [
+        {
+          'role': 'user',
+          'content': {'type': 'text', 'text': 'Hello'},
+        },
+      ];
+      for (final value in [double.nan, double.infinity]) {
+        expect(
+          () => CreateMessageRequestParams.fromJson({
+            'messages': messages,
+            'maxTokens': 100,
+            'temperature': value,
+          }),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => CreateMessageRequestParams(
+            messages: const [
+              SamplingMessage(
+                role: SamplingMessageRole.user,
+                content: SamplingTextContent(text: 'Hello'),
+              ),
+            ],
+            maxTokens: 100,
+            temperature: value,
+          ).toJson(),
+          throwsA(isA<ArgumentError>()),
+        );
+      }
+    });
+
+    test('rejects non-JSON metadata objects', () {
+      final messages = [
+        {
+          'role': 'user',
+          'content': {'type': 'text', 'text': 'Hello'},
+        },
+      ];
+      expect(
+        () => CreateMessageRequestParams.fromJson({
+          'messages': messages,
+          'maxTokens': 100,
+          'metadata': {1: 'bad'},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const CreateMessageRequestParams(
+          messages: [
+            SamplingMessage(
+              role: SamplingMessageRole.user,
+              content: SamplingTextContent(text: 'Hello'),
+            ),
+          ],
+          maxTokens: 100,
+          metadata: {'bad': Object()},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+    });
   });
 
   group('CreateMessageResult', () {
@@ -504,6 +618,27 @@ void main() {
       };
       final result = CreateMessageResult.fromJson(json);
       expect(result.stopReason, equals('customReason'));
+    });
+
+    test('rejects non-JSON metadata objects', () {
+      expect(
+        () => CreateMessageResult.fromJson({
+          'role': 'assistant',
+          'content': {'type': 'text', 'text': 'Message'},
+          'model': 'model-x',
+          '_meta': {1: 'bad'},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const CreateMessageResult(
+          role: SamplingMessageRole.assistant,
+          content: SamplingTextContent(text: 'Message'),
+          model: 'model-x',
+          meta: {'bad': Object()},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
     });
   });
 

--- a/test/types/subscriptions_test.dart
+++ b/test/types/subscriptions_test.dart
@@ -284,6 +284,16 @@ void main() {
         ),
         throwsFormatException,
       );
+      expect(
+        () => JsonRpcSubscriptionsAcknowledgedNotification.fromJson({
+          'method': Method.notificationsSubscriptionsAcknowledged,
+          'params': {
+            'notifications': {'toolsListChanged': true},
+            '_meta': {'bad': Object()},
+          },
+        }),
+        throwsFormatException,
+      );
     });
   });
 

--- a/test/types/tasks_extension_test.dart
+++ b/test/types/tasks_extension_test.dart
@@ -127,6 +127,46 @@ void main() {
       expect(parsed.meta, {'trace': 'abc'});
     });
 
+    test('rejects non-JSON task extension object values', () {
+      final taskJson = {
+        'taskId': 'task-1',
+        'status': 'completed',
+        'createdAt': '2026-07-28T00:00:00Z',
+        'lastUpdatedAt': '2026-07-28T00:02:00Z',
+        'ttlMs': 60000,
+        'result': {'bad': Object()},
+      };
+
+      expect(
+        () => TaskExtensionTask.fromJson(taskJson),
+        throwsFormatException,
+      );
+      expect(
+        () => const TaskExtensionTask(
+          taskId: 'task-1',
+          status: TaskStatus.completed,
+          createdAt: '2026-07-28T00:00:00Z',
+          lastUpdatedAt: '2026-07-28T00:02:00Z',
+          ttlMs: 60000,
+          result: {'bad': Object()},
+        ).toJson(),
+        throwsFormatException,
+      );
+      expect(
+        () => TaskExtensionAcknowledgementResult.fromJson({
+          'resultType': resultTypeComplete,
+          '_meta': {'bad': Object()},
+        }),
+        throwsFormatException,
+      );
+      expect(
+        () => const TaskExtensionAcknowledgementResult(
+          meta: {'bad': Object()},
+        ).toJson(),
+        throwsFormatException,
+      );
+    });
+
     test('serializes notifications/tasks with detailed task state', () {
       final notification = JsonRpcTaskNotification(
         task: const TaskExtensionTask(

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -53,6 +53,93 @@ void main() {
       final restored = JsonRpcErrorData.fromJson(json);
       expect(restored.data['nested']['level'], equals(2));
     });
+
+    test('JsonRpcErrorData validates required code and message fields', () {
+      for (final code in [
+        null,
+        false,
+        'not-code',
+        1.5,
+        <String, dynamic>{},
+        <Object>[],
+      ]) {
+        expect(
+          () => JsonRpcErrorData.fromJson({
+            'code': code,
+            'message': 'Bad code',
+          }),
+          throwsA(
+            isA<FormatException>()
+                .having((e) => e.message, 'message', contains('code')),
+          ),
+        );
+      }
+
+      for (final message in [null, false, 1, <String, dynamic>{}, <Object>[]]) {
+        expect(
+          () => JsonRpcErrorData.fromJson({
+            'code': ErrorCode.invalidRequest.value,
+            'message': message,
+          }),
+          throwsA(
+            isA<FormatException>()
+                .having((e) => e.message, 'message', contains('message')),
+          ),
+        );
+      }
+    });
+
+    test('JsonRpcErrorData accepts whole-number numeric code values', () {
+      final errorData = JsonRpcErrorData.fromJson({
+        'code': -32600.0,
+        'message': 'Whole-number JSON code',
+      });
+
+      expect(errorData.code, ErrorCode.invalidRequest.value);
+    });
+
+    test('JsonRpcErrorData rejects non-JSON data values', () {
+      expect(
+        () => const JsonRpcErrorData(
+          code: -32600,
+          message: 'Bad data',
+          data: {'bad': Object()},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const JsonRpcErrorData(
+          code: -32600,
+          message: 'Bad number',
+          data: {'score': double.infinity},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => JsonRpcErrorData.fromJson({
+          'code': -32600,
+          'message': 'Bad data',
+          'data': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('JsonRpcError rejects malformed error object wire values', () {
+      for (final error in [null, false, 1, 'not-error', <Object>[]]) {
+        expect(
+          () => JsonRpcMessage.fromJson({
+            'jsonrpc': '2.0',
+            'id': 1,
+            'error': error,
+          }),
+          throwsA(
+            isA<FormatException>()
+                .having((e) => e.message, 'message', contains('error')),
+          ),
+        );
+      }
+    });
   });
 
   group('JsonRpcCancelledNotification Edge Cases', () {
@@ -91,7 +178,15 @@ void main() {
     });
 
     test('rejects malformed requestId wire values', () {
-      for (final requestId in [null, true, <String, dynamic>{}, <Object>[]]) {
+      for (final requestId in [
+        null,
+        true,
+        123.5,
+        double.nan,
+        double.infinity,
+        <String, dynamic>{},
+        <Object>[],
+      ]) {
         expect(
           () => JsonRpcCancelledNotification.fromJson({
             'jsonrpc': '2.0',
@@ -106,6 +201,21 @@ void main() {
           ),
         );
       }
+
+      expect(
+        () => const CancelledNotificationParams(requestId: 123.5).toJson(),
+        throwsA(
+          isA<FormatException>()
+              .having((e) => e.message, 'message', contains('requestId')),
+        ),
+      );
+      expect(
+        () => const CancelledNotificationParams(requestId: double.nan).toJson(),
+        throwsA(
+          isA<FormatException>()
+              .having((e) => e.message, 'message', contains('requestId')),
+        ),
+      );
     });
 
     test('preserves string and integer requestId wire values', () {
@@ -212,10 +322,34 @@ void main() {
       expect(json.containsKey('total'), isFalse);
     });
 
+    test('rejects non-finite progress numbers', () {
+      for (final value in [double.nan, double.infinity]) {
+        expect(
+          () => Progress.fromJson({'progress': value}),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => Progress(progress: value).toJson(),
+          throwsA(isA<ArgumentError>()),
+        );
+        expect(
+          () => Progress.fromJson({'progress': 1, 'total': value}),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => Progress(progress: 1, total: value).toJson(),
+          throwsA(isA<ArgumentError>()),
+        );
+      }
+    });
+
     test('rejects malformed progressToken wire values', () {
       for (final progressToken in [
         null,
         false,
+        123.5,
+        double.nan,
+        double.infinity,
         <String, dynamic>{},
         <Object>[],
       ]) {
@@ -237,6 +371,23 @@ void main() {
           ),
         );
       }
+
+      expect(
+        () => const ProgressNotification(progressToken: 123.5, progress: 1)
+            .toJson(),
+        throwsA(
+          isA<FormatException>()
+              .having((e) => e.message, 'message', contains('progressToken')),
+        ),
+      );
+      expect(
+        () => const ProgressNotification(progressToken: double.nan, progress: 1)
+            .toJson(),
+        throwsA(
+          isA<FormatException>()
+              .having((e) => e.message, 'message', contains('progressToken')),
+        ),
+      );
     });
 
     test('preserves string and integer progressToken wire values', () {
@@ -289,8 +440,81 @@ void main() {
       );
     });
 
+    test('rejects malformed method wire values', () {
+      for (final method in [
+        null,
+        false,
+        1,
+        <String, dynamic>{},
+        <Object>[],
+      ]) {
+        for (final hasId in [true, false]) {
+          expect(
+            () => JsonRpcMessage.fromJson({
+              'jsonrpc': '2.0',
+              if (hasId) 'id': 'request-1',
+              'method': method,
+            }),
+            throwsA(
+              isA<FormatException>()
+                  .having((e) => e.message, 'message', contains('method')),
+            ),
+          );
+        }
+      }
+    });
+
+    test('rejects malformed generic request params wire values', () {
+      for (final params in [null, false, 1, 'not-params', <Object>[]]) {
+        expect(
+          () => JsonRpcMessage.fromJson({
+            'jsonrpc': '2.0',
+            'id': 'request-1',
+            'method': 'unknown/request',
+            'params': params,
+          }),
+          throwsA(
+            isA<FormatException>()
+                .having((e) => e.message, 'message', contains('params')),
+          ),
+        );
+      }
+    });
+
+    test('rejects explicit null params on typed request and notification', () {
+      for (final json in [
+        {
+          'jsonrpc': '2.0',
+          'id': 'request-1',
+          'method': Method.ping,
+          'params': null,
+        },
+        {
+          'jsonrpc': '2.0',
+          'method': Method.notificationsInitialized,
+          'params': null,
+        },
+      ]) {
+        expect(
+          () => JsonRpcMessage.fromJson(json),
+          throwsA(
+            isA<FormatException>()
+                .having((e) => e.message, 'message', contains('params')),
+          ),
+        );
+      }
+    });
+
     test('rejects malformed request id wire values', () {
-      for (final id in [null, false, 1.5, <String, dynamic>{}, <Object>[]]) {
+      for (final id in [
+        null,
+        false,
+        123.5,
+        double.nan,
+        double.infinity,
+        <String, dynamic>{},
+        <Object>[],
+      ]) {
         expect(
           () => JsonRpcMessage.fromJson({
             'jsonrpc': '2.0',
@@ -303,6 +527,33 @@ void main() {
           ),
         );
       }
+
+      expect(
+        () => const JsonRpcRequest(
+          id: 123.5,
+          method: 'unknown/request',
+        ).toJson(),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('JsonRpcRequest.id'),
+          ),
+        ),
+      );
+      expect(
+        () => const JsonRpcRequest(
+          id: double.nan,
+          method: 'unknown/request',
+        ).toJson(),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('JsonRpcRequest.id'),
+          ),
+        ),
+      );
     });
 
     test('preserves string and integer request ids', () {
@@ -320,7 +571,15 @@ void main() {
     });
 
     test('rejects malformed request progressToken wire values', () {
-      for (final token in [null, false, 1.5, <String, dynamic>{}, <Object>[]]) {
+      for (final token in [
+        null,
+        false,
+        123.5,
+        double.nan,
+        double.infinity,
+        <String, dynamic>{},
+        <Object>[],
+      ]) {
         expect(
           () => JsonRpcMessage.fromJson({
             'jsonrpc': '2.0',
@@ -339,6 +598,21 @@ void main() {
           ),
         );
       }
+
+      expect(
+        () => const JsonRpcRequest(
+          id: 'request-1',
+          method: 'unknown/request',
+          meta: {'progressToken': 123.5},
+        ).toJson(),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('_meta.progressToken'),
+          ),
+        ),
+      );
     });
 
     test('rejects malformed request _meta wire values', () {
@@ -431,7 +705,14 @@ void main() {
     });
 
     test('rejects malformed response id wire values', () {
-      for (final id in [false, 1.5, <String, dynamic>{}, <Object>[]]) {
+      for (final id in [
+        false,
+        123.5,
+        double.nan,
+        double.infinity,
+        <String, dynamic>{},
+        <Object>[],
+      ]) {
         expect(
           () => JsonRpcMessage.fromJson({
             'jsonrpc': '2.0',
@@ -446,10 +727,25 @@ void main() {
       }
     });
 
-    test('handles error with null id', () {
+    test('rejects response envelopes with both result and error', () {
+      expect(
+        () => JsonRpcMessage.fromJson({
+          'jsonrpc': '2.0',
+          'id': 1,
+          'result': {'data': 'test'},
+          'error': {'code': -32603, 'message': 'Internal error'},
+        }),
+        throwsA(
+          isA<FormatException>()
+              .having((e) => e.message, 'message', contains('result'))
+              .having((e) => e.message, 'message', contains('error')),
+        ),
+      );
+    });
+
+    test('handles error with omitted id', () {
       final json = {
         'jsonrpc': '2.0',
-        'id': null,
         'error': {'code': -32600, 'message': 'Error'},
       };
 
@@ -459,7 +755,15 @@ void main() {
     });
 
     test('rejects malformed error id wire values', () {
-      for (final id in [false, 1.5, <String, dynamic>{}, <Object>[]]) {
+      for (final id in [
+        null,
+        false,
+        123.5,
+        double.nan,
+        double.infinity,
+        <String, dynamic>{},
+        <Object>[],
+      ]) {
         expect(
           () => JsonRpcMessage.fromJson({
             'jsonrpc': '2.0',
@@ -510,7 +814,7 @@ void main() {
 
     test('handles null roots and elicitation maps', () {
       final json = {
-        'experimental': {'feature': true},
+        'experimental': {'feature': <String, dynamic>{}},
         'sampling': {'enabled': true},
         'roots': null,
         'elicitation': null,
@@ -542,7 +846,7 @@ void main() {
 
     test('handles null capability maps', () {
       final json = {
-        'experimental': {'feature': true},
+        'experimental': {'feature': <String, dynamic>{}},
         'logging': {'level': 'info'},
         'prompts': null,
         'resources': null,

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -9,7 +9,9 @@ void main() {
         initParams: const InitializeRequestParams(
           protocolVersion: latestProtocolVersion,
           capabilities: ClientCapabilities(
-            experimental: {'featureX': true},
+            experimental: {
+              'featureX': <String, dynamic>{},
+            },
             sampling: ClientCapabilitiesSampling(),
           ),
           clientInfo: Implementation(name: 'test-client', version: '1.0.0'),
@@ -41,6 +43,41 @@ void main() {
       expect(json['id'], equals(1));
       expect(json['result']['key'], equals('value'));
       expect(json['result']['_meta']['metaKey'], equals('metaValue'));
+    });
+
+    test('JSON-RPC envelope metadata rejects non-JSON Dart maps', () {
+      final invalidMeta = {'bad': Object()};
+
+      expect(
+        () => JsonRpcRequest(
+          id: 1,
+          method: 'custom/request',
+          meta: invalidMeta,
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => JsonRpcNotification(
+          method: 'custom/notification',
+          meta: invalidMeta,
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => JsonRpcMessage.fromJson({
+          'jsonrpc': jsonRpcVersion,
+          'method': 'custom/notification',
+          'params': {'_meta': invalidMeta},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const JsonRpcResponse(
+          id: 1,
+          result: {'bad': Object()},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
     });
 
     test('JsonRpcError serialization and deserialization', () {
@@ -131,6 +168,135 @@ void main() {
         expectMeta(result);
       }
     });
+
+    test('typed metadata rejects non-JSON Dart maps', () {
+      final invalidMeta = {'bad': Object()};
+      final task = Task(
+        taskId: 'task-1',
+        status: TaskStatus.completed,
+        ttl: null,
+        createdAt: '2026-05-25T00:00:00.000Z',
+        lastUpdatedAt: '2026-05-25T00:00:01.000Z',
+        meta: invalidMeta,
+      );
+
+      for (final serialize in <Map<String, dynamic> Function()>[
+        () => Root(uri: 'file:///repo', meta: invalidMeta).toJson(),
+        () => Resource(
+              uri: 'file:///repo/readme.md',
+              name: 'readme',
+              meta: invalidMeta,
+            ).toJson(),
+        () => ResourceTemplate(
+              uriTemplate: 'file:///repo/{name}',
+              name: 'repo-file',
+              meta: invalidMeta,
+            ).toJson(),
+        () => Prompt(name: 'summary', meta: invalidMeta).toJson(),
+        () => EmptyResult(meta: invalidMeta).toJson(),
+        () => InitializeResult(
+              protocolVersion: latestProtocolVersion,
+              capabilities: const ServerCapabilities(),
+              serverInfo: const Implementation(name: 'server', version: '1.0'),
+              meta: invalidMeta,
+            ).toJson(),
+        () => DiscoverResult(
+              supportedVersions: const [draftProtocolVersion2026_07_28],
+              capabilities: const ServerCapabilities(),
+              serverInfo: const Implementation(name: 'server', version: '1.0'),
+              meta: invalidMeta,
+            ).toJson(),
+        () => ListRootsResult(roots: const [], meta: invalidMeta).toJson(),
+        () => ListResourcesResult(resources: const [], meta: invalidMeta)
+            .toJson(),
+        () => ListResourceTemplatesResult(
+              resourceTemplates: const [],
+              meta: invalidMeta,
+            ).toJson(),
+        () =>
+            ReadResourceResult(contents: const [], meta: invalidMeta).toJson(),
+        () => ListPromptsResult(prompts: const [], meta: invalidMeta).toJson(),
+        () => GetPromptResult(messages: const [], meta: invalidMeta).toJson(),
+        () => CompleteResult(
+              completion: CompletionResultData(values: const []),
+              meta: invalidMeta,
+            ).toJson(),
+        () => ElicitResult(action: 'accept', meta: invalidMeta).toJson(),
+        () => ListToolsResult(tools: const [], meta: invalidMeta).toJson(),
+        () => task.toJson(),
+        () => ListTasksResult(tasks: const [], meta: invalidMeta).toJson(),
+        () => CreateTaskResult(task: task, meta: invalidMeta).toJson(),
+        () => JsonRpcResponse(
+              id: 1,
+              result: const {'ok': true},
+              meta: invalidMeta,
+            ).toJson(),
+      ]) {
+        expect(serialize, throwsA(isA<FormatException>()));
+      }
+
+      for (final parse in <Object Function()>[
+        () => Root.fromJson({'uri': 'file:///repo', '_meta': invalidMeta}),
+        () => Resource.fromJson({
+              'uri': 'file:///repo/readme.md',
+              'name': 'readme',
+              '_meta': invalidMeta,
+            }),
+        () => ResourceTemplate.fromJson({
+              'uriTemplate': 'file:///repo/{name}',
+              'name': 'repo-file',
+              '_meta': invalidMeta,
+            }),
+        () => Prompt.fromJson({'name': 'summary', '_meta': invalidMeta}),
+        () => ListRootsResult.fromJson({'roots': [], '_meta': invalidMeta}),
+        () => ListResourcesResult.fromJson({
+              'resources': [],
+              '_meta': invalidMeta,
+            }),
+        () => ListResourceTemplatesResult.fromJson({
+              'resourceTemplates': [],
+              '_meta': invalidMeta,
+            }),
+        () => ReadResourceResult.fromJson({
+              'contents': [],
+              '_meta': invalidMeta,
+            }),
+        () => ListPromptsResult.fromJson({'prompts': [], '_meta': invalidMeta}),
+        () => GetPromptResult.fromJson({'messages': [], '_meta': invalidMeta}),
+        () => CompleteResult.fromJson({
+              'completion': {'values': []},
+              '_meta': invalidMeta,
+            }),
+        () => ElicitResult.fromJson({'action': 'accept', '_meta': invalidMeta}),
+        () => ListToolsResult.fromJson({'tools': [], '_meta': invalidMeta}),
+        () => Task.fromJson({
+              'taskId': 'task-1',
+              'status': 'completed',
+              'ttl': null,
+              'createdAt': '2026-05-25T00:00:00.000Z',
+              'lastUpdatedAt': '2026-05-25T00:00:01.000Z',
+              '_meta': invalidMeta,
+            }),
+        () => ListTasksResult.fromJson({'tasks': [], '_meta': invalidMeta}),
+        () => CreateTaskResult.fromJson({
+              'task': const {
+                'taskId': 'task-1',
+                'status': 'completed',
+                'ttl': null,
+                'createdAt': '2026-05-25T00:00:00.000Z',
+                'lastUpdatedAt': '2026-05-25T00:00:01.000Z',
+              },
+              '_meta': invalidMeta,
+            }),
+        () => JsonRpcMessage.fromJson({
+              'jsonrpc': jsonRpcVersion,
+              'id': 1,
+              'result': {'ok': true, '_meta': invalidMeta},
+            }),
+      ]) {
+        expect(parse, throwsA(isA<FormatException>()));
+      }
+    });
   });
 
   group('ToolExecution Tests', () {
@@ -165,7 +331,9 @@ void main() {
 
     test('ServerCapabilities includes completions', () {
       final capabilities = const ServerCapabilities(
-        experimental: {'featureY': true},
+        experimental: {
+          'featureY': <String, dynamic>{},
+        },
         logging: {'enabled': true},
         prompts: ServerCapabilitiesPrompts(listChanged: true),
         resources:
@@ -175,7 +343,7 @@ void main() {
       );
 
       final json = capabilities.toJson();
-      expect(json['experimental']['featureY'], equals(true));
+      expect(json['experimental']['featureY'], isEmpty);
       expect(json['logging']['enabled'], equals(true));
       expect(json['prompts']['listChanged'], equals(true));
       expect(json['resources']['subscribe'], equals(true));
@@ -190,7 +358,9 @@ void main() {
 
     test('ServerCapabilities serialization and deserialization', () {
       final capabilities = const ServerCapabilities(
-        experimental: {'featureY': true},
+        experimental: {
+          'featureY': <String, dynamic>{},
+        },
         logging: {'enabled': true},
         prompts: ServerCapabilitiesPrompts(listChanged: true),
         resources:
@@ -199,7 +369,7 @@ void main() {
       );
 
       final json = capabilities.toJson();
-      expect(json['experimental']['featureY'], equals(true));
+      expect(json['experimental']['featureY'], isEmpty);
       expect(json['logging']['enabled'], equals(true));
       expect(json['prompts']['listChanged'], equals(true));
       expect(json['resources']['subscribe'], equals(true));
@@ -212,18 +382,70 @@ void main() {
 
     test('ClientCapabilities serialization and deserialization', () {
       final capabilities = const ClientCapabilities(
-        experimental: {'featureZ': true},
+        experimental: {
+          'featureZ': <String, dynamic>{},
+        },
         sampling: ClientCapabilitiesSampling(),
         roots: ClientCapabilitiesRoots(listChanged: true),
       );
 
       final json = capabilities.toJson();
-      expect(json['experimental']['featureZ'], equals(true));
+      expect(json['experimental']['featureZ'], isEmpty);
       expect(json['sampling'], isNotNull);
       expect(json['roots']['listChanged'], equals(true));
 
       final deserialized = ClientCapabilities.fromJson(json);
       expect(deserialized.roots?.listChanged, equals(true));
+    });
+
+    test('experimental capability values must be objects', () {
+      expect(
+        () => ClientCapabilities.fromJson(
+          const {
+            'experimental': {'feature': true},
+          },
+        ),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ServerCapabilities.fromJson(
+          const {
+            'experimental': {'feature': true},
+          },
+        ),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ClientCapabilities(
+          experimental: {'feature': true},
+        ).toJson(),
+        throwsA(anyOf(isA<FormatException>(), isA<ArgumentError>())),
+      );
+      expect(
+        () => const ServerCapabilities(
+          experimental: {'feature': true},
+        ).toJson(),
+        throwsA(anyOf(isA<FormatException>(), isA<ArgumentError>())),
+      );
+    });
+
+    test('extension capability values must be objects', () {
+      expect(
+        () => ClientCapabilities.fromJson(
+          const {
+            'extensions': {'io.example/feature': true},
+          },
+        ),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ServerCapabilities.fromJson(
+          const {
+            'extensions': {'io.example/feature': true},
+          },
+        ),
+        throwsA(isA<FormatException>()),
+      );
     });
   });
 
@@ -416,6 +638,41 @@ void main() {
       );
       expect(deserialized.meta?['display'], equals('inline'));
     });
+
+    test('content JSON object fields reject non-JSON Dart maps', () {
+      expect(
+        () => TextContent.fromJson({
+          'type': 'text',
+          'text': 'Hello',
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const TextContent(
+          text: 'Hello',
+          meta: {'bad': Object()},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ResourceLink.fromJson({
+          'type': 'resource_link',
+          'uri': 'file:///docs/readme.md',
+          'name': 'readme',
+          'annotations': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const ResourceLink(
+          uri: 'file:///docs/readme.md',
+          name: 'readme',
+          annotations: {'bad': Object()},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+    });
   });
 
   group('Resource Tests', () {
@@ -472,6 +729,41 @@ void main() {
           ResourceContents.fromJson(json) as BlobResourceContents;
       expect(deserialized.uri, equals('file://example.bin'));
       expect(deserialized.blob, equals('base64data'));
+    });
+
+    test('ResourceContents rejects non-JSON metadata and passthrough maps', () {
+      expect(
+        () => ResourceContents.fromJson({
+          'uri': 'file://example.txt',
+          'text': 'Sample text content',
+          '_meta': {'bad': Object()},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => ResourceContents.fromJson({
+          'uri': 'file://example.txt',
+          'text': 'Sample text content',
+          'x-extra': Object(),
+        }),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const TextResourceContents(
+          uri: 'file://example.txt',
+          text: 'Sample text content',
+          meta: {'bad': Object()},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => const TextResourceContents(
+          uri: 'file://example.txt',
+          text: 'Sample text content',
+          extra: {'bad': Object()},
+        ).toJson(),
+        throwsA(isA<FormatException>()),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- consolidate JSON value, metadata object, stateless result/header, request identity, progress token, JSON-RPC envelope, and nested metadata validation hardening
- keeps protocol-envelope compatibility and stateless metadata routing reviewable in one layer
- replaces the JSON-RPC/metadata hardening portion of the prior micro-PR stack (#219-#246)

## Validation
- dart format --output=none --set-exit-if-changed .
- dart analyze
- git diff --check
- dart test
- dart pub global run coverage:test_with_coverage

Stacked on #269. This is a draft RC PR and should stay off `main` until the official spec release.