### PR TITLE
Update conformance alpha4 baseline

### DIFF
--- a/.github/workflows/test_core.yml
+++ b/.github/workflows/test_core.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run official MCP 2025 client conformance
         run: >
-          npx -y @modelcontextprotocol/conformance@0.2.0-alpha.3 client
+          npx -y @modelcontextprotocol/conformance@0.2.0-alpha.4 client
           --command "dart run test/conformance/mcp_2026_rc_client.dart"
           --suite all
           --spec-version 2025-11-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ### Conformance and release readiness
 
 - Updated official conformance gates to
-  `@modelcontextprotocol/conformance@0.2.0-alpha.3`, with 2026 RC runs pinned
-  to `2026-07-28`, the full 2026 server scenario list covered in CI, and the
-  current upstream client fixture gap tracked as an
-  expected failure.
+  `@modelcontextprotocol/conformance@0.2.0-alpha.4`, with 2026 RC runs pinned
+  to `2026-07-28`, the full 2026 server scenario list covered in CI, the 2026
+  client wrapper aligned with alpha.4's spec-filtered scenario list, and the
+  current upstream client fixture gap tracked as an expected failure.
 - Removed the legacy `DRAFT-2026-v1` draft alias now that official conformance
   targets the `2026-07-28` wire version.
 

--- a/test/conformance/2026_rc_client_expected_failures.txt
+++ b/test/conformance/2026_rc_client_expected_failures.txt
@@ -1,10 +1,10 @@
-# Expected failures for @modelcontextprotocol/conformance@0.2.0-alpha.3
+# Expected failures for @modelcontextprotocol/conformance@0.2.0-alpha.4
 # against the 2026 RC/DRAFT client suite.
 #
 # Keep this list scenario-based so the baseline is easy to review. When a
 # scenario turns green, remove it from this file in the same PR as the fix.
 #
-# Upstream alpha.3 fixture gap: this scenario's mock server rejects
+# Upstream alpha.4 fixture gap: this scenario's mock server still rejects
 # 2026-07-28 with HTTP 400 and advertises only stable protocol versions.
 # Keep it expected-fail until the conformance fixture is draft-capable.
 json-schema-ref-no-deref

--- a/test/conformance/2026_rc_expected_failures.txt
+++ b/test/conformance/2026_rc_expected_failures.txt
@@ -1,4 +1,4 @@
-# Expected failures for @modelcontextprotocol/conformance@0.2.0-alpha.3
+# Expected failures for @modelcontextprotocol/conformance@0.2.0-alpha.4
 # against the full 2026-07-28 RC/DRAFT server suite.
 #
 # Keep this list scenario-based so the baseline is easy to review. When a

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -26,14 +26,14 @@ dart run test/conformance/run_2025_server_conformance.dart
 ```
 
 The runner starts `mcp_2025_server.dart`, runs
-`@modelcontextprotocol/conformance@0.2.0-alpha.3 server --suite all
+`@modelcontextprotocol/conformance@0.2.0-alpha.4 server --suite all
 --spec-version 2025-11-25`, and writes artifacts under
 `.dart_tool/conformance/2025_server/`.
 
 Run the stable client suite from the repository root:
 
 ```bash
-npx -y @modelcontextprotocol/conformance@0.2.0-alpha.3 client \
+npx -y @modelcontextprotocol/conformance@0.2.0-alpha.4 client \
   --command "dart run test/conformance/mcp_2026_rc_client.dart" \
   --suite all \
   --spec-version 2025-11-25 \
@@ -55,7 +55,7 @@ dart run test/conformance/run_2026_rc_server_conformance.dart
 
 The runner starts a local `StreamableMcpServer` in default Streamable HTTP SSE
 response mode, runs the full `2026-07-28` server scenario list from
-`@modelcontextprotocol/conformance@0.2.0-alpha.3` one by one with `--suite all`
+`@modelcontextprotocol/conformance@0.2.0-alpha.4` one by one with `--suite all`
 and `--spec-version 2026-07-28`, and writes per-run artifacts under
 `.dart_tool/conformance/2026_rc/`.
 
@@ -73,3 +73,6 @@ package's scenario servers and writes per-run artifacts under
 `.dart_tool/conformance/2026_rc_client/`.
 
 Client expected failures live in `2026_rc_client_expected_failures.txt`.
+The 2026 client wrapper is aligned with the scenarios returned by
+`conformance list --client --spec-version 2026-07-28`; stable-only client
+scenarios remain covered by the stable `2025-11-25` client suite above.

--- a/test/conformance/run_2025_server_conformance.dart
+++ b/test/conformance/run_2025_server_conformance.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 const _defaultConformancePackage =
-    '@modelcontextprotocol/conformance@0.2.0-alpha.3';
+    '@modelcontextprotocol/conformance@0.2.0-alpha.4';
 const _defaultTimeout = Duration(seconds: 60);
 
 Future<void> main(List<String> args) async {

--- a/test/conformance/run_2026_rc_client_conformance.dart
+++ b/test/conformance/run_2026_rc_client_conformance.dart
@@ -3,14 +3,11 @@ import 'dart:convert';
 import 'dart:io';
 
 const _defaultConformancePackage =
-    '@modelcontextprotocol/conformance@0.2.0-alpha.3';
+    '@modelcontextprotocol/conformance@0.2.0-alpha.4';
 const _defaultTimeout = Duration(seconds: 30);
 
 const _draftClientScenarios = [
-  'initialize',
   'tools_call',
-  'elicitation-sep1034-client-defaults',
-  'sse-retry',
   'request-metadata',
   'auth/metadata-default',
   'auth/metadata-var1',

--- a/test/conformance/run_2026_rc_server_conformance.dart
+++ b/test/conformance/run_2026_rc_server_conformance.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 const _defaultConformancePackage =
-    '@modelcontextprotocol/conformance@0.2.0-alpha.3';
+    '@modelcontextprotocol/conformance@0.2.0-alpha.4';
 const _defaultTimeout = Duration(seconds: 25);
 
 const _serverScenarios = [


### PR DESCRIPTION
## Summary
- Bump official conformance references from 0.2.0-alpha.3 to 0.2.0-alpha.4.
- Align the 2026 RC client wrapper with alpha.4's spec-filtered client scenario list.
- Keep json-schema-ref-no-deref as the only expected 2026 RC client failure; alpha.4 still rejects 2026-07-28 in that mock server before the ref-preservation check can run.

## Verification
- dart format test/conformance/run_2026_rc_client_conformance.dart test/conformance/run_2025_server_conformance.dart test/conformance/run_2026_rc_server_conformance.dart
- dart analyze lib test/conformance
- dart run test/conformance/run_2026_rc_server_conformance.dart --timeout-seconds 90 --output-dir .dart_tool/conformance/alpha4_2026_server
- dart run test/conformance/run_2026_rc_client_conformance.dart --timeout-seconds 90 --output-dir .dart_tool/conformance/alpha4_2026_client
- dart run test/conformance/run_2025_server_conformance.dart --timeout-seconds 120 --output-dir .dart_tool/conformance/alpha4_2025_server
- npx -y @modelcontextprotocol/conformance@0.2.0-alpha.4 client --command "dart run test/conformance/mcp_2026_rc_client.dart" --suite all --spec-version 2025-11-25 --verbose -o .dart_tool/conformance/alpha4_2025_client
- dart test

Note: a full repo dart analyze still reports pre-existing nested example/package context issues when run from the root; targeted analysis over lib and test/conformance passes.