### PR TITLE
Prepare dev release 2.3.0-dev.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,37 @@
 ## Unreleased
 
-### Conformance and release readiness
+## 2.3.0-dev.1
 
+This dev preview refreshes MCP `2026-07-28` draft/RC support while keeping MCP
+`2025-11-25` as the default protocol profile.
+
+### MCP 2026-07-28 draft/RC refresh
+
+- Aligned draft protocol-defined error codes with the live draft:
+  `HeaderMismatch` is now `-32020`,
+  `MissingRequiredClientCapability` is now `-32021`, and
+  `UnsupportedProtocolVersion` is now `-32022`.
+- Marked `server/discover` as a 2026 cacheable result so stateless responses
+  include default `ttlMs` and `cacheScope` hints.
+- Removed the legacy `DRAFT-2026-v1` draft alias now that official conformance
+  targets the `2026-07-28` wire version.
+- Ported the JSON Schema boolean-subschema preservation fix onto the RC dev
+  line, including legacy tool-schema shims.
+
+### Conformance and interoperability
+
+- Updated official conformance gates to
+  `@modelcontextprotocol/conformance@0.2.0-alpha.4`, with full 2026 RC server
+  scenario coverage and alpha.4's spec-filtered 2026 client scenario list in CI.
 - Expanded the manual TypeScript SDK 2026 RC interop fixture pinned to the
   upstream PR #2327 preview package, covering modern negotiation,
   `server/discover` cache metadata, `tools/list`, `tools/call`,
-  `x-mcp-header` mirroring, progress notifications, raw HTTP header,
-  unsupported-version, and removed core RPC rejection, `subscriptions/listen`,
-  and Streamable HTTP SSE cancellation against the Dart 2026 RC conformance
-  server.
+  `x-mcp-header` mirroring, progress notifications, raw HTTP header validation,
+  unsupported-version and removed core RPC rejection, `subscriptions/listen`,
+  and Streamable HTTP SSE cancellation.
 - Added a diagnostic Dart preview client -> TypeScript server alpha path and
   documented the current TS alpha gaps around mandatory `server/discover` and
   stateless `resultType` responses.
-- Aligned 2026 draft protocol-defined error codes with the live draft:
-  `HeaderMismatch` is now `-32020`,
-  `MissingRequiredClientCapability` is now `-32021`, and
-  `UnsupportedProtocolVersion` is now `-32022`. The conformance alpha.4 server
-  scenarios that still expect the old `HeaderMismatch` code are tracked as
-  expected failures.
-- Marked `server/discover` as a 2026 cacheable result so stateless responses
-  include default `ttlMs` and `cacheScope` hints.
-- Updated official conformance gates to
-  `@modelcontextprotocol/conformance@0.2.0-alpha.4`, with 2026 RC runs pinned
-  to `2026-07-28`, the full 2026 server scenario list covered in CI, the 2026
-  client wrapper aligned with alpha.4's spec-filtered scenario list, and the
-  current upstream client fixture gap tracked as an expected failure.
-- Removed the legacy `DRAFT-2026-v1` draft alias now that official conformance
-  targets the `2026-07-28` wire version.
 
 ## 2.3.0-dev.0
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.3.0-dev.0
+  mcp_dart: ^2.3.0-dev.1
 ```
 
 Then install dependencies:

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -8,7 +8,7 @@ Add the MCP Dart SDK to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.3.0-dev.0
+  mcp_dart: ^2.3.0-dev.1
 ```
 
 Then run:

--- a/doc/mcp-2026-rc.md
+++ b/doc/mcp-2026-rc.md
@@ -175,10 +175,10 @@ dev release, `mcp_dart_cli 0.2.0-dev.0`, is already published. The CLI publish
 workflow removes the local SDK override before publishing so users receive the
 published SDK dependency.
 
-Install the dev CLI explicitly by version:
+Install the current dev CLI explicitly by version:
 
 ```sh
-dart pub global activate mcp_dart_cli 0.2.0-dev.0
+dart pub global activate mcp_dart_cli 0.2.0-dev.1
 ```
 
 The standalone install and update scripts intentionally track stable GitHub
@@ -186,5 +186,5 @@ releases; use Dart SDK activation when testing prerelease CLI builds.
 
 `mcp_dart create` continues to generate projects that resolve the stable SDK by
 default. For draft/RC testing, update generated projects to depend on
-`mcp_dart: ^2.3.0-dev.0` and opt into `McpProtocol.preview2026` or
+`mcp_dart: ^2.3.0-dev.1` and opt into `McpProtocol.preview2026` or
 `McpProtocol.require2026`.

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -7,7 +7,7 @@ Fast lookup guide for common MCP Dart SDK operations.
 ```yaml
 # pubspec.yaml
 dependencies:
-  mcp_dart: ^2.3.0-dev.0
+  mcp_dart: ^2.3.0-dev.1
 ```
 
 ```bash

--- a/packages/mcp_dart_cli/CHANGELOG.md
+++ b/packages/mcp_dart_cli/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.2.0-dev.1
+
+- Update the dev CLI package to depend on `mcp_dart ^2.3.0-dev.1`.
+- Refresh built-in 2026 RC conformance checks for the current draft error
+  codes and cacheable `server/discover` behavior.
+- Keep CLI standalone binary release automation current with GitHub runner and
+  artifact action updates.
+- Add installer fallback behavior for resolving the latest stable CLI GitHub
+  release when the GitHub Releases API is unavailable.
+
 ## 0.2.0-dev.0
 
 - Prepare the CLI for the MCP `2026-07-28` draft/RC SDK dev line with a

--- a/packages/mcp_dart_cli/README.md
+++ b/packages/mcp_dart_cli/README.md
@@ -17,7 +17,7 @@ For the MCP `2026-07-28` draft/RC dev release, pass the prerelease version
 explicitly:
 
 ```bash
