### PR TITLE
Expand TS 2026 RC interop critical paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,22 @@
 
 ### Conformance and release readiness
 
-- Added a manual TypeScript SDK 2026 RC interop fixture pinned to the upstream
-  PR #2327 preview package, covering modern negotiation, `tools/list`, and
-  `tools/call` against the Dart 2026 RC conformance server.
+- Expanded the manual TypeScript SDK 2026 RC interop fixture pinned to the
+  upstream PR #2327 preview package, covering modern negotiation,
+  `server/discover` cache metadata, `tools/list`, `tools/call`,
+  `x-mcp-header` mirroring, progress notifications, raw HTTP header,
+  unsupported-version, and removed core RPC rejection, `subscriptions/listen`,
+  and Streamable HTTP SSE cancellation against the Dart 2026 RC conformance
+  server.
+- Added a diagnostic Dart preview client -> TypeScript server alpha path and
+  documented the current TS alpha gaps around mandatory `server/discover` and
+  stateless `resultType` responses.
+- Aligned 2026 draft protocol-defined error codes with the live draft:
+  `HeaderMismatch` is now `-32020`,
+  `MissingRequiredClientCapability` is now `-32021`, and
+  `UnsupportedProtocolVersion` is now `-32022`. The conformance alpha.4 server
+  scenarios that still expect the old `HeaderMismatch` code are tracked as
+  expected failures.
 - Marked `server/discover` as a 2026 cacheable result so stateless responses
   include default `ttlMs` and `cacheScope` hints.
 - Updated official conformance gates to

--- a/doc/interoperability.md
+++ b/doc/interoperability.md
@@ -21,7 +21,8 @@ For requirement-level MCP 2025-11-25 coverage, see the
 | Dart client -> TypeScript SDK server | Streamable HTTP | `2025-11-25` | [`test/interop/dart_client_with_ts_server_test.dart`](../test/interop/dart_client_with_ts_server_test.dart), [`test/interop/ts/`](../test/interop/ts/) | Verified | Covers tool calls and stale preconfigured session-id recovery. |
 | TypeScript SDK client -> Dart server | stdio | `2025-11-25` | [`test/interop/ts_client_with_dart_server_test.dart`](../test/interop/ts_client_with_dart_server_test.dart), [`test/interop/test_dart_server.dart`](../test/interop/test_dart_server.dart) | Verified | Runs the compiled TypeScript client fixture against a Dart server process and checks that an official TS client can list tools immediately after the lifecycle handshake. |
 | TypeScript SDK client -> Dart server | Streamable HTTP | `2025-11-25` | [`test/interop/ts_client_with_dart_server_test.dart`](../test/interop/ts_client_with_dart_server_test.dart), [`test/interop/test_dart_server.dart`](../test/interop/test_dart_server.dart) | Verified | Includes official TS Streamable HTTP client lifecycle coverage, pre-`initialized` operation rejection, GET SSE streams, and `Last-Event-ID` replay behavior. |
