### PR TITLE
Add installer fallback for latest CLI release

### DIFF
--- a/tool/install.ps1
+++ b/tool/install.ps1
@@ -16,14 +16,33 @@ switch ($Arch) {
 }
 
 if ($Version -eq "latest") {
-  $Releases = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases?per_page=50"
-  $Release = $Releases | Where-Object {
-    $_.tag_name -like "mcp_dart_cli-v*" -and -not $_.prerelease
-  } | Select-Object -First 1
-  if (-not $Release) {
+  $Tag = $null
+  try {
+    $Releases = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases?per_page=50"
+    $Release = $Releases | Where-Object {
+      $_.tag_name -like "mcp_dart_cli-v*" -and -not $_.prerelease
+    } | Select-Object -First 1
+    if ($Release) {
+      $Tag = $Release.tag_name
+    }
+  } catch {
+    # Fall through to the public releases page, which avoids API rate limits.
+  }
+
+  if (-not $Tag) {
+    $ReleasesPage = Invoke-WebRequest "https://github.com/$Repo/releases"
+    $Match = [regex]::Match(
+      $ReleasesPage.Content,
+      "mcp_dart_cli-v[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?"
+    )
+    if ($Match.Success) {
+      $Tag = $Match.Value
+    }
+  }
+
+  if (-not $Tag) {
     throw "Could not find a mcp_dart_cli GitHub release."
   }
-  $Tag = $Release.tag_name
 } elseif ($Version.StartsWith("mcp_dart_cli-v")) {
   $Tag = $Version
 } else {

--- a/tool/install.sh
+++ b/tool/install.sh
@@ -34,8 +34,9 @@ detect_arch() {
   esac
 }
 
-latest_cli_tag() {
-  curl -fsSL "https://api.github.com/repos/$repo/releases?per_page=50" |
+latest_cli_tag_from_api() {
+  response="$(curl -fsSL "https://api.github.com/repos/$repo/releases?per_page=50" 2>/dev/null)" || return 1
+  printf '%s\n' "$response" |
     awk '
       function reset_release() {
         tag = ""
@@ -74,6 +75,27 @@ latest_cli_tag() {
         depth += opens - closes
       }
     '
+}
+
+latest_cli_tag_from_releases_page() {
+  response="$(curl -fsSL "https://github.com/$repo/releases")" || return 1
+  printf '%s\n' "$response" |
+    awk '
+      match($0, /mcp_dart_cli-v[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?/) {
+        print substr($0, RSTART, RLENGTH)
+        exit
+      }
+    '
+}
+
+latest_cli_tag() {
+  tag="$(latest_cli_tag_from_api || true)"
+  if [ -n "$tag" ]; then
+    echo "$tag"
+    return 0
+  fi
+
+  latest_cli_tag_from_releases_page
 }
 
 require curl


### PR DESCRIPTION
## Summary
- Add a fallback for `latest` CLI release discovery in `tool/install.sh` and `tool/install.ps1`.
- If the unauthenticated GitHub Releases API is rate-limited or unavailable, parse the public releases page for the newest `mcp_dart_cli-v*` tag.

## Validation
- `sh -n tool/install.sh`
- `MCP_DART_INSTALL_DIR=$(mktemp -d)/bin sh tool/install.sh`
- Confirmed installed binary reports `0.1.9`

PowerShell syntax was not checked locally because `pwsh` is not installed here; CI covers it.