-dart pub global activate mcp_dart_cli 0.2.0-dev.0
+dart pub global activate mcp_dart_cli 0.2.0-dev.1
 ```
 
 Without the Dart SDK, install the latest standalone binary from GitHub Releases:
@@ -60,7 +60,7 @@ If `directory` is omitted, the project will be created in the current directory 
 
 Generated projects resolve the stable `mcp_dart` SDK by default. For MCP
 `2026-07-28` draft/RC testing, update the generated `pubspec.yaml` to depend on
-`mcp_dart: ^2.3.0-dev.0`.
+`mcp_dart: ^2.3.0-dev.1`.
 
 ### Create from a specific template
 
@@ -466,9 +466,8 @@ dart run tool/validate_cli_publish.dart
 
 For follow-up CLI dev releases whose matching `mcp_dart` SDK dev package is not
 published yet, this uses `pubspec_overrides.yaml` so the CLI can validate
-against the local SDK checkout. The initial `mcp_dart 2.3.0-dev.0` SDK package
-is already published, so release validation should also cover the pub.dev SDK
-version:
+against the local SDK checkout. After the matching SDK dev package is published,
+also validate the CLI against the pub.dev SDK version:
 
 ```bash
 dart run tool/validate_cli_publish.dart --published-sdk

--- a/packages/mcp_dart_cli/lib/src/version.dart
+++ b/packages/mcp_dart_cli/lib/src/version.dart
@@ -1,1 +1,1 @@
-const packageVersion = '0.2.0-dev.0';
+const packageVersion = '0.2.0-dev.1';

--- a/packages/mcp_dart_cli/pubspec.yaml
+++ b/packages/mcp_dart_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mcp_dart_cli
 description: Command-line tools for creating, serving, inspecting, and testing Dart Model Context Protocol (MCP) servers.
-version: 0.2.0-dev.0
+version: 0.2.0-dev.1
 repository: https://github.com/leehack/mcp_dart
 homepage: https://github.com/leehack/mcp_dart/tree/dev/2026-07-28-rc/packages/mcp_dart_cli
 issue_tracker: https://github.com/leehack/mcp_dart/issues
@@ -27,7 +27,7 @@ dependencies:
   stream_transform: ^2.1.1
   watcher: ^1.2.0
   yaml: ^3.1.3
-  mcp_dart: ^2.3.0-dev.0
+  mcp_dart: ^2.3.0-dev.1
   mason_logger: ^0.3.3
   meta: ^1.17.0
   pub_updater: ^0.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mcp_dart
 description: Dart and Flutter SDK for building Model Context Protocol (MCP) servers, clients, hosts, and AI tools.
-version: 2.3.0-dev.0
+version: 2.3.0-dev.1
 repository: https://github.com/leehack/mcp_dart
 homepage: https://github.com/leehack/mcp_dart
 issue_tracker: https://github.com/leehack/mcp_dart/issues


### PR DESCRIPTION
## Summary
- bump SDK to `2.3.0-dev.1` and CLI to `0.2.0-dev.1`
- refresh SDK/CLI changelogs for the latest 2026-07-28 draft/RC work
- update install snippets and dev-release docs for the new prerelease versions
- clarify that CLI published-SDK validation should run after the matching SDK dev package is published

## Validation
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test`
- `(cd packages/mcp_dart_cli && dart test)`
- `(cd packages/mcp_dart_cli && dart run bin/mcp_dart.dart conformance --suite all --json)`
- `dart run test/conformance/run_2025_server_conformance.dart --timeout-seconds 90 --output-dir .dart_tool/conformance/release_prep_2025_server`
- `npx -y @modelcontextprotocol/conformance@0.2.0-alpha.4 client --command "dart run test/conformance/mcp_2026_rc_client.dart" --suite all --spec-version 2025-11-25 --verbose -o .dart_tool/conformance/release_prep_2025_client`
- `dart run test/conformance/run_2026_rc_server_conformance.dart --timeout-seconds 90 --output-dir .dart_tool/conformance/release_prep_2026_server`
- `dart run test/conformance/run_2026_rc_client_conformance.dart --timeout-seconds 90 --output-dir .dart_tool/conformance/release_prep_2026_client`
- `dart run tool/testing/run_ts_2026_rc_interop.dart`
- `dart pub publish --dry-run`
- `dart run tool/validate_cli_publish.dart`
- `dart pub global run pana --no-warning .`