### PR TITLE
Preserve JSON Schema boolean subschemas on dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ explicitly and may still change before the official spec release.
 
 - Tightened JSON-RPC envelope parsing, wrapper constant checks, error object
   validation, `_meta` key validation, and mixed request/response rejection.
+- Accepted and preserved JSON Schema 2020-12 boolean subschemas in nested
+  schema positions such as object properties, array items, composition
+  keywords, and `not`.
 - Tightened typed parsing for content, resources, prompts, tools, roots,
   sampling, elicitation, tasks, subscriptions, completions, capabilities, and
   JSON Schema fields so malformed wire values fail with protocol errors instead

--- a/lib/src/server/mcp_server.dart
+++ b/lib/src/server/mcp_server.dart
@@ -2281,7 +2281,8 @@ class McpServer {
           (inputSchemaProperties != null
               ? ToolInputSchema(
                   properties: inputSchemaProperties.map(
-                    (key, value) => MapEntry(key, JsonSchema.fromJson(value)),
+                    (key, value) =>
+                        MapEntry(key, JsonSchema.fromJsonValue(value)),
                   ),
                 )
               : null),
@@ -2289,7 +2290,8 @@ class McpServer {
           (outputSchemaProperties != null
               ? ToolOutputSchema(
                   properties: outputSchemaProperties.map(
-                    (key, value) => MapEntry(key, JsonSchema.fromJson(value)),
+                    (key, value) =>
+                        MapEntry(key, JsonSchema.fromJsonValue(value)),
                   ),
                 )
               : null),

--- a/lib/src/shared/json_schema/json_schema.dart
+++ b/lib/src/shared/json_schema/json_schema.dart
@@ -40,6 +40,7 @@ int? _integerApiValue(num? value) {
 sealed class JsonSchema {
   final String? title;
   final String? description;
+  final bool? _rawBooleanSubschema;
 
   /// The default value for this schema.
   ///
@@ -47,11 +48,36 @@ sealed class JsonSchema {
   /// [JsonString], [num] for [JsonNumber], [int] for [JsonInteger], etc.).
   dynamic get defaultValue;
 
-  const JsonSchema({this.title, this.description});
+  const JsonSchema({
+    this.title,
+    this.description,
+    bool? rawBooleanSubschema,
+  }) : _rawBooleanSubschema = rawBooleanSubschema;
 
   /// Creates a [JsonSchema] from a JSON map.
   factory JsonSchema.fromJson(Map<String, dynamic> json) {
     return _fromJson(json);
+  }
+
+  /// Creates a [JsonSchema] from a JSON Schema value.
+  ///
+  /// JSON Schema 2020-12 subschemas can be either schema objects or boolean
+  /// schemas. This parser accepts both forms for nested schema positions.
+  static JsonSchema fromJsonValue(Object? json) {
+    return _fromJsonValue(json, 'JsonSchema');
+  }
+
+  static JsonSchema _fromJsonValue(Object? json, String field) {
+    if (json is bool) {
+      return json ? const JsonAny._booleanSubschema() : const JsonNot._never();
+    }
+    if (json is Map<String, dynamic>) {
+      return JsonSchema.fromJson(json);
+    }
+    if (json is Map) {
+      return JsonSchema.fromJson(Map<String, dynamic>.from(json));
+    }
+    throw FormatException('$field must be a JSON Schema object or boolean');
   }
 
   static JsonSchema _fromJson(Map<String, dynamic> json) {
@@ -270,6 +296,13 @@ sealed class JsonSchema {
 
   /// Converts the schema to a JSON map.
   Map<String, dynamic> toJson();
+
+  /// Converts the schema to a JSON Schema value.
+  ///
+  /// This preserves JSON Schema boolean schemas parsed with [fromJsonValue].
+  Object toJsonValue() {
+    return _jsonSchemaValue(this);
+  }
 
   /// Creates a string schema.
   static JsonString string({
@@ -507,6 +540,14 @@ sealed class JsonSchema {
       defaultValue: defaultValue,
     );
   }
+}
+
+dynamic _jsonSchemaValue(JsonSchema schema) {
+  final rawBooleanSubschema = schema._rawBooleanSubschema;
+  if (rawBooleanSubschema != null) {
+    return rawBooleanSubschema;
+  }
+  return schema.toJson();
 }
 
 /// A schema for string values.
@@ -995,7 +1036,7 @@ class JsonArray extends JsonSchema {
   factory JsonArray.fromJson(Map<String, dynamic> json) {
     return JsonArray._(
       items: json['items'] != null
-          ? JsonSchema.fromJson(json['items'] as Map<String, dynamic>)
+          ? JsonSchema._fromJsonValue(json['items'], 'JsonArray.items')
           : null,
       minItems: _readOptionalInteger(
         json['minItems'],
@@ -1019,6 +1060,8 @@ class JsonArray extends JsonSchema {
     final serializedItems = itemSchema == null
         ? null
         : switch (itemSchema) {
+            final JsonSchema schema when schema._rawBooleanSubschema != null =>
+              schema._rawBooleanSubschema,
             final JsonEnum enumItems => enumItems._toJson(
                 titledStringConstListKeyword: 'anyOf',
               ),
@@ -1086,15 +1129,18 @@ class JsonObject extends JsonSchema {
     if (additionalProps is bool) {
       parsedAdditionalProps = additionalProps;
     } else if (additionalProps is Map) {
-      parsedAdditionalProps = JsonSchema.fromJson(
-        Map<String, dynamic>.from(additionalProps),
+      parsedAdditionalProps = JsonSchema._fromJsonValue(
+        additionalProps,
+        'JsonObject.additionalProperties',
       );
     }
 
     return JsonObject._(
       properties: (json['properties'] as Map<String, dynamic>?)?.map(
-        (key, value) =>
-            MapEntry(key, JsonSchema.fromJson(value as Map<String, dynamic>)),
+        (key, value) => MapEntry(
+          key,
+          JsonSchema._fromJsonValue(value, 'JsonObject.properties.$key'),
+        ),
       ),
       required: (json['required'] as List?)?.cast<String>(),
       additionalProperties: parsedAdditionalProps,
@@ -1116,11 +1162,12 @@ class JsonObject extends JsonSchema {
       if (_hasDefault) 'default': defaultValue,
       'type': 'object',
       if (properties != null)
-        'properties': properties!.map((k, v) => MapEntry(k, v.toJson())),
+        'properties':
+            properties!.map((k, v) => MapEntry(k, _jsonSchemaValue(v))),
       if (required != null && required!.isNotEmpty) 'required': required,
       if (additionalProperties != null)
         'additionalProperties': additionalProperties is JsonSchema
-            ? (additionalProperties as JsonSchema).toJson()
+            ? _jsonSchemaValue(additionalProperties as JsonSchema)
             : additionalProperties,
       if (dependentRequired != null) 'dependentRequired': dependentRequired,
       ...?extra,
@@ -1166,6 +1213,12 @@ class JsonAny extends JsonSchema {
     required bool hasDefault,
   })  : _hasDefault = hasDefault,
         super(title: title, description: description);
+
+  const JsonAny._booleanSubschema()
+      : properties = const {},
+        _hasDefault = false,
+        defaultValue = null,
+        super(rawBooleanSubschema: true);
 
   @override
   final dynamic defaultValue;
@@ -1307,7 +1360,7 @@ class JsonUnion extends JsonSchema {
       if (typeNames != null)
         'type': typeNames
       else
-        'anyOf': schemas.map((schema) => schema.toJson()).toList(),
+        'anyOf': schemas.map(_jsonSchemaValue).toList(),
     };
   }
 
@@ -1403,7 +1456,7 @@ class JsonAllOf extends JsonSchema {
   factory JsonAllOf.fromJson(Map<String, dynamic> json) {
     return JsonAllOf._(
       (json['allOf'] as List)
-          .map((e) => JsonSchema.fromJson(e as Map<String, dynamic>))
+          .map((e) => JsonSchema._fromJsonValue(e, 'JsonAllOf.allOf'))
           .toList(),
       title: json['title'] as String?,
       description: json['description'] as String?,
@@ -1418,7 +1471,7 @@ class JsonAllOf extends JsonSchema {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
       if (_hasDefault) 'default': defaultValue,
-      'allOf': schemas.map((s) => s.toJson()).toList(),
+      'allOf': schemas.map(_jsonSchemaValue).toList(),
     };
   }
 }
@@ -1449,7 +1502,7 @@ class JsonAnyOf extends JsonSchema {
   factory JsonAnyOf.fromJson(Map<String, dynamic> json) {
     return JsonAnyOf._(
       (json['anyOf'] as List)
-          .map((e) => JsonSchema.fromJson(e as Map<String, dynamic>))
+          .map((e) => JsonSchema._fromJsonValue(e, 'JsonAnyOf.anyOf'))
           .toList(),
       title: json['title'] as String?,
       description: json['description'] as String?,
@@ -1464,7 +1517,7 @@ class JsonAnyOf extends JsonSchema {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
       if (_hasDefault) 'default': defaultValue,
-      'anyOf': schemas.map((s) => s.toJson()).toList(),
+      'anyOf': schemas.map(_jsonSchemaValue).toList(),
     };
   }
 }
@@ -1495,7 +1548,7 @@ class JsonOneOf extends JsonSchema {
   factory JsonOneOf.fromJson(Map<String, dynamic> json) {
     return JsonOneOf._(
       (json['oneOf'] as List)
-          .map((e) => JsonSchema.fromJson(e as Map<String, dynamic>))
+          .map((e) => JsonSchema._fromJsonValue(e, 'JsonOneOf.oneOf'))
           .toList(),
       title: json['title'] as String?,
       description: json['description'] as String?,
@@ -1510,7 +1563,7 @@ class JsonOneOf extends JsonSchema {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
       if (_hasDefault) 'default': defaultValue,
-      'oneOf': schemas.map((s) => s.toJson()).toList(),
+      'oneOf': schemas.map(_jsonSchemaValue).toList(),
     };
   }
 }
@@ -1535,12 +1588,18 @@ class JsonNot extends JsonSchema {
     required bool hasDefault,
   }) : _hasDefault = hasDefault;
 
+  const JsonNot._never()
+      : schema = const JsonAny(),
+        defaultValue = null,
+        _hasDefault = false,
+        super(rawBooleanSubschema: false);
+
   @override
   final dynamic defaultValue;
 
   factory JsonNot.fromJson(Map<String, dynamic> json) {
     return JsonNot._(
-      JsonSchema.fromJson(json['not'] as Map<String, dynamic>),
+      JsonSchema._fromJsonValue(json['not'], 'JsonNot.not'),
       title: json['title'] as String?,
       description: json['description'] as String?,
       defaultValue: json['default'],
@@ -1554,7 +1613,7 @@ class JsonNot extends JsonSchema {
       if (title != null) 'title': title,
       if (description != null) 'description': description,
       if (_hasDefault) 'default': defaultValue,
-      'not': schema.toJson(),
+      'not': _jsonSchemaValue(schema),
     };
   }
 }

--- a/lib/src/shared/json_schema/json_schema_validator.dart
+++ b/lib/src/shared/json_schema/json_schema_validator.dart
@@ -550,24 +550,17 @@ extension JsonSchemaValidation on JsonSchema {
   ) {
     final allOf = keywords['allOf'];
     if (keywords.containsKey('allOf')) {
-      for (final entry in _compositionSchemaList('allOf', allOf, path)) {
-        _validate(
-          JsonSchema.fromJson(entry),
-          data,
-          path,
-        );
+      for (final schema in _compositionSchemaList('allOf', allOf, path)) {
+        _validate(schema, data, path);
       }
     }
 
     final anyOf = keywords['anyOf'];
     if (keywords.containsKey('anyOf')) {
-      final matches = _compositionSchemaList('anyOf', anyOf, path).any((entry) {
+      final matches =
+          _compositionSchemaList('anyOf', anyOf, path).any((schema) {
         try {
-          _validate(
-            JsonSchema.fromJson(entry),
-            data,
-            path,
-          );
+          _validate(schema, data, path);
           return true;
         } on JsonSchemaValidationException {
           return false;
@@ -584,13 +577,9 @@ extension JsonSchemaValidation on JsonSchema {
     final oneOf = keywords['oneOf'];
     if (keywords.containsKey('oneOf')) {
       final matches =
-          _compositionSchemaList('oneOf', oneOf, path).where((entry) {
+          _compositionSchemaList('oneOf', oneOf, path).where((schema) {
         try {
-          _validate(
-            JsonSchema.fromJson(entry),
-            data,
-            path,
-          );
+          _validate(schema, data, path);
           return true;
         } on JsonSchemaValidationException {
           return false;
@@ -606,18 +595,17 @@ extension JsonSchemaValidation on JsonSchema {
 
     final not = keywords['not'];
     if (keywords.containsKey('not')) {
-      if (not is! Map) {
+      final JsonSchema notSchema;
+      try {
+        notSchema = JsonSchema.fromJsonValue(not);
+      } on FormatException {
         throw JsonSchemaValidationException(
-          'not must be a schema object',
+          'not must be a schema object or boolean',
           path,
         );
       }
       try {
-        _validate(
-          JsonSchema.fromJson(Map<String, dynamic>.from(not)),
-          data,
-          path,
-        );
+        _validate(notSchema, data, path);
       } on JsonSchemaValidationException {
         return;
       }
@@ -625,7 +613,7 @@ extension JsonSchemaValidation on JsonSchema {
     }
   }
 
-  List<Map<String, dynamic>> _compositionSchemaList(
+  List<JsonSchema> _compositionSchemaList(
     String keyword,
     dynamic value,
     List<String> path,
@@ -634,13 +622,14 @@ extension JsonSchemaValidation on JsonSchema {
       throw JsonSchemaValidationException('$keyword must be a list', path);
     }
     return value.map((entry) {
-      if (entry is! Map) {
+      try {
+        return JsonSchema.fromJsonValue(entry);
+      } on FormatException {
         throw JsonSchemaValidationException(
-          '$keyword entries must be schema objects',
+          '$keyword entries must be schema objects or booleans',
           path,
         );
       }
-      return Map<String, dynamic>.from(entry);
     }).toList();
   }
 

--- a/test/server/mcp_server_test.dart
+++ b/test/server/mcp_server_test.dart
@@ -132,6 +132,43 @@ void main() {
       expect(tools.first['name'], equals('test-tool'));
     });
 
+    test('legacy tool schema shims preserve boolean subschemas', () async {
+      server.tool(
+        'legacy-boolean-schema-tool',
+        inputSchemaProperties: {
+          'allowed': true,
+          'denied': false,
+          'named': {'type': 'string'},
+        },
+        outputSchemaProperties: {
+          'allowed': true,
+          'denied': false,
+        },
+        callback: ({args, extra}) async => const CallToolResult(content: []),
+      );
+
+      await server.connect(transport);
+
+      transport.receiveMessage(const JsonRpcListToolsRequest(id: 1));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final response = transport.sentMessages.last as JsonRpcResponse;
+      final tools = response.result['tools'] as List;
+      final tool = tools.single as Map;
+      final inputSchema = tool['inputSchema'] as Map;
+      final outputSchema = tool['outputSchema'] as Map;
+
+      expect(inputSchema['properties'], {
+        'allowed': true,
+        'denied': false,
+        'named': {'type': 'string'},
+      });
+      expect(outputSchema['properties'], {
+        'allowed': true,
+        'denied': false,
+      });
+    });
+
     test('connect syncs tool parameter header mappings to transports',
         () async {
       server = McpServer(

--- a/test/shared/json_schema_from_json_test.dart
+++ b/test/shared/json_schema_from_json_test.dart
@@ -239,6 +239,31 @@ void main() {
       expect(schema, isA<JsonBoolean>());
     });
 
+    test('round trips boolean schema values', () {
+      expect(JsonSchema.fromJsonValue(true).toJsonValue(), true);
+      expect(JsonSchema.fromJsonValue(false).toJsonValue(), false);
+    });
+
+    test('parses object properties with boolean subschemas', () {
+      final json = {
+        'type': 'object',
+        'properties': {
+          'allowed': true,
+          'denied': false,
+          'named': {'type': 'string'},
+        },
+      };
+
+      final schema = JsonSchema.fromJson(json);
+
+      expect(schema, isA<JsonObject>());
+      final object = schema as JsonObject;
+      expect(object.properties!['allowed'], isA<JsonAny>());
+      expect(object.properties!['denied'], isA<JsonNot>());
+      expect(object.properties!['named'], isA<JsonString>());
+      expect(object.toJson(), json);
+    });
+
     test('parses null schema', () {
       final json = {'type': 'null'};
       final schema = JsonSchema.fromJson(json);
@@ -286,6 +311,18 @@ void main() {
         }),
         throwsA(isA<FormatException>()),
       );
+    });
+
+    test('parses array items with boolean subschemas', () {
+      for (final json in [
+        {'type': 'array', 'items': true},
+        {'type': 'array', 'items': false},
+      ]) {
+        final schema = JsonSchema.fromJson(json);
+
+        expect(schema, isA<JsonArray>());
+        expect(schema.toJson(), json);
+      }
     });
 
     test('parses object schema', () {
@@ -421,6 +458,32 @@ void main() {
       expect(s.schemas[1].toJson(), {'minLength': 5});
     });
 
+    test('parses composition keywords with boolean subschemas', () {
+      final schemas = [
+        {
+          'allOf': [
+            true,
+            {'type': 'string'},
+          ],
+        },
+        {
+          'anyOf': [
+            false,
+            {'type': 'integer'},
+          ],
+        },
+        {
+          'oneOf': [true, false],
+        },
+        {'not': false},
+        {'not': true},
+      ];
+
+      for (final json in schemas) {
+        expect(JsonSchema.fromJson(json).toJson(), json);
+      }
+    });
+
     test('parses anyOf schema', () {
       final json = {
         'anyOf': [
@@ -502,6 +565,30 @@ void main() {
       expect(parsed.toJson(), json);
     });
 
+    test('nested boolean subschemas round trip', () {
+      final schemas = [
+        {
+          'type': 'object',
+          'properties': {
+            'allowed': true,
+            'denied': false,
+          },
+        },
+        {'type': 'array', 'items': false},
+        {
+          'allOf': [
+            true,
+            {'type': 'string'},
+          ],
+        },
+        {'not': true},
+      ];
+
+      for (final json in schemas) {
+        expect(JsonSchema.fromJson(json).toJson(), json);
+      }
+    });
+
     test('const round trip', () {
       final original = JsonSchema.constValue('DELETE');
       final json = original.toJson();
@@ -516,6 +603,20 @@ void main() {
       ]);
       final json = original.toJson();
       final parsed = JsonSchema.fromJson(json);
+      expect(parsed.toJson(), json);
+    });
+
+    test('union with boolean subschema branches round trip', () {
+      final original = JsonSchema.union([
+        JsonSchema.fromJsonValue(true),
+        JsonSchema.fromJsonValue(false),
+      ]);
+      final json = original.toJson();
+      final parsed = JsonSchema.fromJson(json);
+
+      expect(json, {
+        'anyOf': [true, false],
+      });
       expect(parsed.toJson(), json);
     });
 

--- a/test/shared/json_schema_validator_test.dart
+++ b/test/shared/json_schema_validator_test.dart
@@ -277,6 +277,24 @@ void main() {
         );
       });
 
+      test('validates array items with boolean subschemas', () {
+        final alwaysValid = JsonSchema.fromJson({
+          'type': 'array',
+          'items': true,
+        });
+        alwaysValid.validate([1, 'two', null]);
+
+        final alwaysInvalid = JsonSchema.fromJson({
+          'type': 'array',
+          'items': false,
+        });
+        alwaysInvalid.validate([]);
+        expect(
+          () => alwaysInvalid.validate([1]),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+      });
+
       test('uniqueItems works with objects', () {
         final schema = JsonSchema.array(uniqueItems: true);
         schema.validate([
@@ -402,6 +420,24 @@ void main() {
           "baz": 123,
           "nested": {"a": true},
         });
+      });
+
+      test('validates object properties with boolean subschemas', () {
+        final schema = JsonSchema.fromJson({
+          'type': 'object',
+          'properties': {
+            'allowed': true,
+            'denied': false,
+          },
+        });
+
+        schema.validate({'allowed': 'anything'});
+        schema.validate({'allowed': null});
+
+        expect(
+          () => schema.validate({'denied': 'anything'}),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
       });
     });
 
@@ -623,6 +659,47 @@ void main() {
         schema.validate(true);
         expect(
           () => schema.validate("string"),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+      });
+
+      test('validates composition keywords with boolean subschemas', () {
+        final allOfTrue = JsonSchema.fromJson({
+          'allOf': [
+            true,
+            {'type': 'string'},
+          ],
+        });
+        allOfTrue.validate('value');
+        expect(
+          () => allOfTrue.validate(1),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+
+        final anyOfFalse = JsonSchema.fromJson({
+          'anyOf': [
+            false,
+            {'type': 'integer'},
+          ],
+        });
+        anyOfFalse.validate(1);
+        expect(
+          () => anyOfFalse.validate('value'),
+          throwsA(isA<JsonSchemaValidationException>()),
+        );
+
+        final oneOfTrueFalse = JsonSchema.fromJson({
+          'oneOf': [true, false],
+        });
+        oneOfTrueFalse.validate('value');
+        oneOfTrueFalse.validate(null);
+
+        final notFalse = JsonSchema.fromJson({'not': false});
+        notFalse.validate('value');
+
+        final notTrue = JsonSchema.fromJson({'not': true});
+        expect(
+          () => notTrue.validate('value'),
           throwsA(isA<JsonSchemaValidationException>()),
         );
       });

--- a/test/tool_schema_test.dart
+++ b/test/tool_schema_test.dart
@@ -366,6 +366,31 @@ void main() {
       );
     });
 
+    test('Tool preserves boolean subschema properties end-to-end', () {
+      final json = {
+        'name': 'boolean-subschemas',
+        'inputSchema': {
+          'type': 'object',
+          'properties': {
+            'allowed': true,
+            'denied': false,
+          },
+        },
+      };
+
+      final tool = Tool.fromJson(json);
+
+      expect(tool.toJson(), json);
+      expect(
+        ListToolsResult.fromJson({
+          'tools': [json],
+        }).toJson(),
+        {
+          'tools': [json],
+        },
+      );
+    });
+
     test('Real-world MCP server tool schema example', () {
       // Example from a real MCP server like Hugging Face
       final serverResponse = {


### PR DESCRIPTION
## Summary

- accept JSON Schema 2020-12 boolean subschemas in nested schema positions on the dev branch
- preserve raw `true`/`false` schema values when parsed from wire JSON
- validate boolean subschema semantics so `true` accepts any value and `false` rejects every value
- keep deprecated tool schema-property shims consistent with the boolean-subschema parser
- add focused parser, validator, server, and tool schema regression coverage
- document the spec-hardening fix in the dev changelog

## Root cause

The dev branch still assumed nested JSON Schema values were objects in several subschema positions. JSON Schema 2020-12 also allows boolean schemas anywhere a subschema is expected, so valid peer tool schemas could be rejected or normalized incorrectly.

## Compatibility

This is additive for SDK consumers: existing object-form schemas still serialize the same way, and the existing `toJson()` object API remains unchanged. The new boolean-preserving path is used for parsed wire schemas and nested subschema serialization. Deprecated schema-property shims now accept the same boolean subschema values they could previously receive dynamically, instead of failing at runtime.

## Validation

- `dart format .`
- `dart analyze`
- `dart test`
- `dart test test/server/mcp_server_test.dart test/shared/json_schema_from_json_test.dart test/shared/json_schema_validator_test.dart test/tool_schema_test.dart`
- `git diff --check origin/dev/2026-07-28-rc..HEAD`
- `dart run test/conformance/run_2025_server_conformance.dart --scenario json-schema-2020-12 --output-dir .dart_tool/conformance/json_schema_dev_2025_server --timeout-seconds 90`
