### PR TITLE
Prepare dev release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,10 @@ jobs:
         working-directory: ${{ steps.publish-dir.outputs.working_directory }}
         run: dart pub get
 
+      - name: Validate package for publishing
+        working-directory: ${{ steps.publish-dir.outputs.working_directory }}
+        run: dart pub publish --dry-run
+
       - name: Publish to pub.dev
         working-directory: ${{ steps.publish-dir.outputs.working_directory }}
         run: dart pub publish --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,20 @@ jobs:
           echo "📦 Package: ${{ inputs.package }}"
           echo "📦 Detected version: $VERSION"
 
+      - name: Determine release type
+        id: release-type
+        run: |
+          VERSION="${{ steps.get-version.outputs.version }}"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "make_latest=false" >> "$GITHUB_OUTPUT"
+            echo "📦 Release type: prerelease"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "make_latest=true" >> "$GITHUB_OUTPUT"
+            echo "📦 Release type: stable"
+          fi
+
       - name: Check if tag already exists
         run: |
           TAG="${{ steps.set-config.outputs.tag_prefix }}${{ steps.get-version.outputs.version }}"
@@ -69,4 +83,6 @@ jobs:
           tag_name: ${{ steps.create-tag.outputs.tag }}
           name: ${{ inputs.package }} ${{ steps.get-version.outputs.version }}
           generate_release_notes: true
+          prerelease: ${{ steps.release-type.outputs.prerelease }}
+          make_latest: ${{ steps.release-type.outputs.make_latest }}
           draft: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,272 +1,57 @@
 ## 2.3.0-dev.0
 
-### MCP 2026-07-28 draft/RC
+This is a dev preview for MCP `2026-07-28` draft/RC support. MCP
+`2025-11-25` remains the default protocol profile; draft/RC behavior is enabled
+explicitly and may still change before the official spec release.
 
