### PR TITLE
Prepare mcp_dart_cli 0.1.9 release

### DIFF
--- a/.github/workflows/test_core.yml
+++ b/.github/workflows/test_core.yml
@@ -2,13 +2,9 @@ name: Run Core Tests on PR
 
 on:
   pull_request:
-    paths-ignore:
-      - 'packages/mcp_dart_cli/**'
   push:
     branches:
       - main
-    paths-ignore:
-      - 'packages/mcp_dart_cli/**'
 
 jobs:
   test:

--- a/packages/mcp_dart_cli/CHANGELOG.md
+++ b/packages/mcp_dart_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.1.9
 
 - Add `mcp_dart inspect-server` for structured MCP server inspection reports
   covering handshake, capabilities, ping, tools, resources, resource templates,

--- a/packages/mcp_dart_cli/bin/mcp_dart.dart
+++ b/packages/mcp_dart_cli/bin/mcp_dart.dart
@@ -20,6 +20,10 @@ bool shouldCheckForUpdate(List<String> arguments) {
     return false;
   }
 
+  if (arguments.isNotEmpty && arguments.first == 'serve') {
+    return false;
+  }
+
   if (arguments.isNotEmpty && arguments.first == 'inspect-client') {
     return false;
   }

--- a/packages/mcp_dart_cli/lib/src/version.dart
+++ b/packages/mcp_dart_cli/lib/src/version.dart
@@ -1,1 +1,1 @@
-const packageVersion = '0.1.8';
+const packageVersion = '0.1.9';

--- a/packages/mcp_dart_cli/pubspec.yaml
+++ b/packages/mcp_dart_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mcp_dart_cli
 description: Command-line tools for creating, serving, inspecting, and testing Dart Model Context Protocol (MCP) servers.
-version: 0.1.8
+version: 0.1.9
 repository: https://github.com/leehack/mcp_dart
 homepage: https://github.com/leehack/mcp_dart/tree/main/packages/mcp_dart_cli
 issue_tracker: https://github.com/leehack/mcp_dart/issues

--- a/packages/mcp_dart_cli/test/bin/mcp_dart_test.dart
+++ b/packages/mcp_dart_cli/test/bin/mcp_dart_test.dart
@@ -8,6 +8,10 @@ void main() {
       expect(cli.shouldCheckForUpdate(['update']), isFalse);
     });
 
+    test('skips serve because stdout is MCP protocol traffic', () {
+      expect(cli.shouldCheckForUpdate(['serve']), isFalse);
+    });
+
     test('skips conformance JSON mode to keep stdout machine-readable', () {
       expect(cli.shouldCheckForUpdate(['conformance', '--json']), isFalse);
     });


### PR DESCRIPTION
## Summary
- Bump `mcp_dart_cli` to 0.1.9 and mark the changelog release.
- Suppress update checks for `mcp_dart serve` because stdout is MCP protocol traffic.
- Run the core workflow for CLI changes too, so Codecov project coverage has both root and CLI coverage uploads.

## Validation
- `dart format .`
- `dart analyze`
- `PYTHON=/opt/UnitySrc/personal/mcp/mcp_dart-cli-release-prep/.dart_tool/python-interop/bin/python dart test`
- `dart run bin/mcp_dart.dart conformance --suite all --json`
- `sh -n tool/install.sh`
- `dart pub global run pana --no-warning --exit-code-threshold 0` (160/160)
- CI-layout `dart pub publish --dry-run` for nested CLI package (0 warnings, 1 expected dependency override hint)
- `git diff --check`

PowerShell installer syntax was not checked locally because `pwsh` is not installed on this machine; the CLI workflow covers it.