-| TypeScript SDK preview client -> Dart server | Streamable HTTP | `2026-07-28` draft/RC | [`test/interop/ts_2026_rc/`](../test/interop/ts_2026_rc/), [`tool/testing/run_ts_2026_rc_interop.dart`](../tool/testing/run_ts_2026_rc_interop.dart) | Experimental manual check | Uses a pinned `pkg.pr.new` preview from TypeScript SDK PR #2327 because published TS packages do not yet advertise `2026-07-28`. Covers modern negotiation, `tools/list`, and `tools/call` against the Dart 2026 RC conformance server. Not a CI gate yet. |
+| TypeScript SDK preview client -> Dart server | Streamable HTTP | `2026-07-28` draft/RC | [`test/interop/ts_2026_rc/`](../test/interop/ts_2026_rc/), [`tool/testing/run_ts_2026_rc_interop.dart`](../tool/testing/run_ts_2026_rc_interop.dart) | Experimental manual check | Uses a pinned `pkg.pr.new` preview from TypeScript SDK PR #2327. Covers modern negotiation, cache metadata, `tools/list`, `tools/call`, `x-mcp-header` mirroring, raw header and unsupported-version rejection, removed core RPC rejection, progress notifications, `subscriptions/listen`, and HTTP SSE cancellation against the Dart 2026 RC conformance server. Not a CI gate yet. |
+| Dart preview client -> TypeScript SDK alpha server | Streamable HTTP | `2026-07-28` draft/RC | [`test/interop/ts_2026_rc/src/server.mjs`](../test/interop/ts_2026_rc/src/server.mjs), [`tool/testing/run_ts_2026_rc_interop.dart`](../tool/testing/run_ts_2026_rc_interop.dart) | Diagnostic only | The fixture attempts the reverse path, but the current TS server alpha does not yet answer mandatory `server/discover` and omits `resultType` on stateless `tools/list`; the runner reports this as a TS-alpha gap instead of a Dart failure. |
 | Dart client -> Python MCP server | stdio | Server-dependent | [`doc/transports.md`](transports.md#connect-to-python-server) | Documented recipe | The transport can spawn Python servers over stdio, but this repo does not yet include an automated Python SDK fixture. |
 | Flutter/Web client -> Dart server | Streamable HTTP | `2025-11-25` | [`example/flutter_http_client/`](../example/flutter_http_client/), [`doc/flutter-recipes.md`](flutter-recipes.md) | Documented recipe | Flutter Web cannot spawn stdio servers; use Streamable HTTP or another browser-safe transport. |
 | MCP Apps host/client metadata | stdio or Streamable HTTP | `2025-11-25` plus `io.modelcontextprotocol/ui` extension | [`doc/mcp-apps.md`](mcp-apps.md), [`example/mcp_apps_helpers_server.dart`](../example/mcp_apps_helpers_server.dart), [`test/types/mcp_ui_test.dart`](../test/types/mcp_ui_test.dart), [`test/server/mcp_ui_test.dart`](../test/server/mcp_ui_test.dart) | Verified | Verified coverage is limited to SDK metadata helpers, serialization, and checked-in examples; host rendering behavior varies by host, so verify UI metadata against your target host. |
@@ -54,8 +55,9 @@ cd ../../..
 dart run tool/testing/run_ts_2026_rc_interop.dart
 ```
 
-This starts the Dart 2026 RC conformance server and runs the pinned TypeScript
-SDK preview client against it.
+This starts the Dart 2026 RC conformance server, runs the pinned TypeScript SDK
+preview client against it, then attempts the reverse Dart-client diagnostic
+against the TypeScript server alpha and reports known TS-alpha spec gaps.
 
 The CLI spec conformance gate covers raw-wire negative cases that do not need a
 cross-SDK fixture, including stable MCP 2025-11-25 checks and MCP 2026-07-28 RC
@@ -81,7 +83,8 @@ When adding a new interoperability claim:
 
 - Automated Python SDK fixture coverage.
 - CI promotion for the TypeScript 2026 RC interop fixture after the TypeScript
-  SDK publishes a 2026-compatible alpha package.
+  SDK publishes a 2026-compatible alpha package whose server answers
+  `server/discover` and includes `resultType` on stateless results.
 - Host-specific MCP Apps rendering compatibility notes.
 - More OAuth-protected remote server scenarios beyond the checked-in examples.
 - A broader compatibility table once additional SDKs expose stable 2025-11-25 fixtures.

--- a/lib/src/types/json_rpc.dart
+++ b/lib/src/types/json_rpc.dart
@@ -695,19 +695,16 @@ enum ErrorCode {
   requestTimeout(-32001),
 
   /// HTTP request metadata headers do not match the JSON-RPC body.
-  ///
-  /// This is the MCP 2026-07-28 meaning of the shared -32001 server-error
-  /// code. [requestTimeout] is retained for older SDK behavior.
-  headerMismatch(-32001),
+  headerMismatch(-32020),
 
   /// Resource not found in stable MCP 2025-11-25.
   resourceNotFound(-32002),
 
   /// Required per-request client capabilities were not declared.
-  missingRequiredClientCapability(-32003),
+  missingRequiredClientCapability(-32021),
 
   /// The requested protocol version is unsupported by the receiver.
-  unsupportedProtocolVersion(-32004),
+  unsupportedProtocolVersion(-32022),
 
   /// URL mode elicitation is required before the request can be processed.
   /// The error data contains elicitations that must be completed.

--- a/packages/mcp_dart_cli/lib/src/conformance_runner.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_runner.dart
@@ -24,8 +24,9 @@ const String _methodTasksGet = 'tasks/get';
 const String _methodTasksUpdate = 'tasks/update';
 const String _methodSubscriptionsListen = 'subscriptions/listen';
 const String _methodNotificationsTasksStatus = 'notifications/tasks/status';
-const int _headerMismatchCode = -32001;
-const int _unsupportedProtocolVersionCode = -32004;
+final int _headerMismatchCode = ErrorCode.headerMismatch.value;
+final int _unsupportedProtocolVersionCode =
+    ErrorCode.unsupportedProtocolVersion.value;
 
 const List<String> conformanceSuiteNames = <String>[
   _fixtureSuite,

--- a/test/conformance/2026_rc_expected_failures.txt
+++ b/test/conformance/2026_rc_expected_failures.txt
@@ -3,3 +3,8 @@
 #
 # Keep this list scenario-based so the baseline is easy to review. When a
 # scenario turns green, remove it from this file in the same PR as the fix.
+
+# alpha.4 still expects the pre-renumber HeaderMismatch error code -32001.
+# The live 2026-07-28 draft now assigns HeaderMismatch to -32020.
+server-stateless
+http-custom-header-server-validation

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -62,6 +62,12 @@ and `--spec-version 2026-07-28`, and writes per-run artifacts under
 Expected failures live in `2026_rc_expected_failures.txt`. When a scenario is
 fixed, remove it from that file so the baseline remains useful.
 
+As of `@modelcontextprotocol/conformance@0.2.0-alpha.4`, the server expected
+failure file includes scenarios where the conformance package still expects the
+pre-renumber `HeaderMismatch` code `-32001`. The live `2026-07-28` draft assigns
+`HeaderMismatch` to `-32020`, so the SDK follows the draft and keeps those
+alpha.4 scenarios expected until the conformance package catches up.
+
 Run the current client baseline from the repository root:
 
 ```bash

--- a/test/conformance/mcp_2026_rc_server.dart
+++ b/test/conformance/mcp_2026_rc_server.dart
@@ -6,6 +6,8 @@ import 'package:mcp_dart/mcp_dart.dart';
 import '../interop/test_dart_server.dart' as interop;
 import 'mcp_2025_server.dart' as stable_conformance;
 
+int _streamCancellationCount = 0;
+
 /// Dedicated HTTP server fixture for the MCP 2026 RC conformance package.
 ///
 /// This deliberately starts from the existing cross-SDK interop server and
@@ -66,6 +68,11 @@ McpServer _createConformanceServer() {
     server,
     includeResourceSubscriptions: false,
   );
+  server.server.registerCapabilities(
+    const ServerCapabilities(
+      tools: ServerCapabilitiesTools(listChanged: true),
+    ),
+  );
 
   server.registerTool(
     'a_header_probe',
@@ -97,9 +104,75 @@ McpServer _createConformanceServer() {
     },
   );
 
+  _registerStreamDiagnostics(server);
   _registerInputRequiredDiagnostics(server);
 
   return server;
+}
+
+void _registerStreamDiagnostics(McpServer server) {
+  server.registerTool(
+    'test_stream_cancellation',
+    description: 'Keeps an SSE response open until the HTTP client aborts it',
+    callback: (args, extra) async {
+      final observed = Completer<void>();
+      final abortSub = extra.signal.onAbort.listen((_) {
+        _streamCancellationCount++;
+        if (!observed.isCompleted) {
+          observed.complete();
+        }
+      });
+
+      try {
+        await extra.sendProgress(
+          1,
+          total: 1,
+          message: 'cancellation probe started',
+        );
+        await observed.future.timeout(
+          const Duration(seconds: 10),
+          onTimeout: () {
+            if (!observed.isCompleted) {
+              observed.complete();
+            }
+          },
+        );
+      } finally {
+        await abortSub.cancel();
+      }
+
+      return _textResult(
+        extra.signal.aborted ? 'cancelled' : 'not-cancelled',
+      );
+    },
+  );
+
+  server.registerTool(
+    'test_stream_cancellation_status',
+    description: 'Reports observed HTTP stream cancellation count',
+    callback: (args, extra) async {
+      return _textResult(_streamCancellationCount.toString());
+    },
+  );
+
+  server.server.setRequestHandler<JsonRpcSubscriptionsListenRequest>(
+    Method.subscriptionsListen,
+    (request, extra) async {
+      final acknowledged = request.listenParams.notifications.acknowledgedBy(
+        server.server.getCapabilities(),
+      );
+      await extra.sendSubscriptionAcknowledged(acknowledged);
+      await extra.sendSubscriptionNotification(
+        const JsonRpcToolListChangedNotification(),
+      );
+      return const EmptyResult();
+    },
+    (id, params, meta) => JsonRpcSubscriptionsListenRequest(
+      id: id,
+      listenParams: SubscriptionsListenRequest.fromJson(params!),
+      meta: meta,
+    ),
+  );
 }
 
 void _registerInputRequiredDiagnostics(McpServer server) {

--- a/test/conformance/mcp_2026_rc_server.dart
+++ b/test/conformance/mcp_2026_rc_server.dart
@@ -73,6 +73,30 @@ McpServer _createConformanceServer() {
     callback: (args, extra) async => const CallToolResult(content: []),
   );
 
+  server.registerTool(
+    'test_custom_headers_valid',
+    description: 'Exercises valid 2026 x-mcp-header parameter mirroring',
+    inputSchema: JsonSchema.object(
+      properties: {
+        'region': JsonSchema.string(mcpHeader: 'Region'),
+        'count': JsonSchema.integer(mcpHeader: 'Count'),
+        'dryRun': JsonSchema.boolean(mcpHeader: 'Dry-Run'),
+        'auth': JsonSchema.object(
+          properties: {
+            'tenant': JsonSchema.string(mcpHeader: 'Tenant'),
+          },
+          required: ['tenant'],
+        ),
+      },
+      required: ['region', 'count', 'dryRun', 'auth'],
+    ),
+    callback: (args, extra) async {
+      return const CallToolResult(
+        content: [TextContent(text: 'custom-header-ok')],
+      );
+    },
+  );
+
   _registerInputRequiredDiagnostics(server);
 
   return server;

--- a/test/interop/ts_2026_rc/README.md
+++ b/test/interop/ts_2026_rc/README.md
@@ -5,11 +5,12 @@ This fixture is an experimental smoke test for the unreleased MCP
 progress.
 
 It is intentionally separate from `test/interop/ts`, which tracks the published
-stable TypeScript SDK and MCP `2025-11-25` behavior. The published split
-TypeScript packages still do not advertise `2026-07-28`, so this fixture pins a
-`pkg.pr.new` preview package from TypeScript SDK PR #2327. That PR includes the
-modern Streamable HTTP `Mcp-Name` header support needed to interoperate with the
-Dart 2026 RC server.
+stable TypeScript SDK and MCP `2025-11-25` behavior. The fixture pins a
+`pkg.pr.new` client preview from TypeScript SDK PR #2327 for the modern
+Streamable HTTP `Mcp-Name` header support needed to interoperate with the Dart
+2026 RC server. It also installs `@modelcontextprotocol/server@2.0.0-alpha.2`
+for a reverse-path diagnostic, but the server alpha is not yet a strict 2026
+interoperability gate.
 
 ## Run
 
@@ -36,10 +37,33 @@ bound local URL, and then runs `src/client.mjs` against it. The fixture asserts:
 - `tools/call` can invoke the Dart `echo` tool over modern Streamable HTTP.
 - `tools/call` can complete a 2026 `input_required` elicitation retry flow
   using the TypeScript client's registered `elicitation/create` handler.
+- `notifications/progress` callbacks arrive for a long-running tool call and
+  report monotonic progress from `0` to `100`.
+- Raw Streamable HTTP requests with missing or mismatched
+  `MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`, and `Mcp-Param-*` headers
+  are rejected with the current draft `HeaderMismatch` error code `-32020`.
+- Raw Streamable HTTP requests for removed 2026 core RPCs such as `ping` are
+  rejected with JSON-RPC `Method not found`.
+- Raw Streamable HTTP requests for unsupported protocol versions are rejected
+  with the current draft `UnsupportedProtocolVersion` error code `-32022` and
+  include `requested` and `supported` version data.
+- `subscriptions/listen` returns an acknowledgment before list-change
+  notifications and tags subscription notifications with
+  `io.modelcontextprotocol/subscriptionId`.
+- Closing a 2026 HTTP SSE response stream cancels the in-flight Dart server
+  request without sending `notifications/cancelled`.
+
+The runner also starts `src/server.mjs` and attempts a Dart preview client
+against the TypeScript server alpha. That reverse path is currently diagnostic:
+the fixture shims `server/discover` because the TS server alpha does not answer
+that mandatory 2026 method yet, and the Dart client then reports the current TS
+alpha `tools/list` gap where stateless results omit `resultType`.
 
 Keep this fixture anchored to the official draft/RC behavior rather than the
 preview TypeScript implementation alone. In particular, `x-mcp-header` tests use
 only the draft-permitted primitive types: `string`, `integer`, and `boolean`.
+When TypeScript preview behavior conflicts with the draft, keep the draft as the
+assertion source and document the preview gap near the test.
 
 Keep this as a manual, non-blocking check until the TypeScript SDK publishes a
 stable 2026-compatible alpha package or the upstream PR stack lands on the

--- a/test/interop/ts_2026_rc/README.md
+++ b/test/interop/ts_2026_rc/README.md
@@ -23,13 +23,24 @@ dart run tool/testing/run_ts_2026_rc_interop.dart
 ```
 
 The runner starts `test/conformance/mcp_2026_rc_server.dart`, waits for its
-bound local URL, and then runs `src/client.mjs` against it. The smoke asserts:
+bound local URL, and then runs `src/client.mjs` against it. The fixture asserts:
 
 - TypeScript client negotiation selects the modern `2026-07-28` era.
-- `tools/list` returns the Dart fixture tools.
+- `server/discover` advertises `2026-07-28` and exposes cache metadata through
+  the TypeScript client API.
+- `tools/list` returns the Dart fixture tools with 2026 cache metadata.
+- Valid `x-mcp-header` annotations survive `tools/list` and the TypeScript
+  client mirrors string, integer, boolean, and nested string arguments into
+  `Mcp-Param-*` headers. The Dart server validates those headers against the
+  body before invoking the tool.
 - `tools/call` can invoke the Dart `echo` tool over modern Streamable HTTP.
+- `tools/call` can complete a 2026 `input_required` elicitation retry flow
+  using the TypeScript client's registered `elicitation/create` handler.
+
+Keep this fixture anchored to the official draft/RC behavior rather than the
+preview TypeScript implementation alone. In particular, `x-mcp-header` tests use
+only the draft-permitted primitive types: `string`, `integer`, and `boolean`.
 
 Keep this as a manual, non-blocking check until the TypeScript SDK publishes a
 stable 2026-compatible alpha package or the upstream PR stack lands on the
 `v2-2026-07-28` branch.
-

--- a/test/interop/ts_2026_rc/package-lock.json
+++ b/test/interop/ts_2026_rc/package-lock.json
@@ -8,11 +8,19 @@
       "name": "mcp-dart-ts-2026-rc-interop",
       "version": "0.0.0",
       "dependencies": {
-        "@modelcontextprotocol/client": "https://pkg.pr.new/modelcontextprotocol/typescript-sdk/@modelcontextprotocol/client@87ce6c5"
+        "@cfworker/json-schema": "4.1.1",
+        "@modelcontextprotocol/client": "https://pkg.pr.new/modelcontextprotocol/typescript-sdk/@modelcontextprotocol/client@87ce6c5",
+        "@modelcontextprotocol/server": "2.0.0-alpha.2"
       },
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/client": {
       "version": "2.0.0-alpha.2",
@@ -29,6 +37,26 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-gmLgdHzlYM8L7Aw/+VE0kxjT25WKamtUSLNhdOgrJq5CrESvqVSoAfWSJJeNPUXNTluQ+dYDGFbKVitdsJtbPA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        }
       }
     },
     "node_modules/cross-spawn": {

--- a/test/interop/ts_2026_rc/package.json
+++ b/test/interop/ts_2026_rc/package.json
@@ -8,10 +8,11 @@
     "client": "node src/client.mjs"
   },
   "dependencies": {
-    "@modelcontextprotocol/client": "https://pkg.pr.new/modelcontextprotocol/typescript-sdk/@modelcontextprotocol/client@87ce6c5"
+    "@cfworker/json-schema": "4.1.1",
+    "@modelcontextprotocol/client": "https://pkg.pr.new/modelcontextprotocol/typescript-sdk/@modelcontextprotocol/client@87ce6c5",
+    "@modelcontextprotocol/server": "2.0.0-alpha.2"
   },
   "engines": {
     "node": ">=20"
   }
 }
-

--- a/test/interop/ts_2026_rc/src/client.mjs
+++ b/test/interop/ts_2026_rc/src/client.mjs
@@ -1,11 +1,70 @@
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 
+const PROTOCOL_VERSION = '2026-07-28';
+const CLIENT_INFO = { name: 'mcp-dart-ts-2026-rc-client', version: '0.0.0' };
+
 function readArg(args, name) {
   const index = args.indexOf(name);
   if (index < 0 || index + 1 >= args.length) {
     return undefined;
   }
   return args[index + 1];
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertCacheMetadata(result, method) {
+  assert(
+    Number.isInteger(result.ttlMs) && result.ttlMs >= 0,
+    `${method} expected non-negative integer ttlMs, got ${JSON.stringify(result)}`,
+  );
+  assert(
+    result.cacheScope === 'public' || result.cacheScope === 'private',
+    `${method} expected cacheScope public/private, got ${JSON.stringify(result)}`,
+  );
+}
+
+function requireTool(tools, name) {
+  const tool = tools.find((candidate) => candidate.name === name);
+  assert(
+    tool,
+    `Expected ${name} tool, got ${tools.map((item) => item.name).join(', ')}`,
+  );
+  return tool;
+}
+
+function requireText(result, expected, label) {
+  const content = Array.isArray(result.content) ? result.content : [];
+  const first = content[0];
+  assert(
+    first && first.type === 'text' && first.text === expected,
+    `${label} unexpected result: ${JSON.stringify(result)}`,
+  );
+  return first.text;
+}
+
+function assertCustomHeaderSchema(tool) {
+  const properties = tool.inputSchema?.properties ?? {};
+  assert(
+    properties.region?.['x-mcp-header'] === 'Region',
+    `region x-mcp-header missing from ${tool.name}`,
+  );
+  assert(
+    properties.count?.['x-mcp-header'] === 'Count',
+    `count x-mcp-header missing from ${tool.name}`,
+  );
+  assert(
+    properties.dryRun?.['x-mcp-header'] === 'Dry-Run',
+    `dryRun x-mcp-header missing from ${tool.name}`,
+  );
+  assert(
+    properties.auth?.properties?.tenant?.['x-mcp-header'] === 'Tenant',
+    `nested tenant x-mcp-header missing from ${tool.name}`,
+  );
 }
 
 async function main() {
@@ -15,12 +74,23 @@ async function main() {
   }
 
   const client = new Client(
-    { name: 'mcp-dart-ts-2026-rc-client', version: '0.0.0' },
+    CLIENT_INFO,
     {
-      capabilities: {},
-      versionNegotiation: { mode: { pin: '2026-07-28' } },
+      capabilities: { elicitation: {} },
+      versionNegotiation: { mode: { pin: PROTOCOL_VERSION } },
     },
   );
+  client.setRequestHandler('elicitation/create', async (request) => {
+    assert(
+      request.params?.mode === 'form' || request.params?.mode === undefined,
+      `Expected form elicitation, got ${JSON.stringify(request)}`,
+    );
+    return {
+      action: 'accept',
+      content: { name: 'TypeScript Tester' },
+    };
+  });
+
   const transport = new StreamableHTTPClientTransport(new URL(urlValue));
 
   try {
@@ -28,33 +98,68 @@ async function main() {
 
     const era = client.getProtocolEra();
     const version = client.getNegotiatedProtocolVersion();
-    if (era !== 'modern' || version !== '2026-07-28') {
-      throw new Error(`Expected modern 2026-07-28, got ${era}/${version}`);
-    }
+    assert(
+      era === 'modern' && version === PROTOCOL_VERSION,
+      `Expected modern ${PROTOCOL_VERSION}, got ${era}/${version}`,
+    );
+
+    const discover = await client.discover();
+    assertCacheMetadata(discover, 'server/discover');
+    assert(
+      discover.supportedVersions?.includes(PROTOCOL_VERSION),
+      `server/discover did not advertise ${PROTOCOL_VERSION}: ${JSON.stringify(discover)}`,
+    );
+    assert(
+      discover.serverInfo?.name === 'dart-test-server',
+      `server/discover returned unexpected serverInfo: ${JSON.stringify(discover.serverInfo)}`,
+    );
 
     const tools = await client.listTools();
+    assertCacheMetadata(tools, 'tools/list');
     const toolNames = tools.tools.map((tool) => tool.name);
-    if (!toolNames.includes('echo')) {
-      throw new Error(`Expected echo tool, got ${toolNames.join(', ')}`);
-    }
+    requireTool(tools.tools, 'echo');
+    assertCustomHeaderSchema(
+      requireTool(tools.tools, 'test_custom_headers_valid'),
+    );
+    requireTool(tools.tools, 'test_input_required_result_elicitation');
 
     const message = 'from TypeScript 2026 RC preview';
     const result = await client.callTool({
       name: 'echo',
       arguments: { message },
     });
-    const content = Array.isArray(result.content) ? result.content : [];
-    const first = content[0];
-    if (!first || first.type !== 'text' || first.text !== message) {
-      throw new Error(`Unexpected echo result: ${JSON.stringify(result)}`);
-    }
+    const echo = requireText(result, message, 'echo');
+
+    const customHeaders = await client.callTool({
+      name: 'test_custom_headers_valid',
+      arguments: {
+        region: 'us-east1',
+        count: 42,
+        dryRun: false,
+        auth: { tenant: ' padded ' },
+      },
+    });
+    requireText(customHeaders, 'custom-header-ok', 'custom header mirroring');
+
+    const elicitation = await client.callTool({
+      name: 'test_input_required_result_elicitation',
+      arguments: {},
+    });
+    const elicitationText = requireText(
+      elicitation,
+      'Hello, TypeScript Tester!',
+      'input_required elicitation',
+    );
 
     console.log(
       JSON.stringify({
         protocolEra: era,
         protocolVersion: version,
+        discoveredVersions: discover.supportedVersions,
         toolCount: toolNames.length,
-        echo: first.text,
+        echo,
+        customHeaders: 'ok',
+        inputRequired: elicitationText,
       }),
     );
   } finally {
@@ -66,4 +171,3 @@ main().catch((error) => {
   console.error(error);
   process.exit(1);
 });
-

--- a/test/interop/ts_2026_rc/src/client.mjs
+++ b/test/interop/ts_2026_rc/src/client.mjs
@@ -425,8 +425,8 @@ async function assertProgressNotifications(client) {
   );
   for (let index = 1; index < progressValues.length; index++) {
     assert(
-      progressValues[index] >= progressValues[index - 1],
-      `progress demo values were not monotonic: ${JSON.stringify(progressValues)}`,
+      progressValues[index] > progressValues[index - 1],
+      `progress demo values did not strictly increase: ${JSON.stringify(progressValues)}`,
     );
   }
 }

--- a/test/interop/ts_2026_rc/src/client.mjs
+++ b/test/interop/ts_2026_rc/src/client.mjs
@@ -47,6 +47,390 @@ function requireText(result, expected, label) {
   return first.text;
 }
 
+function firstText(result, label) {
+  const content = Array.isArray(result.content) ? result.content : [];
+  const first = content[0];
+  assert(
+    first && first.type === 'text',
+    `${label} expected text content: ${JSON.stringify(result)}`,
+  );
+  return first.text;
+}
+
+function requestMeta(extra = {}) {
+  return {
+    'io.modelcontextprotocol/protocolVersion': PROTOCOL_VERSION,
+    'io.modelcontextprotocol/clientInfo': CLIENT_INFO,
+    'io.modelcontextprotocol/clientCapabilities': { elicitation: {} },
+    ...extra,
+  };
+}
+
+async function rawRpc(urlValue, {
+  id,
+  method,
+  params = {},
+  headers = {},
+  removeHeaders = [],
+  signal,
+}) {
+  const requestHeaders = new Headers({
+    Accept: 'application/json, text/event-stream',
+    'Content-Type': 'application/json',
+    'MCP-Protocol-Version': PROTOCOL_VERSION,
+    'Mcp-Method': method,
+    ...headers,
+  });
+  for (const header of removeHeaders) {
+    requestHeaders.delete(header);
+  }
+
+  return fetch(urlValue, {
+    method: 'POST',
+    headers: requestHeaders,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id,
+      method,
+      params,
+    }),
+    signal,
+  });
+}
+
+async function readJsonResponse(response, label) {
+  const text = await response.text();
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`${label} returned non-JSON body: ${text}`);
+  }
+}
+
+async function expectHeaderMismatch(response, label) {
+  assert(
+    response.status === 400,
+    `${label} expected HTTP 400, got ${response.status}`,
+  );
+  const body = await readJsonResponse(response, label);
+  assert(
+    body.error?.code === -32020,
+    `${label} expected HeaderMismatch -32020, got ${JSON.stringify(body)}`,
+  );
+}
+
+async function expectUnsupportedProtocolVersion(response, label) {
+  assert(
+    response.status === 400,
+    `${label} expected HTTP 400, got ${response.status}`,
+  );
+  const body = await readJsonResponse(response, label);
+  assert(
+    body.error?.code === -32022,
+    `${label} expected UnsupportedProtocolVersion -32022, got ${JSON.stringify(body)}`,
+  );
+  assert(
+    body.error?.data?.requested === '1900-01-01',
+    `${label} missing requested version in error data: ${JSON.stringify(body)}`,
+  );
+  assert(
+    body.error?.data?.supported?.includes(PROTOCOL_VERSION),
+    `${label} missing supported ${PROTOCOL_VERSION} in error data: ${JSON.stringify(body)}`,
+  );
+}
+
+async function expectMethodNotFound(response, label) {
+  assert(
+    response.status === 404,
+    `${label} expected HTTP 404, got ${response.status}`,
+  );
+  const body = await readJsonResponse(response, label);
+  assert(
+    body.error?.code === -32601,
+    `${label} expected MethodNotFound -32601, got ${JSON.stringify(body)}`,
+  );
+}
+
+async function assertRawHeaderValidation(urlValue) {
+  await expectHeaderMismatch(
+    await rawRpc(urlValue, {
+      id: 'missing-protocol-version-header',
+      method: 'server/discover',
+      params: { _meta: requestMeta() },
+      removeHeaders: ['MCP-Protocol-Version'],
+    }),
+    'missing MCP-Protocol-Version',
+  );
+
+  await expectHeaderMismatch(
+    await rawRpc(urlValue, {
+      id: 'missing-method-header',
+      method: 'server/discover',
+      params: { _meta: requestMeta() },
+      removeHeaders: ['Mcp-Method'],
+    }),
+    'missing Mcp-Method',
+  );
+
+  await expectHeaderMismatch(
+    await rawRpc(urlValue, {
+      id: 'protocol-header-mismatch',
+      method: 'server/discover',
+      params: {
+        _meta: requestMeta({
+          'io.modelcontextprotocol/protocolVersion': '2025-11-25',
+        }),
+      },
+    }),
+    'MCP-Protocol-Version mismatch',
+  );
+
+  await expectUnsupportedProtocolVersion(
+    await rawRpc(urlValue, {
+      id: 'unsupported-protocol-version',
+      method: 'server/discover',
+      params: {
+        _meta: requestMeta({
+          'io.modelcontextprotocol/protocolVersion': '1900-01-01',
+        }),
+      },
+      headers: { 'MCP-Protocol-Version': '1900-01-01' },
+    }),
+    'unsupported MCP-Protocol-Version',
+  );
+
+  await expectHeaderMismatch(
+    await rawRpc(urlValue, {
+      id: 'name-header-mismatch',
+      method: 'tools/call',
+      params: {
+        name: 'a_header_probe',
+        arguments: {},
+        _meta: requestMeta(),
+      },
+      headers: { 'Mcp-Name': 'echo' },
+    }),
+    'Mcp-Name mismatch',
+  );
+
+  await expectHeaderMismatch(
+    await rawRpc(urlValue, {
+      id: 'param-header-mismatch',
+      method: 'tools/call',
+      params: {
+        name: 'test_custom_headers_valid',
+        arguments: {
+          region: 'us-east1',
+          count: 42,
+          dryRun: false,
+          auth: { tenant: 'tenant-a' },
+        },
+        _meta: requestMeta(),
+      },
+      headers: {
+        'Mcp-Name': 'test_custom_headers_valid',
+        'Mcp-Param-Region': 'us-east1',
+        'Mcp-Param-Count': '43',
+        'Mcp-Param-Dry-Run': 'false',
+        'Mcp-Param-Tenant': 'tenant-a',
+      },
+    }),
+    'Mcp-Param header mismatch',
+  );
+}
+
+async function assertRemovedCoreRequests(urlValue) {
+  await expectMethodNotFound(
+    await rawRpc(urlValue, {
+      id: 'removed-ping',
+      method: 'ping',
+      params: { _meta: requestMeta() },
+    }),
+    'removed ping',
+  );
+}
+
+function parseSseFrames(buffer, messages) {
+  let remaining = buffer;
+  for (;;) {
+    const separator = remaining.indexOf('\n\n');
+    if (separator < 0) {
+      return remaining;
+    }
+
+    const frame = remaining.slice(0, separator);
+    remaining = remaining.slice(separator + 2);
+    const data = frame
+      .split('\n')
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice(5).trimStart())
+      .join('\n');
+    if (data.length > 0) {
+      messages.push(JSON.parse(data));
+    }
+  }
+}
+
+async function collectSseMessages(response, expectedCount, label) {
+  assert(
+    response.headers.get('content-type')?.includes('text/event-stream'),
+    `${label} expected SSE response, got ${response.headers.get('content-type')}`,
+  );
+  assert(response.body, `${label} response did not expose a body stream`);
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const messages = [];
+  let buffer = '';
+  const deadline = Date.now() + 5000;
+
+  try {
+    while (messages.length < expectedCount) {
+      const remainingMs = Math.max(1, deadline - Date.now());
+      const read = await Promise.race([
+        reader.read(),
+        new Promise((_, reject) =>
+          setTimeout(
+            () => reject(new Error(`${label} timed out waiting for SSE`)),
+            remainingMs,
+          ),
+        ),
+      ]);
+      if (read.done) {
+        break;
+      }
+      buffer = parseSseFrames(
+        buffer + decoder.decode(read.value, { stream: true }),
+        messages,
+      );
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+
+  assert(
+    messages.length >= expectedCount,
+    `${label} expected ${expectedCount} SSE messages, got ${JSON.stringify(messages)}`,
+  );
+  return messages;
+}
+
+async function assertSubscriptionListen(urlValue) {
+  const response = await rawRpc(urlValue, {
+    id: 'listen-tools',
+    method: 'subscriptions/listen',
+    params: {
+      notifications: { toolsListChanged: true },
+      _meta: requestMeta(),
+    },
+  });
+  assert(
+    response.status === 200,
+    `subscriptions/listen expected HTTP 200, got ${response.status}`,
+  );
+
+  const messages = await collectSseMessages(
+    response,
+    2,
+    'subscriptions/listen',
+  );
+  assert(
+    messages[0].method === 'notifications/subscriptions/acknowledged',
+    `subscriptions/listen expected acknowledgment first, got ${JSON.stringify(messages[0])}`,
+  );
+  assert(
+    messages[0].params?._meta?.['io.modelcontextprotocol/subscriptionId'] ===
+      'listen-tools',
+    `subscriptions/listen acknowledgment missing subscription id: ${JSON.stringify(messages[0])}`,
+  );
+  assert(
+    messages[1].method === 'notifications/tools/list_changed',
+    `subscriptions/listen expected tools list_changed notification, got ${JSON.stringify(messages[1])}`,
+  );
+  assert(
+    messages[1].params?._meta?.['io.modelcontextprotocol/subscriptionId'] ===
+      'listen-tools',
+    `subscriptions/listen notification missing subscription id: ${JSON.stringify(messages[1])}`,
+  );
+}
+
+async function cancellationCount(client) {
+  const status = await client.callTool({
+    name: 'test_stream_cancellation_status',
+    arguments: {},
+  });
+  return Number.parseInt(firstText(status, 'cancellation status'), 10);
+}
+
+async function assertStreamCancellation(urlValue, client) {
+  const before = await cancellationCount(client);
+  const controller = new AbortController();
+  const response = await rawRpc(urlValue, {
+    id: 'cancel-stream',
+    method: 'tools/call',
+    params: {
+      name: 'test_stream_cancellation',
+      arguments: {},
+      _meta: requestMeta({ progressToken: 'cancel-stream-progress' }),
+    },
+    headers: { 'Mcp-Name': 'test_stream_cancellation' },
+    signal: controller.signal,
+  });
+  assert(
+    response.status === 200,
+    `stream cancellation expected HTTP 200, got ${response.status}`,
+  );
+
+  await collectSseMessages(response, 1, 'stream cancellation startup');
+  controller.abort();
+
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    const after = await cancellationCount(client);
+    if (after > before) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('stream cancellation was not observed by the Dart server');
+}
+
+async function assertProgressNotifications(client) {
+  const progressValues = [];
+  const result = await client.callTool(
+    {
+      name: 'progress_demo',
+      arguments: { steps: 3 },
+    },
+    {
+      timeout: 10000,
+      onprogress: (progress) => {
+        progressValues.push(progress.progress);
+      },
+    },
+  );
+
+  requireText(
+    result,
+    'Completed 3 steps with progress notifications',
+    'progress demo',
+  );
+  assert(
+    progressValues.length >= 2,
+    `progress demo expected multiple progress callbacks, got ${JSON.stringify(progressValues)}`,
+  );
+  assert(
+    progressValues[0] === 0 && progressValues.at(-1) === 100,
+    `progress demo expected 0..100 progress, got ${JSON.stringify(progressValues)}`,
+  );
+  for (let index = 1; index < progressValues.length; index++) {
+    assert(
+      progressValues[index] >= progressValues[index - 1],
+      `progress demo values were not monotonic: ${JSON.stringify(progressValues)}`,
+    );
+  }
+}
+
 function assertCustomHeaderSchema(tool) {
   const properties = tool.inputSchema?.properties ?? {};
   assert(
@@ -122,6 +506,7 @@ async function main() {
       requireTool(tools.tools, 'test_custom_headers_valid'),
     );
     requireTool(tools.tools, 'test_input_required_result_elicitation');
+    requireTool(tools.tools, 'progress_demo');
 
     const message = 'from TypeScript 2026 RC preview';
     const result = await client.callTool({
@@ -151,6 +536,12 @@ async function main() {
       'input_required elicitation',
     );
 
+    await assertRawHeaderValidation(urlValue);
+    await assertRemovedCoreRequests(urlValue);
+    await assertProgressNotifications(client);
+    await assertSubscriptionListen(urlValue);
+    await assertStreamCancellation(urlValue, client);
+
     console.log(
       JSON.stringify({
         protocolEra: era,
@@ -160,6 +551,11 @@ async function main() {
         echo,
         customHeaders: 'ok',
         inputRequired: elicitationText,
+        rawHeaderValidation: 'ok',
+        removedCoreRequests: 'ok',
+        progress: 'ok',
+        subscriptionsListen: 'ok',
+        streamCancellation: 'ok',
       }),
     );
   } finally {

--- a/test/interop/ts_2026_rc/src/server.mjs
+++ b/test/interop/ts_2026_rc/src/server.mjs
@@ -1,0 +1,187 @@
+import { createServer } from 'node:http';
+
+import {
+  McpServer,
+  WebStandardStreamableHTTPServerTransport,
+} from '@modelcontextprotocol/server';
+import { z } from 'zod';
+
+const PROTOCOL_VERSION = '2026-07-28';
+
+function readArg(args, name) {
+  const index = args.indexOf(name);
+  if (index < 0 || index + 1 >= args.length) {
+    return undefined;
+  }
+  return args[index + 1];
+}
+
+function createInteropServer() {
+  const serverInfo = { name: 'ts-2026-rc-interop-server', version: '0.0.0' };
+  const server = new McpServer(
+    serverInfo,
+    {
+      supportedProtocolVersions: [PROTOCOL_VERSION],
+      capabilities: { tools: {} },
+    },
+  );
+
+  server.registerTool(
+    'ts_echo',
+    {
+      description: 'Echoes a message from the Dart 2026 RC client.',
+      inputSchema: z.object({ message: z.string() }),
+    },
+    async ({ message }) => ({
+      content: [{ type: 'text', text: message }],
+    }),
+  );
+
+  return server;
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+function requestHeaders(req) {
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        headers.append(name, item);
+      }
+    } else if (value !== undefined) {
+      headers.set(name, value);
+    }
+  }
+  return headers;
+}
+
+function discoveryResponse(id) {
+  // The current TS server alpha does not answer server/discover yet, but the
+  // 2026 draft requires it. Keep this shim local to the diagnostic fixture.
+  return new Response(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id,
+      result: {
+        resultType: 'complete',
+        supportedVersions: [PROTOCOL_VERSION],
+        capabilities: { tools: {} },
+        serverInfo: {
+          name: 'ts-2026-rc-interop-server',
+          version: '0.0.0',
+        },
+        ttlMs: 1000,
+        cacheScope: 'public',
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
+}
+
+async function writeWebResponse(webResponse, res) {
+  res.writeHead(
+    webResponse.status,
+    Object.fromEntries(webResponse.headers.entries()),
+  );
+  if (!webResponse.body) {
+    res.end();
+    return;
+  }
+
+  const reader = webResponse.body.getReader();
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      res.write(Buffer.from(value));
+    }
+  } finally {
+    res.end();
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const host = readArg(args, '--host') ?? '127.0.0.1';
+  const port = Number.parseInt(readArg(args, '--port') ?? '0', 10);
+  const mcpServer = createInteropServer();
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+    enableJsonResponse: false,
+    supportedProtocolVersions: [PROTOCOL_VERSION],
+  });
+  await mcpServer.connect(transport);
+
+  const httpServer = createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+      if (url.pathname !== '/mcp') {
+        res.writeHead(404).end('Not found');
+        return;
+      }
+
+      const init = {
+        method: req.method,
+        headers: requestHeaders(req),
+      };
+      let body;
+      if (req.method !== 'GET' && req.method !== 'HEAD') {
+        body = await readBody(req);
+        init.body = body;
+      }
+
+      const webRequest = new Request(url, init);
+      if (body && body.length > 0) {
+        const message = JSON.parse(body.toString('utf8'));
+        if (message.method === 'server/discover') {
+          await writeWebResponse(discoveryResponse(message.id), res);
+          return;
+        }
+      }
+
+      const webResponse = await transport.handleRequest(webRequest);
+      await writeWebResponse(webResponse, res);
+    } catch (error) {
+      console.error(error);
+      if (!res.headersSent) {
+        res.writeHead(500);
+      }
+      res.end(String(error));
+    }
+  });
+
+  await new Promise((resolve) => httpServer.listen(port, host, resolve));
+  const address = httpServer.address();
+  const boundPort = typeof address === 'object' && address ? address.port : port;
+  console.log(
+    `TS 2026 RC interop server listening on http://${host}:${boundPort}/mcp`,
+  );
+
+  const stop = async () => {
+    await mcpServer.close().catch(() => {});
+    await new Promise((resolve) => httpServer.close(resolve));
+  };
+  process.once('SIGTERM', () => {
+    stop().finally(() => process.exit(0));
+  });
+  process.once('SIGINT', () => {
+    stop().finally(() => process.exit(0));
+  });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/test/types_edge_cases_test.dart
+++ b/test/types_edge_cases_test.dart
@@ -14,6 +14,15 @@ void main() {
       expect(ErrorCode.fromValue(-32000), equals(ErrorCode.connectionClosed));
       expect(ErrorCode.fromValue(-32001), equals(ErrorCode.requestTimeout));
       expect(ErrorCode.fromValue(-32002), equals(ErrorCode.resourceNotFound));
+      expect(ErrorCode.fromValue(-32020), equals(ErrorCode.headerMismatch));
+      expect(
+        ErrorCode.fromValue(-32021),
+        equals(ErrorCode.missingRequiredClientCapability),
+      );
+      expect(
+        ErrorCode.fromValue(-32022),
+        equals(ErrorCode.unsupportedProtocolVersion),
+      );
       expect(ErrorCode.fromValue(-32700), equals(ErrorCode.parseError));
       expect(ErrorCode.fromValue(-32600), equals(ErrorCode.invalidRequest));
       expect(ErrorCode.fromValue(-32601), equals(ErrorCode.methodNotFound));

--- a/tool/testing/run_ts_2026_rc_interop.dart
+++ b/tool/testing/run_ts_2026_rc_interop.dart
@@ -2,12 +2,18 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:mcp_dart/mcp_dart.dart';
+
 Future<void> main(List<String> args) async {
   final repoRoot = Directory.current;
   final fixtureDir = Directory('test/interop/ts_2026_rc');
   final clientPackage = File(
     'test/interop/ts_2026_rc/node_modules/'
     '@modelcontextprotocol/client/package.json',
+  );
+  final serverPackage = File(
+    'test/interop/ts_2026_rc/node_modules/'
+    '@modelcontextprotocol/server/package.json',
   );
 
   if (!File('pubspec.yaml').existsSync() || !fixtureDir.existsSync()) {
@@ -27,7 +33,29 @@ Future<void> main(List<String> args) async {
     exitCode = 64;
     return;
   }
+  if (!serverPackage.existsSync()) {
+    stderr.writeln(
+      'Missing TypeScript server fixture dependencies. Run:\n'
+      '  cd test/interop/ts_2026_rc\n'
+      '  npm install',
+    );
+    exitCode = 64;
+    return;
+  }
 
+  try {
+    await _runTsClientAgainstDartServer(repoRoot, fixtureDir);
+    await _runDartClientAgainstTsServer(repoRoot, fixtureDir);
+  } on Object catch (error) {
+    stderr.writeln('TS 2026 RC interop failed: $error');
+    exitCode = 1;
+  }
+}
+
+Future<void> _runTsClientAgainstDartServer(
+  Directory repoRoot,
+  Directory fixtureDir,
+) async {
   final server = await Process.start(
     Platform.resolvedExecutable,
     [
@@ -42,22 +70,15 @@ Future<void> main(List<String> args) async {
   );
 
   final serverUrl = Completer<String>();
-  final urlPattern = RegExp(r'(http://[^\s]+)');
-
   final serverStdout = _pipeLines(
     server.stdout,
     stdout,
     '[dart-server]',
-    onLine: (line) {
-      if (serverUrl.isCompleted ||
-          !line.contains('MCP 2026 RC conformance server listening on')) {
-        return;
-      }
-      final match = urlPattern.firstMatch(line);
-      if (match != null) {
-        serverUrl.complete(match.group(1)!);
-      }
-    },
+    onLine: (line) => _completeUrlFromLine(
+      serverUrl,
+      line,
+      'MCP 2026 RC conformance server listening on',
+    ),
   );
   final serverStderr = _pipeLines(server.stderr, stderr, '[dart-server]');
 
@@ -82,16 +103,128 @@ Future<void> main(List<String> args) async {
     await Future.wait([clientStdout, clientStderr]);
 
     if (clientExit != 0) {
-      exitCode = clientExit;
-      return;
+      throw StateError('TypeScript 2026 RC client exited with $clientExit');
     }
-  } on Object catch (error) {
-    stderr.writeln('TS 2026 RC interop failed: $error');
-    exitCode = 1;
   } finally {
     await _terminate(server);
     await Future.wait([serverStdout, serverStderr]);
   }
+}
+
+Future<void> _runDartClientAgainstTsServer(
+  Directory repoRoot,
+  Directory fixtureDir,
+) async {
+  final server = await Process.start(
+    'node',
+    ['src/server.mjs', '--host', '127.0.0.1', '--port', '0'],
+    workingDirectory: fixtureDir.path,
+  );
+
+  final serverUrl = Completer<String>();
+  final serverStdout = _pipeLines(
+    server.stdout,
+    stdout,
+    '[ts-server]',
+    onLine: (line) => _completeUrlFromLine(
+      serverUrl,
+      line,
+      'TS 2026 RC interop server listening on',
+    ),
+  );
+  final serverStderr = _pipeLines(server.stderr, stderr, '[ts-server]');
+
+  try {
+    final url = await serverUrl.future.timeout(
+      const Duration(seconds: 20),
+      onTimeout: () {
+        throw TimeoutException('Timed out waiting for TypeScript server URL');
+      },
+    );
+    try {
+      await _exerciseDartClient(url);
+    } on McpError catch (error) {
+      if (!_isKnownTypeScriptServerAlphaGap(error)) {
+        rethrow;
+      }
+      stdout.writeln(
+        '[dart-client] reverse TS server diagnostic skipped: ${error.message}',
+      );
+    }
+  } finally {
+    await _terminate(server);
+    await Future.wait([serverStdout, serverStderr]);
+  }
+}
+
+bool _isKnownTypeScriptServerAlphaGap(McpError error) {
+  final text = error.toString();
+  return text.contains('MCP stateless responses must include resultType') ||
+      text.contains('server/discover not available');
+}
+
+Future<void> _exerciseDartClient(String url) async {
+  final transport = StreamableHttpClientTransport(Uri.parse(url));
+  final client = McpClient(
+    const Implementation(name: 'mcp-dart-2026-rc-client', version: '0.0.0'),
+    options: const McpClientOptions(
+      protocol: McpProtocol.preview2026,
+      capabilities: ClientCapabilities(),
+    ),
+  );
+
+  try {
+    await client.connect(transport).timeout(const Duration(seconds: 20));
+    final version = client.getProtocolVersion();
+    if (version != draftProtocolVersion2026_07_28) {
+      throw StateError('Expected 2026-07-28, got $version');
+    }
+    final serverInfo = client.getServerVersion();
+    if (serverInfo?.name != 'ts-2026-rc-interop-server') {
+      throw StateError('Unexpected TS server info: ${serverInfo?.toJson()}');
+    }
+
+    final tools = await client.listTools().timeout(const Duration(seconds: 10));
+    if (!tools.tools.any((tool) => tool.name == 'ts_echo')) {
+      throw StateError(
+        'TS server tools/list did not include ts_echo: '
+        '${tools.tools.map((tool) => tool.name).toList()}',
+      );
+    }
+
+    const message = 'from Dart 2026 RC preview';
+    final echo = await client
+        .callTool(
+          const CallToolRequest(
+            name: 'ts_echo',
+            arguments: {'message': message},
+          ),
+        )
+        .timeout(const Duration(seconds: 10));
+    final text = _firstText(echo, 'ts_echo');
+    if (text != message) {
+      throw StateError('Unexpected ts_echo result: $text');
+    }
+
+    stdout.writeln(
+      '[dart-client] ${jsonEncode({
+            'protocolVersion': version,
+            'serverInfo': serverInfo?.toJson(),
+            'toolCount': tools.tools.length,
+            'echo': text,
+          })}',
+    );
+  } finally {
+    await client.close();
+  }
+}
+
+String _firstText(CallToolResult result, String label) {
+  final content = result.content;
+  if (content.isEmpty || content.first is! TextContent) {
+    throw StateError('$label expected text content: ${result.toJson()}');
+  }
+  return (content.first as TextContent).text;
 }
 
 Future<void> _pipeLines(
@@ -104,6 +237,21 @@ Future<void> _pipeLines(
       in stream.transform(utf8.decoder).transform(const LineSplitter())) {
     onLine?.call(line);
     sink.writeln('$prefix $line');
+  }
+}
+
+void _completeUrlFromLine(
+  Completer<String> completer,
+  String line,
+  String marker,
+) {
+  if (completer.isCompleted || !line.contains(marker)) {
+    return;
+  }
+  final urlPattern = RegExp(r'(http://[^\s]+)');
+  final match = urlPattern.firstMatch(line);
+  if (match != null) {
+    completer.complete(match.group(1)!);
   }
 }
 


### PR DESCRIPTION
## Summary

- Expand the manual TypeScript 2026 RC interop fixture beyond echo/list smoke coverage.
- Add raw Streamable HTTP assertions for required routing headers, unsupported protocol versions, removed 2026 core RPCs, custom `Mcp-Param-*` mismatches, `subscriptions/listen`, and HTTP SSE cancellation.
- Add progress notification coverage through the TypeScript preview client's `onprogress` callback.
- Add a reverse Dart preview client -> TypeScript server alpha diagnostic path. It is intentionally non-gating while the TS alpha server still misses mandatory `server/discover` and stateless `resultType` behavior.
- Align draft MCP error codes with the live 2026-07-28 draft and document the temporary conformance alpha.4 expected failures where upstream still expects the old `HeaderMismatch` code.

## Spec Anchors

- Official 2026 draft `server/discover` is required for modern protocol discovery.
- Streamable HTTP 2026 requires standard routing headers and rejects header/body mismatches.
- `x-mcp-header` tests use only draft-permitted primitive types: `string`, `integer`, and `boolean`.
- `ping` is removed from the 2026 stateless core RPC set, so this fixture asserts rejection instead of accepting TS behavior blindly.
- Request-scoped `notifications/progress` and stream cancellation are checked against the draft transport model.

## Validation

- `dart format .`
- `dart analyze`
- `cd packages/mcp_dart_cli && dart analyze`
- `node --check test/interop/ts_2026_rc/src/client.mjs && node --check test/interop/ts_2026_rc/src/server.mjs`
- `dart run tool/testing/run_ts_2026_rc_interop.dart`
- `dart test`
- `dart test test/mcp_2026_07_28_test.dart test/server/streamable_https_test.dart`
- `dart test test/types_edge_cases_test.dart test/server/streamable_mcp_server_test.dart`
- `dart run test/conformance/run_2026_rc_client_conformance.dart` (31 passed, 1 expected failure)
- `dart run test/conformance/run_2026_rc_server_conformance.dart` (38 passed, 2 expected failures)
- `dart run test/conformance/run_2025_server_conformance.dart` (49 passed)
- `npx -y @modelcontextprotocol/conformance@0.2.0-alpha.4 client --command "dart run test/conformance/mcp_2026_rc_client.dart" --suite all --spec-version 2025-11-25 -o .dart_tool/conformance/2025_client` (222 passed)
- `cd packages/mcp_dart_cli && dart run bin/mcp_dart.dart conformance --suite all --json` (72/72 passed)