-- Started the MCP 2026-07-28 RC development line with opt-in protocol
-  constants, stateless request metadata helpers, and `server/discover` request
-  and result types.
-- Added server-side `server/discover` handling before legacy initialization and
-  initial stateless request validation for per-request protocol version,
-  client identity, and client capability metadata.
-- Added explicit protocol profiles via
-  `McpClientOptions(protocol: McpProtocol.preview2026)` and
-  `McpServerOptions(protocol: McpProtocol.preview2026)` while keeping the stable
-  `initialize` flow as the default. The lower-level `protocolVersion` and
-  `useServerDiscover` options remain available for interoperability testing.
-- Kept stable public tool result APIs object-rooted while adding explicit
-  draft-only APIs for non-object values: `JsonValue`,
-  `CallToolResult.fromStructuredArray()`, `structuredContentJson`, and
-  server `outputJsonSchema`.
-- Added 2026 cacheable result support for `tools/list`, `prompts/list`,
-  `resources/list`, `resources/templates/list`, and `resources/read`, including
-  stateless server defaults for `resultType`, `ttlMs`, and `cacheScope` while
-  keeping legacy result serialization unchanged unless cache hints are set.
-- Rejected core RPCs removed from stateless MCP 2026 requests
-  (`initialize`, `ping`, `logging/setLevel`, `resources/subscribe`,
-  `resources/unsubscribe`, `notifications/initialized`, and
-  `notifications/roots/list_changed`) while preserving legacy session behavior.
-- Synced registered tool `x-mcp-header` metadata into Streamable HTTP server
-  transports so 2026 stateless `tools/call` requests reject missing or
-  mismatched `Mcp-Param-*` argument headers.
-- Removed `Mcp-Session-Id` from 2026 stateless Streamable HTTP requests by
-  stripping it from client sends and ignoring it on stateless server POSTs.
-- Prevented 2026 stateless request handlers and task-store operations from
-  inheriting transport session IDs, including direct Streamable HTTP transport
-  responses after a prior stateful initialization.
-- Enforced 2026 stateless Streamable HTTP POST-only behavior by skipping
-  legacy client GET/DELETE session paths and returning `Allow: POST` for
-  stateless non-POST server requests.
-- Rejected server-initiated JSON-RPC requests on 2026 stateless Streamable HTTP
-  response streams so client input is routed through MRTR input-required
-  results instead.
-- Escaped sentinel-shaped `Mcp-Param-*` values with Base64 encoding so literal
-  values beginning with `=?base64?` and ending with `?=` round-trip correctly.
-- Synced nested 2026 `x-mcp-header` mappings into Streamable HTTP transports
-  using JSON Pointer selectors for nested tool arguments.
-- Limited 2026 Streamable HTTP `x-mcp-header` mirroring to string, boolean,
-  finite number, and JavaScript-safe integer argument values; unsafe integers
-  and non-finite numbers are omitted.
-- Returned HTTP 404 with JSON-RPC `Method not found` for unsupported or removed
-  2026 stateless Streamable HTTP request methods before opening response
-  streams.
-- Sent and required `Mcp-Name` for MCP 2026 task lifecycle requests over
-  Streamable HTTP, using the request body `taskId` as the routing value.
-- Accepted MCP 2026 stateless Streamable HTTP JSON-RPC response POSTs without
-  requiring request-only metadata in the response body.
-- Treated client closure of a 2026 stateless Streamable HTTP SSE response stream
-  as cancellation of that pending request.
-- Sorted 2026 stateless high-level `tools/list` responses by tool name for
-  deterministic list results while preserving legacy registration-order output.
-- Omitted stable-only `Tool.execution` metadata from 2026 stateless
-  `tools/list` responses and embedded MRTR sampling tool definitions while
-  preserving stable/default serialization.
-- Rejected legacy `RequestOptions.task` augmentation before sending 2026
-  stateless requests while preserving stable task augmentation.
-- Added `tool/spec_example_audit.dart` so upstream machine-readable spec
-  examples can be parsed through the checked-in typed SDK surfaces during
-  RC/final release audits.
-- Gated 2026 stateless task extension methods on advertised server extension
-  support and rejected legacy task result shapes on extension `tasks/get`,
-  `tasks/update`, and `tasks/cancel` handlers.
-- Ignored legacy `tools/call` `task` parameters on 2026 stateless requests so
-  handlers do not receive legacy task TTL hints through `RequestHandlerExtra`.
-- Required 2026 stateless task creation results to be immediately resolvable
-  through `tasks/get` before returning `resultType: "task"`.
-- Exposed task-store options on `McpServerOptions` and serialized built-in
-  task-store `tasks/get`/`tasks/cancel` handlers in the 2026 task-extension
-  wire shape for stateless requests.
-- Added request-scoped stateless logging gating via
-  `io.modelcontextprotocol/logLevel` metadata so 2026 log notifications are
-  emitted only when the current request opts in.
-- Rejected unrecognized 2026 stateless response `resultType` values on the
-  client while keeping absent `resultType` compatible with stable result parsing.
-- Added `X-Accel-Buffering: no` to Streamable HTTP SSE responses and marked
-  JSON-RPC error bodies with `Content-Type: application/json`.
-- Tightened `x-mcp-header` and `Mcp-Param-*` suffix validation to RFC 9110
-  HTTP field-name token syntax.
-- Removed invalid `x-mcp-header` annotations from 2026 stateless `tools/list`
-  responses when the server has already rejected those header mappings.
-- Rejected server-initiated JSON-RPC requests received on 2026 stateless
-  Streamable HTTP client response streams; servers must use MRTR
-  `input_required` results instead.
-- Enforced `subscriptions/listen` stream ordering and filters for 2026
-  subscription notifications.
-- Required nested request `_meta` on `subscriptions/listen` requests, matching
-  the 2026 schema's per-request metadata requirement.
-- Rejected mismatched JSON-RPC `jsonrpc` and `method` wrapper constants when
-  parsing typed `notifications/subscriptions/acknowledged` notifications.
-- Rejected mismatched JSON-RPC wrapper constants when directly parsing the
-  experimental completion list-changed notification.
-- Rejected incoming `tools/call` JSON-RPC requests that omit the MCP-required
-  `params` object.
-- Rejected JSON-RPC envelopes that mix request/notification `method` fields
-  with response `result` or `error` fields, including direct typed
-  request/notification/error parsing.
-- Returned `MissingRequiredClientCapability` (`-32003`) with required task
-  extension capability data when 2026 task notification subscriptions omit the
-  per-request `io.modelcontextprotocol/tasks` client capability.
-- Rejected deprecated sampling `includeContext` values unless the client
-  advertises `sampling.context`, while still allowing omitted context and
-  `includeContext: "none"`.
-- Stopped sending `notifications/cancelled` when an outgoing `initialize`
-  request is aborted or times out, matching the stable lifecycle rule that
-  clients must not cancel initialization.
-- Required `notifications/cancelled` payloads to carry a valid string-or-integer
-  `requestId` instead of accepting ID-less cancellation notifications.
-- Retried `server/discover` with an advertised compatible stateless protocol
-  version after `UnsupportedProtocolVersionError` instead of falling back to
-  legacy initialization.
-- Accepted whole-number JSON numeric values for integer wire fields such as
-  resource link sizes, completion totals, sampling `maxTokens`, task TTLs, and
-  JSON Schema length/item bounds while continuing to reject fractional values.
-- Added client-side `subscriptions/listen` handles that correlate stream
-  notifications by `io.modelcontextprotocol/subscriptionId`, validate the
-  acknowledgment, and cancel long-lived streams with `notifications/cancelled`.
-- Allowed MCP 2026 tool `outputSchema` declarations to use any JSON Schema and
-  `structuredContent` results to carry any JSON value, while omitting non-object
-  structured output from stable 2025 responses.
-- Allowed MCP 2026 `prompts/get` and `resources/read` handlers to return
-  `InputRequiredResult`, and rejected MRTR input-required results on unsupported
-  request methods.
-- Rejected MCP 2026 MRTR `inputRequests` whose embedded client request type is
-  not declared in the caller's per-request client capabilities.
-- Rejected non-object `experimental` and `extensions` capability entries to
-  match the stable and MCP 2026 capability schemas.
-- Returned version-appropriate resource-not-found errors from high-level
-  `resources/read` handlers: stable 2025 uses legacy `-32002`, while MCP 2026
-  stateless requests use `-32602` with the missing `uri` in error data.
-- Enforced MCP 2026 `_meta` key-name grammar on stateless request metadata and
-  the 2026 request metadata builder while preserving legacy metadata parsing.
-- Exposed typed request-envelope accessors on `RequestHandlerExtra` for
-  per-request protocol version, client info, and client capabilities metadata.
-- Rejected negative cacheable-result `ttlMs` values during parsing instead of
-  clamping malformed wire values to zero.
-- Validated MRTR `inputResponses` as `CreateMessageResult`, `ListRootsResult`,
-  or `ElicitResult` instead of accepting arbitrary result objects.
-- Restricted numeric `ElicitResult.content` values to integers, matching the
-  stable and MCP 2026 `string | integer | boolean | string[]` schemas while
-  still accepting whole-number JSON numeric values.
-- Required integer `minimum`, `maximum`, and `default` values in form
-  elicitation number schemas for both stable 2025 and MCP 2026.
-- Rejected MCP 2026 `CallToolResult.extra` attempts to spoof non-complete
-  `resultType` values, and added CLI conformance coverage for that guard.
-- Rejected form elicitation schemas that provide legacy `enumNames` without the
-  required string `enum`.
-- Rejected `ElicitResult.content` when the result action is `decline` or
-  `cancel`.
-- Rejected URL elicitation values that are not absolute URIs to match the stable
-  and MCP 2026 `format: uri` schemas.
-- Rejected non-absolute resource URIs and malformed resource URI templates to
-  match stable and MCP 2026 `format: uri` and `format: uri-template` schemas.
-- Rejected malformed base64 payloads for image, audio, and blob resource
-  content to match stable and MCP 2026 `format: byte` schemas.
-- Rejected malformed shared annotation fields, including non-role audiences,
-  out-of-range priorities, and non-string `lastModified` values.
-- Rejected malformed `Role` values in prompt and sampling messages instead of
-  allowing raw enum lookup failures.
-- Rejected malformed logging level, sampling `includeContext`, and sampling
-  `toolChoice.mode` enum values with protocol parse errors.
-- Rejected malformed sampling string, boolean, and string-list wire fields with
-  protocol parse errors.
-- Rejected malformed content and resource string/list wire fields with protocol
-  parse errors.
-- Rejected malformed initialization and capability wire fields with protocol
-  parse errors.
-- Rejected malformed prompt, completion, logging, and common notification wire
-  fields with protocol parse errors.
-- Rejected malformed prompt JSON-RPC wrapper constants with protocol parse
-  errors.
-- Rejected malformed resource JSON-RPC wrapper constants with protocol parse
-  errors.
-- Rejected malformed tool JSON-RPC wrapper constants with protocol parse
-  errors.
-- Rejected malformed root JSON-RPC wrapper constants with protocol parse
-  errors.
-- Rejected malformed common notification and logging JSON-RPC wrapper
-  constants with protocol parse errors.
-- Rejected malformed initialization and `server/discover` JSON-RPC wrapper
-  constants with protocol parse errors.
-- Rejected malformed task and task-extension JSON-RPC wrapper constants with
-  protocol parse errors.
-- Rejected malformed sampling and elicitation JSON-RPC wrapper constants while
-  preserving embedded MRTR input request parsing.
-- Preserved `Result._meta` while parsing empty results for high-level ping,
-  logging, and subscription acknowledgments.
-- Preserved MCP 2026 `tools/list` cache hints when client-side tool metadata
-  filtering removes invalid tool definitions.
-- Rejected missing and mismatched completion reference type discriminators with
-  protocol parse errors.
-- Rejected malformed completion JSON-RPC wrapper constants with protocol parse
-  errors.
-- Rejected malformed tool definition, tool-list, and tool-call wire fields with
-  protocol parse errors.
-- Rejected malformed root-list wire fields with protocol parse errors.
-- Rejected malformed stable task and task-extension wire fields with protocol
-  parse errors.
-- Rejected malformed elicitation request, result, completion, and URL-required
-  error wire fields with protocol parse errors.
-- Rejected malformed subscription listen and acknowledgment wire fields with
-  protocol parse errors.
-- Rejected malformed sampling tool-list, tool-choice, and tool-result content
-  wire fields with protocol parse errors.
-- Rejected missing, unknown, and mismatched content block type discriminators
-  with protocol parse errors.
-- Rejected missing and mismatched sampling content type discriminators with
-  protocol parse errors.
-- Rejected resource content items that omit both `text` and `blob`, matching
-  the spec-defined `TextResourceContents | BlobResourceContents` union.
-- Rejected non-finite numeric values for progress, annotation priority, model
-  priority, and sampling temperature fields so SDK-built payloads remain valid
-  JSON numbers.
-- Rejected non-JSON values in sampling JSON object fields, including
-  `tool_use.input`, sampling metadata, annotations, and `_meta` maps.
-- Rejected non-JSON values in common content/resource metadata fields and
-  `resource_link.annotations`.
-- Reused shared JSON-object validation for MRTR, task extension, subscription,
-  and tool object fields.
-- Rejected non-JSON values in JSON-RPC envelope and remaining typed result
-  metadata fields.
-- Rejected non-JSON JSON-RPC error `data` values at parse and serialize
-  boundaries.
-- Rejected JSON-RPC response envelopes that include both `result` and `error`
-  instead of silently treating them as successful responses.
-- Rejected JSON-RPC request and notification envelopes whose `method` member is
-  not a string, and validated generic request `params` as JSON objects.
-- Rejected malformed JSON-RPC `error` objects with missing or invalid `code` or
-  `message` fields instead of surfacing Dart cast errors.
-- Rejected JSON-RPC error responses that include an explicit `id: null` member
-  while continuing to allow omitted IDs for malformed-request error cases.
-- Rejected JSON-RPC request and notification envelopes that include an explicit
-  `params: null` member, since `params` must be an object when present.
-- Prevented stateless MCP 2026 clients from sending core request and
-  notification methods removed from that protocol revision.
-- Rejected server-initiated JSON-RPC requests received by stateless MCP 2026
-  clients on generic transports.
-- Omitted the removed `roots.listChanged` client capability from MCP 2026
-  stateless request metadata while preserving it for stable 2025 metadata.
-- Rejected stateless MCP 2026 responses that omit `resultType` or required
-  cacheable-result fields.
-- Stripped caller-supplied `Mcp-Session-Id` headers case-insensitively from
-  MCP 2026 stateless Streamable HTTP requests.
-- Derived MCP 2026 stateless Streamable HTTP headers from nested
-  `params._meta` metadata for direct JSON-RPC transport sends.
-- Allowed Streamable MCP server CORS preflights for 2026 stateless routing and
-  tool parameter headers, including requested `Mcp-Param-*` headers.
-- Serialized MRTR `ElicitResult` and `ListRootsResult` input responses with the
-  MCP 2026 embedded client-result shapes that omit common Result `_meta`.
-- Accepted finite numeric JSON-RPC request IDs and progress tokens, matching
-  the stable and MCP 2026 `string | number` schema while continuing to reject
-  non-finite numbers.
-- Allowed protocol progress handlers and `RequestHandlerExtra.sendProgress` to
-  dispatch finite numeric progress tokens end-to-end.
-- Widened protocol `relatedRequestId` API parameters to preserve string and
-  finite numeric JSON-RPC request IDs through request and notification routing.
-- Accepted numeric `minimum`, `maximum`, `exclusiveMinimum`,
-  `exclusiveMaximum`, `multipleOf`, and `default` values on JSON Schema
-  `integer` schemas, matching the stable and MCP 2026 schema definitions.
-- Preserved object-level JSON Schema 2020-12 keywords on `JsonObject`
-  round-trips and added official MCP conformance gates for stable 2025 and
-  2026 RC client/server coverage in core CI.
+### MCP 2026-07-28 draft/RC preview
+
+- Added `McpProtocol.preview2026` and `McpProtocol.require2026` profiles for
+  clients and servers, with stable `initialize` behavior preserved by default.
+- Added `server/discover` negotiation, per-request stateless metadata,
+  protocol/client/capability validation, and version-aware fallback behavior.
+- Added stateless Streamable HTTP behavior for POST-only requests, no
+  `Mcp-Session-Id`, `Mcp-Name` task routing, `Mcp-Param-*` argument headers,
+  CORS preflights, SSE cancellation, and request-scoped logging.
+- Added draft-only flows for `subscriptions/listen`, MCP Tasks extension
+  handlers, MRTR `input_required` results, cacheable list/read results, and
+  `input_required` prompt/resource responses.
+- Added explicit typed APIs for non-object draft result data, including
+  `JsonValue`, `structuredContentJson`,
+  `CallToolResult.fromStructuredArray()`, and server `outputJsonSchema`.
+
+### Stable compatibility
+
+- Kept stable public tool-result APIs object-rooted and omitted non-object
+  structured output from stable MCP `2025-11-25` responses.
+- Preserved stable session behavior, registration-order list output, legacy task
+  augmentation, stable-only `Tool.execution` metadata, and legacy resource error
+  codes outside the 2026 stateless profile.
+- Preserved numeric JSON-RPC request IDs and progress tokens end-to-end while
+  continuing to reject non-finite numeric values.
+
+### Spec hardening
+
+- Tightened JSON-RPC envelope parsing, wrapper constant checks, error object
+  validation, `_meta` key validation, and mixed request/response rejection.
+- Tightened typed parsing for content, resources, prompts, tools, roots,
+  sampling, elicitation, tasks, subscriptions, completions, capabilities, and
+  JSON Schema fields so malformed wire values fail with protocol errors instead
+  of Dart cast errors.
+- Validated JSON-only metadata and result data across JSON-RPC, MRTR, task,
+  subscription, sampling, tool, resource, and content boundaries.
+
+### Conformance and release readiness
+
+- Added official MCP `2025-11-25` and MCP `2026-07-28` draft/RC client/server
+  conformance gates to core CI.
+- Added `tool/spec_example_audit.dart` for parsing upstream machine-readable
+  spec examples through checked-in SDK types during RC/final release audits.
+- Prepared the dev release workflow so prerelease tags are GitHub prereleases,
+  publish jobs run `dart pub publish --dry-run`, and the draft/RC transition
+  guide includes a dev release checklist.
+- Pointed prerelease package documentation links at `dev/2026-07-28-rc` so
+  pub.dev users see the draft/RC docs that match the dev package.
 
 ## 2.2.0
 

