### PR TITLE
Use current Intel macOS runner for CLI binary

### DIFF
--- a/.github/workflows/cli_binaries.yml
+++ b/.github/workflows/cli_binaries.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           - os: ubuntu-latest
             asset: mcp_dart-linux-x64
-          - os: macos-13
+          - os: macos-15-intel
             asset: mcp_dart-macos-x64
           - os: macos-14
             asset: mcp_dart-macos-arm64


### PR DESCRIPTION
## Summary
- Switch the CLI macOS x64 binary build from `macos-13` to `macos-15-intel`.

## Context
The `mcp_dart_cli-v0.1.9` binary workflow is stuck with the `Build mcp_dart-macos-x64` job queued on `macos-13` with no runner assigned. GitHub's hosted runner docs list `macos-15-intel` as the current Intel/x64 macOS runner label, so this should let the x64 artifact build and allow the release-assets job to attach binaries.

## Validation
- `git diff --check`
