### PR TITLE
Preserve JSON Schema boolean subschemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 
 ### Spec Alignment
 
+- Accepted and preserved JSON Schema 2020-12 boolean subschemas in nested
+  schema positions such as object properties, array items, composition
+  keywords, and `not`.
 - Preserved the MCP `Result._meta` field across typed result serializers,
   including initialization, roots, resources, prompts, completion, elicitation,
   tools, tasks, sampling, and empty results.

--- a/lib/src/shared/json_schema/json_schema.dart
+++ b/lib/src/shared/json_schema/json_schema.dart
@@ -4,6 +4,7 @@ const _jsonSchemaAnnotationKeys = {'title', 'description', 'default'};
 sealed class JsonSchema {
   final String? title;
   final String? description;
+  final bool? _rawBooleanSubschema;
 
   /// The default value for this schema.
   ///
@@ -11,11 +12,36 @@ sealed class JsonSchema {
   /// [int] for [JsonInteger], etc.).
   dynamic get defaultValue;
 
-  const JsonSchema({this.title, this.description});
+  const JsonSchema({
+    this.title,
+    this.description,
+    bool? rawBooleanSubschema,
+  }) : _rawBooleanSubschema = rawBooleanSubschema;
 
   /// Creates a [JsonSchema] from a JSON map.
   factory JsonSchema.fromJson(Map<String, dynamic> json) {
     return _fromJson(json);
+  }
+
+  /// Creates a [JsonSchema] from a JSON Schema value.
+  ///
+  /// JSON Schema 2020-12 subschemas can be either schema objects or boolean
+  /// schemas. This parser accepts both forms for nested schema positions.
+  static JsonSchema fromJsonValue(Object? json) {
+    return _fromJsonValue(json, 'JsonSchema');
+  }
+
+  static JsonSchema _fromJsonValue(Object? json, String field) {
+    if (json is bool) {
+      return json ? const JsonAny._booleanSubschema() : const JsonNot._never();
+    }
+    if (json is Map<String, dynamic>) {
+      return JsonSchema.fromJson(json);
+    }
+    if (json is Map) {
+      return JsonSchema.fromJson(Map<String, dynamic>.from(json));
+    }
+    throw FormatException('$field must be a JSON Schema object or boolean');
   }
 
   static JsonSchema _fromJson(Map<String, dynamic> json) {
@@ -183,6 +209,13 @@ sealed class JsonSchema {
 
   /// Converts the schema to a JSON map.
   Map<String, dynamic> toJson();
+
+  /// Converts the schema to a JSON Schema value.
+  ///
+  /// This preserves JSON Schema boolean schemas parsed with [fromJsonValue].
+  Object toJsonValue() {
+    return _jsonSchemaValue(this);
+  }
 
   /// Creates a string schema.
   static JsonString string({
@@ -412,6 +445,14 @@ sealed class JsonSchema {
       defaultValue: defaultValue,
     );
   }
+}
+
+dynamic _jsonSchemaValue(JsonSchema schema) {
+  final rawBooleanSubschema = schema._rawBooleanSubschema;
+  if (rawBooleanSubschema != null) {
+    return rawBooleanSubschema;
+  }
+  return schema.toJson();
 }
 
 /// A schema for string values.
@@ -733,7 +774,7 @@ class JsonArray extends JsonSchema {
   factory JsonArray.fromJson(Map<String, dynamic> json) {
     return JsonArray._(
       items: json['items'] != null
-          ? JsonSchema.fromJson(json['items'] as Map<String, dynamic>)
+          ? JsonSchema._fromJsonValue(json['items'], 'JsonArray.items')
           : null,
       minItems: json['minItems'] as int?,
       maxItems: json['maxItems'] as int?,
@@ -751,6 +792,8 @@ class JsonArray extends JsonSchema {
     final serializedItems = itemSchema == null
         ? null
         : switch (itemSchema) {
+            final JsonSchema schema when schema._rawBooleanSubschema != null =>
+              schema._rawBooleanSubschema,
             final JsonEnum enumItems => enumItems._toJson(
                 titledStringConstListKeyword: 'anyOf',
               ),
@@ -810,15 +853,18 @@ class JsonObject extends JsonSchema {
     if (additionalProps is bool) {
       parsedAdditionalProps = additionalProps;
     } else if (additionalProps is Map) {
-      parsedAdditionalProps = JsonSchema.fromJson(
-        Map<String, dynamic>.from(additionalProps),
+      parsedAdditionalProps = JsonSchema._fromJsonValue(
+        additionalProps,
+        'JsonObject.additionalProperties',
       );
     }
 
     return JsonObject._(
       properties: (json['properties'] as Map<String, dynamic>?)?.map(
-        (key, value) =>
-            MapEntry(key, JsonSchema.fromJson(value as Map<String, dynamic>)),
+        (key, value) => MapEntry(
+          key,
+          JsonSchema._fromJsonValue(value, 'JsonObject.properties.$key'),
+        ),
       ),
       required: (json['required'] as List?)?.cast<String>(),
       additionalProperties: parsedAdditionalProps,
@@ -839,11 +885,12 @@ class JsonObject extends JsonSchema {
       if (_hasDefault) 'default': defaultValue,
       'type': 'object',
       if (properties != null)
-        'properties': properties!.map((k, v) => MapEntry(k, v.toJson())),
+        'properties':
+            properties!.map((k, v) => MapEntry(k, _jsonSchemaValue(v))),
       if (required != null && required!.isNotEmpty) 'required': required,
       if (additionalProperties != null)
         'additionalProperties': additionalProperties is JsonSchema
-            ? (additionalProperties as JsonSchema).toJson()
+            ? _jsonSchemaValue(additionalProperties as JsonSchema)
             : additionalProperties,
       if (dependentRequired != null) 'dependentRequired': dependentRequired,
     };
@@ -871,6 +918,12 @@ class JsonAny extends JsonSchema {
     required bool hasDefault,
   })  : _hasDefault = hasDefault,
         super(title: title, description: description);
+
+  const JsonAny._booleanSubschema()
+      : properties = const {},
+        _hasDefault = false,
+        defaultValue = null,
+        super(rawBooleanSubschema: true);
 
   @override
   final dynamic defaultValue;
@@ -1012,7 +1065,7 @@ class JsonUnion extends JsonSchema {
       if (typeNames != null)
         'type': typeNames
       else
-        'anyOf': schemas.map((schema) => schema.toJson()).toList(),
+        'anyOf': schemas.map(_jsonSchemaValue).toList(),
     };
   }
 
@@ -1108,7 +1161,7 @@ class JsonAllOf extends JsonSchema {
   factory JsonAllOf.fromJson(Map<String, dynamic> json) {
     return JsonAllOf._(
       (json['allOf'] as List)
-          .map((e) => JsonSchema.fromJson(e as Map<String, dynamic>))
+          .map((e) => JsonSchema._fromJsonValue(e, 'JsonAllOf.allOf'))
           .toList(),
       title: json['title'] as String?,
       description: json['description'] as String?,
@@ -1123,7 +1176,7 @@ class JsonAllOf extends JsonSchema {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
       if (_hasDefault) 'default': defaultValue,
-      'allOf': schemas.map((s) => s.toJson()).toList(),
+      'allOf': schemas.map(_jsonSchemaValue).toList(),
     };
   }
 }
@@ -1154,7 +1207,7 @@ class JsonAnyOf extends JsonSchema {
   factory JsonAnyOf.fromJson(Map<String, dynamic> json) {
     return JsonAnyOf._(
       (json['anyOf'] as List)
-          .map((e) => JsonSchema.fromJson(e as Map<String, dynamic>))
+          .map((e) => JsonSchema._fromJsonValue(e, 'JsonAnyOf.anyOf'))
           .toList(),
       title: json['title'] as String?,
       description: json['description'] as String?,
@@ -1169,7 +1222,7 @@ class JsonAnyOf extends JsonSchema {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
       if (_hasDefault) 'default': defaultValue,
-      'anyOf': schemas.map((s) => s.toJson()).toList(),
+      'anyOf': schemas.map(_jsonSchemaValue).toList(),
     };
   }
 }
@@ -1200,7 +1253,7 @@ class JsonOneOf extends JsonSchema {
   factory JsonOneOf.fromJson(Map<String, dynamic> json) {
     return JsonOneOf._(
       (json['oneOf'] as List)
-          .map((e) => JsonSchema.fromJson(e as Map<String, dynamic>))
+          .map((e) => JsonSchema._fromJsonValue(e, 'JsonOneOf.oneOf'))
           .toList(),
       title: json['title'] as String?,
       description: json['description'] as String?,
@@ -1215,7 +1268,7 @@ class JsonOneOf extends JsonSchema {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
       if (_hasDefault) 'default': defaultValue,
-      'oneOf': schemas.map((s) => s.toJson()).toList(),
+      'oneOf': schemas.map(_jsonSchemaValue).toList(),
     };
   }
 }
@@ -1240,12 +1293,18 @@ class JsonNot extends JsonSchema {
     required bool hasDefault,
   }) : _hasDefault = hasDefault;
 
+  const JsonNot._never()
+      : schema = const JsonAny(),
+        defaultValue = null,
+        _hasDefault = false,
+        super(rawBooleanSubschema: false);
+
   @override
   final dynamic defaultValue;
 
   factory JsonNot.fromJson(Map<String, dynamic> json) {
     return JsonNot._(
-      JsonSchema.fromJson(json['not'] as Map<String, dynamic>),
+      JsonSchema._fromJsonValue(json['not'], 'JsonNot.not'),
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'],
@@ -1259,7 +1318,7 @@ class JsonNot extends JsonSchema {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
       if (_hasDefault) 'default': defaultValue,
-      'not': schema.toJson(),
+      'not': _jsonSchemaValue(schema),
     };
   }
 }

--- a/lib/src/shared/json_schema/json_schema_validator.dart
+++ b/lib/src/shared/json_schema/json_schema_validator.dart
@@ -544,24 +544,17 @@ extension JsonSchemaValidation on JsonSchema {
   ) {
     final allOf = keywords['allOf'];
     if (keywords.containsKey('allOf')) {
-      for (final entry in _compositionSchemaList('allOf', allOf, path)) {
-        _validate(
-          JsonSchema.fromJson(entry),
-          data,
-          path,
-        );
+      for (final schema in _compositionSchemaList('allOf', allOf, path)) {
+        _validate(schema, data, path);
       }
     }
 
     final anyOf = keywords['anyOf'];
     if (keywords.containsKey('anyOf')) {
-      final matches = _compositionSchemaList('anyOf', anyOf, path).any((entry) {
+      final matches =
+          _compositionSchemaList('anyOf', anyOf, path).any((schema) {
         try {
-          _validate(
-            JsonSchema.fromJson(entry),
-            data,
-            path,
-          );
+          _validate(schema, data, path);
           return true;
         } on JsonSchemaValidationException {
           return false;
@@ -578,13 +571,9 @@ extension JsonSchemaValidation on JsonSchema {
     final oneOf = keywords['oneOf'];
     if (keywords.containsKey('oneOf')) {
       final matches =
-          _compositionSchemaList('oneOf', oneOf, path).where((entry) {
+          _compositionSchemaList('oneOf', oneOf, path).where((schema) {
         try {
-          _validate(
-            JsonSchema.fromJson(entry),
-            data,
-            path,
-          );
+          _validate(schema, data, path);
           return true;
         } on JsonSchemaValidationException {
           return false;
@@ -600,18 +589,17 @@ extension JsonSchemaValidation on JsonSchema {
 
     final not = keywords['not'];
     if (keywords.containsKey('not')) {
-      if (not is! Map) {
+      final JsonSchema notSchema;
+      try {
+        notSchema = JsonSchema.fromJsonValue(not);
+      } on FormatException {
         throw JsonSchemaValidationException(
-          'not must be a schema object',
+          'not must be a schema object or boolean',
           path,
         );
       }
       try {
-        _validate(
-          JsonSchema.fromJson(Map<String, dynamic>.from(not)),
-          data,
-          path,
-        );
+        _validate(notSchema, data, path);
       } on JsonSchemaValidationException {
         return;
       }
@@ -619,7 +607,7 @@ extension JsonSchemaValidation on JsonSchema {
     }
   }
 
-  List<Map<String, dynamic>> _compositionSchemaList(
+  List<JsonSchema> _compositionSchemaList(
     String keyword,
     dynamic value,
     List<String> path,
@@ -628,13 +616,14 @@ extension JsonSchemaValidation on JsonSchema {
       throw JsonSchemaValidationException('$keyword must be a list', path);
     }
     return value.map((entry) {
-      if (entry is! Map) {
+      try {
+        return JsonSchema.fromJsonValue(entry);
+      } on FormatException {
         throw JsonSchemaValidationException(
-          '$keyword entries must be schema objects',
+          '$keyword entries must be schema objects or booleans',
           path,
         );
       }
-      return Map<String, dynamic>.from(entry);
     }).toList();
   }
 

--- a/test/shared/json_schema_from_json_test.dart
+++ b/test/shared/json_schema_from_json_test.dart
@@ -168,6 +168,31 @@ void main() {
       expect(schema, isA<JsonBoolean>());
     });
 
+    test('round trips boolean schema values', () {
+      expect(JsonSchema.fromJsonValue(true).toJsonValue(), true);
+      expect(JsonSchema.fromJsonValue(false).toJsonValue(), false);
+    });
+
+    test('parses object properties with boolean subschemas', () {
+      final json = {
+        'type': 'object',
+        'properties': {
+          'allowed': true,
+          'denied': false,
+          'named': {'type': 'string'},
+        },
+      };
+
+      final schema = JsonSchema.fromJson(json);
+
+      expect(schema, isA<JsonObject>());
+      final object = schema as JsonObject;
+      expect(object.properties!['allowed'], isA<JsonAny>());
+      expect(object.properties!['denied'], isA<JsonNot>());
+      expect(object.properties!['named'], isA<JsonString>());
+      expect(object.toJson(), json);
+    });
+
     test('parses null schema', () {
       final json = {'type': 'null'};
       final schema = JsonSchema.fromJson(json);
@@ -189,6 +214,18 @@ void main() {
       expect(s.minItems, 1);
       expect(s.maxItems, 5);
       expect(s.uniqueItems, true);
+    });
+
+    test('parses array items with boolean subschemas', () {
+      for (final json in [
+        {'type': 'array', 'items': true},
+        {'type': 'array', 'items': false},
+      ]) {
+        final schema = JsonSchema.fromJson(json);
+
+        expect(schema, isA<JsonArray>());
+        expect(schema.toJson(), json);
+      }
     });
 
     test('parses object schema', () {
@@ -276,6 +313,32 @@ void main() {
       expect(s.schemas[1].toJson(), {'minLength': 5});
     });
 
+    test('parses composition keywords with boolean subschemas', () {
+      final schemas = [
+        {
+          'allOf': [
+            true,
+            {'type': 'string'},
+          ],
+        },
+        {
+          'anyOf': [
+            false,
+            {'type': 'integer'},
+          ],
+        },
+        {
+          'oneOf': [true, false],
+        },
+        {'not': false},
+        {'not': true},
+      ];
+
+      for (final json in schemas) {
+        expect(JsonSchema.fromJson(json).toJson(), json);
+      }
+    });
+
     test('parses anyOf schema', () {
       final json = {
         'anyOf': [
@@ -357,6 +420,30 @@ void main() {
       expect(parsed.toJson(), json);
     });
 
+    test('nested boolean subschemas round trip', () {
+      final schemas = [
+        {
+          'type': 'object',
+          'properties': {
+            'allowed': true,
+            'denied': false,
+          },
+        },
+        {'type': 'array', 'items': false},
+        {
+          'allOf': [
+            true,
+            {'type': 'string'},
+          ],
+        },
+        {'not': true},
+      ];
+
+      for (final json in schemas) {
+        expect(JsonSchema.fromJson(json).toJson(), json);
+      }
+    });
+
     test('const round trip', () {
       final original = JsonSchema.constValue('DELETE');
       final json = original.toJson();
@@ -371,6 +458,20 @@ void main() {
       ]);
       final json = original.toJson();
       final parsed = JsonSchema.fromJson(json);
+      expect(parsed.toJson(), json);
+    });
+
+    test('union with boolean subschema branches round trip', () {
+      final original = JsonSchema.union([
+        JsonSchema.fromJsonValue(true),
+        JsonSchema.fromJsonValue(false),
+      ]);
+      final json = original.toJson();
+      final parsed = JsonSchema.fromJson(json);
+
+      expect(json, {
+        'anyOf': [true, false],
+      });
       expect(parsed.toJson(), json);
     });
 

--- a/test/shared/json_schema_validator_test.dart
+++ b/test/shared/json_schema_validator_test.dart
@@ -266,6 +266,24 @@ void main() {
         );
       });
 
+      test('validates array items with boolean subschemas', () {
+        final alwaysValid = JsonSchema.fromJson({
+          'type': 'array',
+          'items': true,
+        });
+        alwaysValid.validate([1, 'two', null]);
+
+        final alwaysInvalid = JsonSchema.fromJson({
+          'type': 'array',
+          'items': false,
+        });
+        alwaysInvalid.validate([]);
+        expect(
+          () => alwaysInvalid.validate([1]),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+      });
+
       test('uniqueItems works with objects', () {
         final schema = JsonSchema.array(uniqueItems: true);
         schema.validate([
@@ -391,6 +409,24 @@ void main() {
           "baz": 123,
           "nested": {"a": true},
         });
+      });
+
+      test('validates object properties with boolean subschemas', () {
+        final schema = JsonSchema.fromJson({
+          'type': 'object',
+          'properties': {
+            'allowed': true,
+            'denied': false,
+          },
+        });
+
+        schema.validate({'allowed': 'anything'});
+        schema.validate({'allowed': null});
+
+        expect(
+          () => schema.validate({'denied': 'anything'}),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
       });
     });
 
@@ -612,6 +648,47 @@ void main() {
         schema.validate(true);
         expect(
           () => schema.validate("string"),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+      });
+
+      test('validates composition keywords with boolean subschemas', () {
+        final allOfTrue = JsonSchema.fromJson({
+          'allOf': [
+            true,
+            {'type': 'string'},
+          ],
+        });
+        allOfTrue.validate('value');
+        expect(
+          () => allOfTrue.validate(1),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+
+        final anyOfFalse = JsonSchema.fromJson({
+          'anyOf': [
+            false,
+            {'type': 'integer'},
+          ],
+        });
+        anyOfFalse.validate(1);
+        expect(
+          () => anyOfFalse.validate('value'),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+
+        final oneOfTrueFalse = JsonSchema.fromJson({
+          'oneOf': [true, false],
+        });
+        oneOfTrueFalse.validate('value');
+        oneOfTrueFalse.validate(null);
+
+        final notFalse = JsonSchema.fromJson({'not': false});
+        notFalse.validate('value');
+
+        final notTrue = JsonSchema.fromJson({'not': true});
+        expect(
+          () => notTrue.validate('value'),
           throwsA(isA<JsonSchemaValidationException>()),
         );
       });

--- a/test/tool_schema_test.dart
+++ b/test/tool_schema_test.dart
@@ -221,6 +221,31 @@ void main() {
       );
     });
 
+    test('Tool preserves boolean subschema properties end-to-end', () {
+      final json = {
+        'name': 'boolean-subschemas',
+        'inputSchema': {
+          'type': 'object',
+          'properties': {
+            'allowed': true,
+            'denied': false,
+          },
+        },
+      };
+
+      final tool = Tool.fromJson(json);
+
+      expect(tool.toJson(), json);
+      expect(
+        ListToolsResult.fromJson({
+          'tools': [json],
+        }).toJson(),
+        {
+          'tools': [json],
+        },
+      );
+    });
+
     test('Real-world MCP server tool schema example', () {
       // Example from a real MCP server like Hugging Face
       final serverResponse = {


### PR DESCRIPTION
Implements support for JSON Schema 2020-12 boolean schemas in MCP tool schemas.

Context: some SDKs can emit nested tool input schemas such as `"x": true` for fields where the schema allows any value. JSON Schema also defines `false` as a schema that matches no values, so the Dart SDK should preserve both values instead of normalizing them.

This update:
- accepts schema values that are either objects or booleans via `JsonSchema.fromJsonValue`
- preserves boolean subschemas in `properties`, `items`, `additionalProperties`, `allOf`, `anyOf`, `oneOf`, and `not`
- validates boolean schema semantics correctly: `true` accepts any value and `false` rejects every value
- keeps the existing `toJson()` map contract and adds `toJsonValue()` for value-level round trips
- adds regression coverage for parser, validator, and MCP tool schema serialization behavior

Validation run locally:
- `dart analyze`
- `dart test`