--- a/README.md
+++ b/README.md
@@ -113,39 +113,39 @@ final server = McpServer(
 ```
 
 Use the preview profile while the spec is still a draft/RC. See the
-[MCP 2026-07-28 draft/RC transition guide](https://github.com/leehack/mcp_dart/blob/main/doc/mcp-2026-rc.md)
+[MCP 2026-07-28 draft/RC transition guide](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/mcp-2026-rc.md)
 for opt-in behavior, fallback rules, and draft-only APIs.
 
 ## Documentation
 
 ### Getting Started
 
-- 📖 **[Quick Start Guide](https://github.com/leehack/mcp_dart/blob/main/doc/getting-started.md)** - Get up and running in 5 minutes
-- 🔧 **[Server Guide](https://github.com/leehack/mcp_dart/blob/main/doc/server-guide.md)** - Complete guide to building MCP servers
-- 💻 **[Client Guide](https://github.com/leehack/mcp_dart/blob/main/doc/client-guide.md)** - Complete guide to building MCP clients
+- 📖 **[Quick Start Guide](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/getting-started.md)** - Get up and running in 5 minutes
+- 🔧 **[Server Guide](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/server-guide.md)** - Complete guide to building MCP servers
+- 💻 **[Client Guide](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/client-guide.md)** - Complete guide to building MCP clients
 
 ### Core Concepts
 
-- 🛠️ **[Tools Documentation](https://github.com/leehack/mcp_dart/blob/main/doc/tools.md)** - Implementing executable tools
-- 🔌 **[Transport Options](https://github.com/leehack/mcp_dart/blob/main/doc/transports.md)** - Built-in and custom transport implementations
-- 📚 **[Examples](https://github.com/leehack/mcp_dart/blob/main/doc/examples.md)** - Real-world usage examples
-- ⚡ **[Quick Reference](https://github.com/leehack/mcp_dart/blob/main/doc/quick-reference.md)** - Fast lookup guide
-- 🪵 **[Runtime Logging](https://github.com/leehack/mcp_dart/blob/main/doc/getting-started.md#sdk-runtime-logging)** - Configure and route internal SDK logs
-- 🧩 **[MCP Apps Guide](https://github.com/leehack/mcp_dart/blob/main/doc/mcp-apps.md)** - Using `io.modelcontextprotocol/ui` metadata
+- 🛠️ **[Tools Documentation](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/tools.md)** - Implementing executable tools
+- 🔌 **[Transport Options](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/transports.md)** - Built-in and custom transport implementations
+- 📚 **[Examples](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/examples.md)** - Real-world usage examples
+- ⚡ **[Quick Reference](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/quick-reference.md)** - Fast lookup guide
+- 🪵 **[Runtime Logging](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/getting-started.md#sdk-runtime-logging)** - Configure and route internal SDK logs
+- 🧩 **[MCP Apps Guide](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/mcp-apps.md)** - Using `io.modelcontextprotocol/ui` metadata
 
 ### Recipes and Compatibility
 
-- 🧪 **[SDK Interoperability Matrix](https://github.com/leehack/mcp_dart/blob/main/doc/interoperability.md)** - Verified Dart/TypeScript and documented cross-SDK scenarios
-- ✅ **[MCP 2025-11-25 Spec Coverage Matrix](https://github.com/leehack/mcp_dart/blob/main/doc/spec-coverage-2025-11-25.md)** - Auditable coverage map with CLI conformance cases and known gaps
-- 🧭 **[MCP 2026-07-28 Draft/RC Transition Guide](https://github.com/leehack/mcp_dart/blob/main/doc/mcp-2026-rc.md)** - Opt-in profile, fallback behavior, and draft-only APIs
-- 🔒 **[Transport Security Recipes](https://github.com/leehack/mcp_dart/blob/main/doc/transports.md#dns-rebinding-protection)** - Host/Origin allowlists, OAuth layering, and compatibility-toggle trade-offs
-- 📱 **[Flutter Recipes](https://github.com/leehack/mcp_dart/blob/main/doc/flutter-recipes.md)** - Flutter Web, mobile, and desktop host/client guidance
-- 🔁 **[Migration Cookbooks](https://github.com/leehack/mcp_dart/blob/main/doc/migration-cookbooks.md)** - TypeScript SDK, `dart_mcp`, stdio-to-HTTP, and version migration paths
+- 🧪 **[SDK Interoperability Matrix](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/interoperability.md)** - Verified Dart/TypeScript and documented cross-SDK scenarios
+- ✅ **[MCP 2025-11-25 Spec Coverage Matrix](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/spec-coverage-2025-11-25.md)** - Auditable coverage map with CLI conformance cases and known gaps
+- 🧭 **[MCP 2026-07-28 Draft/RC Transition Guide](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/mcp-2026-rc.md)** - Opt-in profile, fallback behavior, and draft-only APIs
+- 🔒 **[Transport Security Recipes](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/transports.md#dns-rebinding-protection)** - Host/Origin allowlists, OAuth layering, and compatibility-toggle trade-offs
+- 📱 **[Flutter Recipes](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/flutter-recipes.md)** - Flutter Web, mobile, and desktop host/client guidance
+- 🔁 **[Migration Cookbooks](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/migration-cookbooks.md)** - TypeScript SDK, `dart_mcp`, stdio-to-HTTP, and version migration paths
 
 ### Advanced Features
 
-- 🔐 **[OAuth Authentication](https://github.com/leehack/mcp_dart/tree/main/example/authentication)** - OAuth2 guides and examples
-- 🔁 **[2025-11-25 Compatibility Migration](https://github.com/leehack/mcp_dart/blob/main/doc/migration_2025_11_25_compat.md)** - Backward-compatible API/runtime migration notes
+- 🔐 **[OAuth Authentication](https://github.com/leehack/mcp_dart/tree/dev/2026-07-28-rc/example/authentication)** - OAuth2 guides and examples
+- 🔁 **[2025-11-25 Compatibility Migration](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/migration_2025_11_25_compat.md)** - Backward-compatible API/runtime migration notes
 - 📝 For resources, prompts, and other features, see the Server and Client guides
 
 ## Quick Start with CLI
@@ -183,7 +183,7 @@ mcp_dart inspect --tool add --json-args '{"a": 1, "b": 2}'   # Call a tool
 | `inspect-client` | Run a stdio harness that inspects a connecting client |
 | `trace` | Proxy stdio client/server traffic and write a JSON trace |
 
-📖 **[Full CLI Documentation](https://github.com/leehack/mcp_dart/tree/main/packages/mcp_dart_cli)**
+📖 **[Full CLI Documentation](https://github.com/leehack/mcp_dart/tree/dev/2026-07-28-rc/packages/mcp_dart_cli)**
 
 ### Connecting to AI Hosts
 
@@ -202,11 +202,11 @@ Configure your server with AI hosts like Claude Desktop:
 ```
 
 > [!TIP]
-> For manual server implementation or advanced use cases, see the [Server Guide](https://github.com/leehack/mcp_dart/blob/main/doc/server-guide.md).
+> For manual server implementation or advanced use cases, see the [Server Guide](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/server-guide.md).
 
 ## Authentication
 
-This library provides OAuth-aware client and server authentication hooks, including `OAuthClientProvider` for StreamableHTTP clients, optional `OAuthAuthorizationCodeProvider` discovery support, and server-side `authenticator` / `authenticationHandler` callbacks. For OAuth2/PKCE guides and examples, see the [OAuth Authentication documentation](https://github.com/leehack/mcp_dart/tree/main/example/authentication) and [transport authentication docs](https://github.com/leehack/mcp_dart/blob/main/doc/transports.md#streamable-http-authentication).
+This library provides OAuth-aware client and server authentication hooks, including `OAuthClientProvider` for StreamableHTTP clients, optional `OAuthAuthorizationCodeProvider` discovery support, and server-side `authenticator` / `authenticationHandler` callbacks. For OAuth2/PKCE guides and examples, see the [OAuth Authentication documentation](https://github.com/leehack/mcp_dart/tree/dev/2026-07-28-rc/example/authentication) and [transport authentication docs](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/transports.md#streamable-http-authentication).
 
 ## Platform Support
 
@@ -222,15 +222,15 @@ This library provides OAuth-aware client and server authentication hooks, includ
 
 For additional examples including authentication, HTTP clients, and advanced features:
 
-- [All Examples](https://github.com/leehack/mcp_dart/tree/main/example)
-- [Authentication Examples](https://github.com/leehack/mcp_dart/tree/main/example/authentication)
+- [All Examples](https://github.com/leehack/mcp_dart/tree/dev/2026-07-28-rc/example)
+- [Authentication Examples](https://github.com/leehack/mcp_dart/tree/dev/2026-07-28-rc/example/authentication)
 
 ## Community & Support
 
 - **Issues & Bug Reports**: [GitHub Issues](https://github.com/leehack/mcp_dart/issues)
 - **Package**: [pub.dev/packages/mcp_dart](https://pub.dev/packages/mcp_dart)
 - **API Docs**: [pub.dev documentation](https://pub.dev/documentation/mcp_dart/latest/)
-- **Changelog**: [CHANGELOG.md](https://github.com/leehack/mcp_dart/blob/main/CHANGELOG.md)
+- **Changelog**: [CHANGELOG.md](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/CHANGELOG.md)
 - **Protocol Spec**: [MCP Specification](https://modelcontextprotocol.io/specification/2025-11-25)
 
 ## Credits

--- a/doc/mcp-2026-rc.md
+++ b/doc/mcp-2026-rc.md
@@ -112,3 +112,34 @@ final items = result.structuredContentJson?.asArray;
 The draft/RC API surface may still change before the official spec release.
 Keep applications on the stable profile unless they specifically need draft
 behavior.
+
+## Dev Release Checklist
+
+Use dev releases for MCP `2026-07-28` draft/RC testing until the official spec
+is released. Dev versions must include a prerelease suffix such as
+`2.3.0-dev.0` so pub.dev and GitHub treat them as preview builds.
+
+Before creating tags from `dev/2026-07-28-rc`, run:
+
+```sh
+dart analyze
+dart pub publish --dry-run
+dart pub global run pana --no-warning
+dart run tool/validate_cli_publish.dart
+```
+
+Publish the SDK package first by running the `Create Release` workflow for
+`mcp_dart` from `dev/2026-07-28-rc`. The publish workflow runs a dry-run check
+before `dart pub publish --force`, and prerelease versions are marked as GitHub
+prereleases rather than repository latest releases.
+
+After `mcp_dart` is available on pub.dev, validate the CLI against the published
+SDK package:
+
+```sh
+dart run tool/validate_cli_publish.dart --published-sdk
+```
+
+Then run the `Create Release` workflow for `mcp_dart_cli` from
+`dev/2026-07-28-rc`. The CLI publish workflow removes the local SDK override
+before publishing so users receive the published SDK dependency.

--- a/doc/mcp-2026-rc.md
+++ b/doc/mcp-2026-rc.md
@@ -128,6 +128,10 @@ dart pub global run pana --no-warning
 dart run tool/validate_cli_publish.dart
 ```
 
+For dev packages, keep package documentation links pointed at
+`dev/2026-07-28-rc` until the draft work is ready to merge back to `main`.
+Restore those links to `main` as part of the final spec release prep.
+
 Publish the SDK package first by running the `Create Release` workflow for
 `mcp_dart` from `dev/2026-07-28-rc`. The publish workflow runs a dry-run check
 before `dart pub publish --force`, and prerelease versions are marked as GitHub
@@ -143,3 +147,17 @@ dart run tool/validate_cli_publish.dart --published-sdk
 Then run the `Create Release` workflow for `mcp_dart_cli` from
 `dev/2026-07-28-rc`. The CLI publish workflow removes the local SDK override
 before publishing so users receive the published SDK dependency.
+
+Install the dev CLI explicitly by version:
+
+```sh
+dart pub global activate mcp_dart_cli 0.2.0-dev.0
+```
+
+The standalone install and update scripts intentionally track stable GitHub
+releases; use Dart SDK activation when testing prerelease CLI builds.
+
+`mcp_dart create` continues to generate projects that resolve the stable SDK by
+default. For draft/RC testing, update generated projects to depend on
+`mcp_dart: ^2.3.0-dev.0` and opt into `McpProtocol.preview2026` or
+`McpProtocol.require2026`.

--- a/packages/mcp_dart_cli/CHANGELOG.md
+++ b/packages/mcp_dart_cli/CHANGELOG.md
@@ -4,6 +4,10 @@
   dependency on `mcp_dart ^2.3.0-dev.0`.
 - Keep the local monorepo SDK override in `pubspec_overrides.yaml` so published
   CLI pubspec metadata does not expose path overrides.
+- Point dev CLI package documentation metadata at the `dev/2026-07-28-rc`
+  branch and document explicit prerelease activation.
+- Document that generated projects still resolve the stable SDK by default and
+  need an explicit `mcp_dart ^2.3.0-dev.0` dependency for draft/RC testing.
 
 ## 0.1.9
 

--- a/packages/mcp_dart_cli/README.md
+++ b/packages/mcp_dart_cli/README.md
@@ -13,6 +13,13 @@ With the Dart SDK:
 dart pub global activate mcp_dart_cli
 ```
 
+For the MCP `2026-07-28` draft/RC dev release, pass the prerelease version
+explicitly:
+
+```bash
+dart pub global activate mcp_dart_cli 0.2.0-dev.0
+```
+
 Without the Dart SDK, install the latest standalone binary from GitHub Releases:
 
 ```bash
@@ -32,6 +39,9 @@ same command upgrades the binary. Installed binaries can also run:
 mcp_dart update
 ```
 
+Standalone installers track stable GitHub releases. Use Dart SDK activation
+with an explicit prerelease version when testing a dev CLI release.
+
 ## Usage
 
 ### Create a new project
@@ -48,6 +58,9 @@ mcp_dart create path/to/my_project
 
 If `directory` is omitted, the project will be created in the current directory with the name `<project_name>`.
 
+Generated projects resolve the stable `mcp_dart` SDK by default. For MCP
+`2026-07-28` draft/RC testing, update the generated `pubspec.yaml` to depend on
+`mcp_dart: ^2.3.0-dev.0`.
 
 ### Create from a specific template
 

--- a/packages/mcp_dart_cli/pubspec.yaml
+++ b/packages/mcp_dart_cli/pubspec.yaml
@@ -2,9 +2,9 @@ name: mcp_dart_cli
 description: Command-line tools for creating, serving, inspecting, and testing Dart Model Context Protocol (MCP) servers.
 version: 0.2.0-dev.0
 repository: https://github.com/leehack/mcp_dart
-homepage: https://github.com/leehack/mcp_dart/tree/main/packages/mcp_dart_cli
+homepage: https://github.com/leehack/mcp_dart/tree/dev/2026-07-28-rc/packages/mcp_dart_cli
 issue_tracker: https://github.com/leehack/mcp_dart/issues
-documentation: https://github.com/leehack/mcp_dart/tree/main/packages/mcp_dart_cli
+documentation: https://github.com/leehack/mcp_dart/tree/dev/2026-07-28-rc/packages/mcp_dart_cli
 topics:
   - mcp
   - ai

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.3.0-dev.0
 repository: https://github.com/leehack/mcp_dart
 homepage: https://github.com/leehack/mcp_dart
 issue_tracker: https://github.com/leehack/mcp_dart/issues
-documentation: https://github.com/leehack/mcp_dart/tree/main/doc
+documentation: https://github.com/leehack/mcp_dart/tree/dev/2026-07-28-rc/doc
 topics:
   - mcp
   - ai


### PR DESCRIPTION
## Summary
- mark prerelease versions as GitHub prereleases and keep them out of latest release selection
- add a publish dry-run gate before pub.dev publish
- document the MCP 2026 RC dev release sequence

## Validation
- ruby YAML parse for publish/release workflows
- dart analyze
- dart test test/docs/markdown_docs_test.dart
- dart pub publish --dry-run
- dart run tool/validate_cli_publish.dart

## Notes
This PR prepares the dev-release path for mcp_dart 2.3.0-dev.0 and mcp_dart_cli 0.2.0-dev.0. The SDK should be published first, then the CLI should be validated with --published-sdk before its release.