### PR TITLE
Fix CLI binary workflow runner labels

### DIFF
--- a/.github/workflows/cli_binaries.yml
+++ b/.github/workflows/cli_binaries.yml
@@ -24,11 +24,11 @@ jobs:
         include:
           - os: ubuntu-latest
             asset: mcp_dart-linux-x64
-          - os: macos-13
+          - os: macos-15-intel
             asset: mcp_dart-macos-x64
           - os: macos-14
             asset: mcp_dart-macos-arm64
-          - os: windows-latest
+          - os: windows-2025
             asset: mcp_dart-windows-x64.exe
 
     defaults:
@@ -57,7 +57,7 @@ jobs:
           "./dist/${{ matrix.asset }}" --version
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.asset }}
           path: packages/mcp_dart_cli/dist/${{ matrix.asset }}


### PR DESCRIPTION
## Summary
- move the macOS x64 CLI binary job from retired macos-13 to macos-15-intel
- pin Windows binary job to windows-2025 instead of windows-latest
- update upload-artifact to v6 for the current Node runtime

## Validation
- git diff --check
- YAML parsed with Ruby Psych

This is needed to unblock the pending CLI binary assets for mcp_dart_cli-v0.2.0-dev.0.