### PR TITLE
Prepare mcp_dart 2.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.1
+
+### Spec Alignment
+
+- Accepted and preserved JSON Schema 2020-12 boolean subschemas in nested
+  schema positions such as object properties, array items, composition
+  keywords, and `not`.
+
 ## 2.2.0
 
 ### Documentation
@@ -22,9 +30,6 @@
 
 ### Spec Alignment
 
-- Accepted and preserved JSON Schema 2020-12 boolean subschemas in nested
-  schema positions such as object properties, array items, composition
-  keywords, and `not`.
 - Preserved the MCP `Result._meta` field across typed result serializers,
   including initialization, roots, resources, prompts, completion, elicitation,
   tools, tasks, sampling, and empty results.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mcp_dart
 description: Dart and Flutter SDK for building Model Context Protocol (MCP) servers, clients, hosts, and AI tools.
-version: 2.2.0
+version: 2.2.1
 repository: https://github.com/leehack/mcp_dart
 homepage: https://github.com/leehack/mcp_dart
 issue_tracker: https://github.com/leehack/mcp_dart/issues


### PR DESCRIPTION
## Summary
- Bump the root `mcp_dart` package version to `2.2.1`.
- Add a `2.2.1` changelog section for the JSON Schema boolean subschema spec-compliance fix.
- Move the boolean-subschema note out of the already-published `2.2.0` changelog section.

## Validation
- `dart format .`
- `dart analyze`
- `dart test`
- `dart pub publish --dry-run`
- `git diff --check origin/main..HEAD`

`dart pub publish --dry-run` reports 0 warnings and 1 hint because `2.3.0-dev.0` is already published while this is a stable `2.2.x` patch release.