### PR TITLE
Refresh alpha6 conformance coverage

### DIFF
--- a/.github/workflows/interop_2026_07_28.yml
+++ b/.github/workflows/interop_2026_07_28.yml
@@ -1,0 +1,57 @@
+name: Run MCP 2026-07-28 TypeScript Interop
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 9 * * *'
+  pull_request:
+    paths:
+      - 'lib/**'
+      - 'test/conformance/**'
+      - 'test/interop/ts_2026_07_28_rc/**'
+      - 'tool/testing/run_ts_2026_07_28_rc_interop.dart'
+      - '.github/workflows/interop_2026_07_28.yml'
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
+  push:
+    branches:
+      - dev/2026-07-28-rc
+    paths:
+      - 'lib/**'
+      - 'test/conformance/**'
+      - 'test/interop/ts_2026_07_28_rc/**'
+      - 'tool/testing/run_ts_2026_07_28_rc_interop.dart'
+      - '.github/workflows/interop_2026_07_28.yml'
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
+
+jobs:
+  ts-2026-07-28-interop:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install Dart dependencies
+        run: dart pub get
+
+      - name: Install TypeScript 2026-07-28 fixture dependencies
+        working-directory: test/interop/ts_2026_07_28_rc
+        run: npm ci
+
+      - name: Run TypeScript 2026-07-28 interop fixture
+        run: dart run tool/testing/run_ts_2026_07_28_rc_interop.dart

--- a/.github/workflows/test_core.yml
+++ b/.github/workflows/test_core.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run official MCP 2025 client conformance
         run: >
-          npx -y @modelcontextprotocol/conformance@0.2.0-alpha.5 client
+          npx -y @modelcontextprotocol/conformance@0.2.0-alpha.6 client
           --command "dart run test/conformance/mcp_2026_07_28_rc_client.dart"
           --suite all
           --spec-version 2025-11-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,15 @@
 ### Conformance and interoperability
 
 - Updated official conformance gates to
-  `@modelcontextprotocol/conformance@0.2.0-alpha.5`. The 2026-07-28 RC server suite
+  `@modelcontextprotocol/conformance@0.2.0-alpha.6`. The 2026-07-28 RC server suite
   now has no expected failures; the 2026 client suite keeps only the upstream
   `json-schema-ref-no-deref` fixture gap expected.
-- Re-pinned the manual TypeScript SDK 2026-07-28 RC interop fixture to
+- Added a dedicated CI workflow for the TypeScript SDK 2026-07-28 RC preview
+  interop fixture on relevant PRs, `dev/2026-07-28-rc` pushes, daily schedule,
+  and manual dispatch.
+- Added an MCP 2026-07-28 draft/RC spec coverage matrix that maps the opt-in
+  profile to official conformance, local tests, and TypeScript preview interop.
+- Re-pinned the TypeScript SDK 2026-07-28 RC interop fixture to
   `pkg.pr.new` previews from the merged `v2-2026-07-28` branch head for both
   client and server packages.
 - Switched the reverse Dart preview client -> TypeScript preview server fixture

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ for opt-in behavior, fallback rules, and draft-only APIs.
 
 - 🧪 **[SDK Interoperability Matrix](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/interoperability.md)** - Verified Dart/TypeScript and documented cross-SDK scenarios
 - ✅ **[MCP 2025-11-25 Spec Coverage Matrix](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/spec-coverage-2025-11-25.md)** - Auditable coverage map with CLI conformance cases and known gaps
+- 🧪 **[MCP 2026-07-28 Draft/RC Spec Coverage Matrix](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/spec-coverage-2026-07-28-rc.md)** - Opt-in draft/RC coverage map across official conformance and TypeScript preview interop
 - 🧭 **[MCP 2026-07-28 Draft/RC Transition Guide](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/mcp-2026-07-28-rc.md)** - Opt-in profile, fallback behavior, and draft-only APIs
 - 🔒 **[Transport Security Recipes](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/transports.md#dns-rebinding-protection)** - Host/Origin allowlists, OAuth layering, and compatibility-toggle trade-offs
 - 📱 **[Flutter Recipes](https://github.com/leehack/mcp_dart/blob/dev/2026-07-28-rc/doc/flutter-recipes.md)** - Flutter Web, mobile, and desktop host/client guidance

--- a/doc/interoperability.md
+++ b/doc/interoperability.md
@@ -4,6 +4,8 @@ This page tracks the interoperability evidence that `mcp_dart` currently carries
 
 For requirement-level MCP 2025-11-25 coverage, see the
 [`spec-coverage-2025-11-25.md`](spec-coverage-2025-11-25.md) matrix.
+For MCP 2026-07-28 draft/RC coverage, see the
+[`spec-coverage-2026-07-28-rc.md`](spec-coverage-2026-07-28-rc.md) matrix.
 
 ## How to read the matrix
 
@@ -21,8 +23,8 @@ For requirement-level MCP 2025-11-25 coverage, see the
 | Dart client -> TypeScript SDK server | Streamable HTTP | `2025-11-25` | [`test/interop/dart_client_with_ts_server_test.dart`](../test/interop/dart_client_with_ts_server_test.dart), [`test/interop/ts/`](../test/interop/ts/) | Verified | Covers tool calls and stale preconfigured session-id recovery. |
 | TypeScript SDK client -> Dart server | stdio | `2025-11-25` | [`test/interop/ts_client_with_dart_server_test.dart`](../test/interop/ts_client_with_dart_server_test.dart), [`test/interop/test_dart_server.dart`](../test/interop/test_dart_server.dart) | Verified | Runs the compiled TypeScript client fixture against a Dart server process and checks that an official TS client can list tools immediately after the lifecycle handshake. |
 | TypeScript SDK client -> Dart server | Streamable HTTP | `2025-11-25` | [`test/interop/ts_client_with_dart_server_test.dart`](../test/interop/ts_client_with_dart_server_test.dart), [`test/interop/test_dart_server.dart`](../test/interop/test_dart_server.dart) | Verified | Includes official TS Streamable HTTP client lifecycle coverage, pre-`initialized` operation rejection, GET SSE streams, and `Last-Event-ID` replay behavior. |
-| TypeScript SDK preview client -> Dart server | Streamable HTTP | `2026-07-28` draft/RC | [`test/interop/ts_2026_07_28_rc/`](../test/interop/ts_2026_07_28_rc/), [`tool/testing/run_ts_2026_07_28_rc_interop.dart`](../tool/testing/run_ts_2026_07_28_rc_interop.dart) | Experimental manual check | Uses pinned `pkg.pr.new` previews from the TypeScript SDK `v2-2026-07-28` branch head. Covers modern negotiation, cache metadata, `tools/list`, `tools/call`, `x-mcp-header` mirroring, raw header and unsupported-version rejection, removed core RPC rejection, progress notifications, `subscriptions/listen`, and HTTP SSE cancellation against the Dart 2026-07-28 RC conformance server. Not a CI gate yet. |
-| Dart preview client -> TypeScript SDK preview server | Streamable HTTP | `2026-07-28` draft/RC | [`test/interop/ts_2026_07_28_rc/src/server.mjs`](../test/interop/ts_2026_07_28_rc/src/server.mjs), [`tool/testing/run_ts_2026_07_28_rc_interop.dart`](../tool/testing/run_ts_2026_07_28_rc_interop.dart) | Experimental manual check | Uses the pinned TypeScript SDK server preview through its `createMcpHandler` entry and covers `server/discover` negotiation, `tools/list`, and `tools/call`. Not a CI gate yet. |
+| TypeScript SDK preview client -> Dart server | Streamable HTTP | `2026-07-28` draft/RC | [`test/interop/ts_2026_07_28_rc/`](../test/interop/ts_2026_07_28_rc/), [`tool/testing/run_ts_2026_07_28_rc_interop.dart`](../tool/testing/run_ts_2026_07_28_rc_interop.dart), [`interop_2026_07_28.yml`](../.github/workflows/interop_2026_07_28.yml) | Automated preview check | Uses pinned `pkg.pr.new` previews from the TypeScript SDK `v2-2026-07-28` branch head. Covers modern negotiation, cache metadata, `tools/list`, `tools/call`, `x-mcp-header` mirroring, raw header and unsupported-version rejection, removed core RPC rejection, progress notifications, `subscriptions/listen`, and HTTP SSE cancellation against the Dart 2026-07-28 RC conformance server. |
+| Dart preview client -> TypeScript SDK preview server | Streamable HTTP | `2026-07-28` draft/RC | [`test/interop/ts_2026_07_28_rc/src/server.mjs`](../test/interop/ts_2026_07_28_rc/src/server.mjs), [`tool/testing/run_ts_2026_07_28_rc_interop.dart`](../tool/testing/run_ts_2026_07_28_rc_interop.dart), [`interop_2026_07_28.yml`](../.github/workflows/interop_2026_07_28.yml) | Automated preview check | Uses the pinned TypeScript SDK server preview through its `createMcpHandler` entry and covers `server/discover` negotiation, `tools/list`, and `tools/call`. |
 | Dart client -> Python MCP server | stdio | Server-dependent | [`doc/transports.md`](transports.md#connect-to-python-server) | Documented recipe | The transport can spawn Python servers over stdio, but this repo does not yet include an automated Python SDK fixture. |
 | Flutter/Web client -> Dart server | Streamable HTTP | `2025-11-25` | [`example/flutter_http_client/`](../example/flutter_http_client/), [`doc/flutter-recipes.md`](flutter-recipes.md) | Documented recipe | Flutter Web cannot spawn stdio servers; use Streamable HTTP or another browser-safe transport. |
 | MCP Apps host/client metadata | stdio or Streamable HTTP | `2025-11-25` plus `io.modelcontextprotocol/ui` extension | [`doc/mcp-apps.md`](mcp-apps.md), [`example/mcp_apps_helpers_server.dart`](../example/mcp_apps_helpers_server.dart), [`test/types/mcp_ui_test.dart`](../test/types/mcp_ui_test.dart), [`test/server/mcp_ui_test.dart`](../test/server/mcp_ui_test.dart) | Verified | Verified coverage is limited to SDK metadata helpers, serialization, and checked-in examples; host rendering behavior varies by host, so verify UI metadata against your target host. |
@@ -44,9 +46,8 @@ dart test --tags interop
 
 If the compiled fixtures are missing, local test runs skip the interop groups; CI should fail when required fixtures are unavailable.
 
-The TypeScript 2026-07-28 RC fixture is manual while the upstream SDK support remains
-unreleased and pinned to `pkg.pr.new` previews from the TypeScript SDK
-`v2-2026-07-28` branch:
+The TypeScript 2026-07-28 RC fixture uses unreleased `pkg.pr.new` previews from
+the TypeScript SDK `v2-2026-07-28` branch:
 
 ```bash
 # From repository root
@@ -59,6 +60,10 @@ dart run tool/testing/run_ts_2026_07_28_rc_interop.dart
 This starts the Dart 2026-07-28 RC conformance server, runs the pinned TypeScript SDK
 preview client against it, then runs the reverse Dart preview client smoke check
 against the TypeScript preview server.
+
+CI also runs this fixture in the dedicated
+`Run MCP 2026-07-28 TypeScript Interop` workflow for relevant PRs,
+`dev/2026-07-28-rc` pushes, daily scheduled drift checks, and manual dispatch.
 
 The CLI spec conformance gate covers raw-wire negative cases that do not need a
 cross-SDK fixture, including stable MCP 2025-11-25 checks and MCP 2026-07-28 RC
@@ -83,9 +88,9 @@ When adding a new interoperability claim:
 ## Known gaps worth tracking
 
 - Automated Python SDK fixture coverage.
-- CI promotion for the TypeScript 2026-07-28 RC interop fixture after the TypeScript
-  SDK publishes a 2026-07-28-compatible alpha package instead of requiring
-  `pkg.pr.new` previews.
+- Re-pin the TypeScript 2026-07-28 RC interop fixture to a published upstream
+  alpha package once the TypeScript SDK no longer requires `pkg.pr.new`
+  previews.
 - Broader reverse-path TypeScript preview server coverage beyond discovery,
   `tools/list`, and `tools/call`.
 - Host-specific MCP Apps rendering compatibility notes.

--- a/doc/mcp-2026-07-28-rc.md
+++ b/doc/mcp-2026-07-28-rc.md
@@ -130,27 +130,34 @@ Before creating follow-up dev tags from `dev/2026-07-28-rc`, run:
 ```sh
 dart analyze
 dart run test/conformance/run_2025_server_conformance.dart
-npx -y @modelcontextprotocol/conformance@0.2.0-alpha.5 client \
+npx -y @modelcontextprotocol/conformance@0.2.0-alpha.6 client \
   --command "dart run test/conformance/mcp_2026_07_28_rc_client.dart" \
   --suite all \
   --spec-version 2025-11-25
 dart run test/conformance/run_2026_07_28_rc_server_conformance.dart
 dart run test/conformance/run_2026_07_28_rc_client_conformance.dart
+cd test/interop/ts_2026_07_28_rc
+npm ci
+cd ../../..
+dart run tool/testing/run_ts_2026_07_28_rc_interop.dart
 dart pub publish --dry-run
 dart pub global run pana --no-warning
 dart run tool/validate_cli_publish.dart
 ```
 
 The `run_2026_07_28_rc_server_conformance.dart` gate runs the full
-`@modelcontextprotocol/conformance@0.2.0-alpha.5` server scenario list for
+`@modelcontextprotocol/conformance@0.2.0-alpha.6` server scenario list for
 `--spec-version 2026-07-28`, including the stable-style tool, resource, prompt,
 completion, and JSON Schema scenarios that the alpha package tags for the RC.
 
-For cross-SDK smoke coverage against the TypeScript SDK 2026 preview client,
-run the manual fixture documented in
+For cross-SDK smoke coverage against the TypeScript SDK 2026 preview packages,
+run the fixture documented in
 [`doc/interoperability.md`](interoperability.md#running-interop-checks-locally).
-Keep that fixture out of CI until upstream publishes a 2026-07-28-compatible alpha
-package instead of requiring a `pkg.pr.new` branch preview.
+CI also runs it in the dedicated `Run MCP 2026-07-28 TypeScript Interop`
+workflow on relevant PRs, `dev/2026-07-28-rc` pushes, a daily schedule, and
+manual dispatch. Keep it pinned to the draft behavior rather than TypeScript
+preview behavior alone; re-pin from `pkg.pr.new` to a published TypeScript SDK
+alpha when upstream provides one.
 
 For dev packages, keep package documentation links pointed at
 `dev/2026-07-28-rc` until the draft work is ready to merge back to `main`.

--- a/doc/spec-coverage-2026-07-28-rc.md
+++ b/doc/spec-coverage-2026-07-28-rc.md
@@ -1,0 +1,65 @@
+# MCP 2026-07-28 Draft/RC Spec Coverage Matrix
+
+This matrix maps high-risk MCP `2026-07-28` draft/RC requirements to checked-in
+`mcp_dart` coverage. MCP `2025-11-25` remains the default runtime profile; this
+matrix only applies when callers opt into `McpProtocol.preview2026` or
+`McpProtocol.require2026`.
+
+The protocol is still draft/RC. Treat this as release-prep evidence for the
+`dev/2026-07-28-rc` branch, not as a final-spec guarantee.
+
+## Gates
+
+Run the official conformance gates from the repository root:
+
+```bash
+dart run test/conformance/run_2025_server_conformance.dart
+npx -y @modelcontextprotocol/conformance@0.2.0-alpha.6 client \
+  --command "dart run test/conformance/mcp_2026_07_28_rc_client.dart" \
+  --suite all \
+  --spec-version 2025-11-25
+dart run test/conformance/run_2026_07_28_rc_server_conformance.dart
+dart run test/conformance/run_2026_07_28_rc_client_conformance.dart
+```
+
+Run the TypeScript preview interop gate from the repository root:
+
+```bash
+cd test/interop/ts_2026_07_28_rc
+npm ci
+cd ../../..
+dart run tool/testing/run_ts_2026_07_28_rc_interop.dart
+```
+
+CI runs the official conformance gates in the core workflow. The
+`Run MCP 2026-07-28 TypeScript Interop` workflow runs the TypeScript preview
+interop fixture on relevant PRs, `dev/2026-07-28-rc` pushes, a daily schedule,
+and manual dispatch.
+
+## Matrix
+
+| Spec area | Draft source | Requirement tracked here | Local coverage | Cross-SDK coverage | Official conformance | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| Opt-in profile and stable default | [Versioning and compatibility](https://modelcontextprotocol.io/specification/draft/basic/versioning) | Stable MCP `2025-11-25` remains default, while 2026 behavior is selected explicitly with preview or require profiles. | [`test/mcp_2026_07_28_test.dart`](../test/mcp_2026_07_28_test.dart), [`doc/mcp-2026-07-28-rc.md`](mcp-2026-07-28-rc.md) | TypeScript preview interop uses explicit 2026 clients and servers only. | 2025 and 2026 conformance both run in CI. | Verified |
+| Version negotiation and discovery | [Discovery](https://modelcontextprotocol.io/specification/draft/server/discover), [Versioning](https://modelcontextprotocol.io/specification/draft/basic/versioning) | Servers implement `server/discover`, advertise supported versions and capabilities, reject unsupported versions with draft error data, and clients retry or fall back according to transport-era rules. | [`test/mcp_2026_07_28_test.dart`](../test/mcp_2026_07_28_test.dart), [`test/conformance/mcp_2026_07_28_rc_server.dart`](../test/conformance/mcp_2026_07_28_rc_server.dart), [`test/conformance/mcp_2026_07_28_rc_client.dart`](../test/conformance/mcp_2026_07_28_rc_client.dart) | [`tool/testing/run_ts_2026_07_28_rc_interop.dart`](../tool/testing/run_ts_2026_07_28_rc_interop.dart) validates TypeScript preview client -> Dart server and Dart preview client -> TypeScript preview server discovery. | `protocol-version`, `server/discover`, and client negotiation scenarios in alpha.6. | Verified |
+| Stateless request metadata | [Overview](https://modelcontextprotocol.io/specification/draft/basic), [Versioning](https://modelcontextprotocol.io/specification/draft/basic/versioning) | Every 2026 request carries protocol version, client identity, and client capabilities in `_meta`; servers do not infer protocol state from a prior request. | [`test/mcp_2026_07_28_test.dart`](../test/mcp_2026_07_28_test.dart), [`test/server/streamable_https_test.dart`](../test/server/streamable_https_test.dart) | TypeScript preview client fixture exercises normal request paths with 2026 metadata. | `stateless` and `stateless-http` scenarios in alpha.6. | Verified |
+| Streamable HTTP routing headers | [Key changes](https://modelcontextprotocol.io/specification/draft/changelog), [Transports](https://modelcontextprotocol.io/specification/draft/basic/transports) | 2026 HTTP POST requests include required protocol, method, name, and parameter-routing headers; mismatches reject with draft header errors. | [`test/mcp_2026_07_28_test.dart`](../test/mcp_2026_07_28_test.dart), [`test/server/streamable_https_test.dart`](../test/server/streamable_https_test.dart) | TypeScript preview client fixture validates `x-mcp-header` mirroring and raw header rejection against the Dart server. | `stateless-http.requires-routing-headers`, `stateless-http.validates-parameter-headers`, and related alpha.6 cases. | Verified |
+| Removed session and resumability behavior | [Key changes](https://modelcontextprotocol.io/specification/draft/changelog) | 2026 Streamable HTTP omits protocol-level sessions, rejects removed GET/DELETE behaviors, rejects JSON-RPC batches, and treats closed SSE response streams as request cancellation without legacy redelivery. | [`test/mcp_2026_07_28_test.dart`](../test/mcp_2026_07_28_test.dart), [`test/server/streamable_mcp_server_test.dart`](../test/server/streamable_mcp_server_test.dart) | TypeScript preview fixture closes the Dart SSE response stream and verifies no legacy `notifications/cancelled` side effect is required. | `stateless-http.rejects-non-post-methods`, `stateless-http.rejects-batch-payloads`, and related alpha.6 cases. | Verified |
+| Cacheable results and deterministic lists | [Key changes](https://modelcontextprotocol.io/specification/draft/changelog), [Discovery](https://modelcontextprotocol.io/specification/draft/server/discover) | `server/discover`, list, and read responses include `resultType`, `ttlMs`, and `cacheScope`; stateless `tools/list` is deterministic and omits stable-only tool execution metadata. | [`test/mcp_2026_07_28_test.dart`](../test/mcp_2026_07_28_test.dart), [`test/conformance/mcp_2026_07_28_rc_server.dart`](../test/conformance/mcp_2026_07_28_rc_server.dart) | TypeScript preview client fixture checks discovery cache metadata and `tools/list` cache metadata. | Cacheable-result and tools-list scenarios in alpha.6. | Verified |
+| Tools and JSON Schema 2020-12 | [Tools](https://modelcontextprotocol.io/specification/draft/server/tools), [Overview JSON Schema usage](https://modelcontextprotocol.io/specification/draft/basic) | Tool schemas preserve JSON Schema 2020-12 constructs, including nested boolean schemas; stable root-object compatibility remains intact for 2025 behavior. | [`test/tool_schema_test.dart`](../test/tool_schema_test.dart), [`test/mcp_2026_07_28_test.dart`](../test/mcp_2026_07_28_test.dart), [`test/conformance/mcp_2026_07_28_rc_server.dart`](../test/conformance/mcp_2026_07_28_rc_server.dart) | TypeScript preview fixture validates `tools/list` and `tools/call`; deeper schema semantics are covered by local and conformance tests. | 2026 server suite is green; 2026 client suite keeps the upstream `json-schema-ref-no-deref` fixture gap expected. | Verified with one upstream client fixture gap |
+| MRTR and elicitation | [Message patterns](https://modelcontextprotocol.io/specification/draft/basic) | 2026 `input_required` results are emitted only for supported requests and require advertised client capabilities. | [`test/mcp_2026_07_28_test.dart`](../test/mcp_2026_07_28_test.dart), [`test/elicitation_test.dart`](../test/elicitation_test.dart) | TypeScript preview client fixture completes a 2026 `input_required` retry flow against the Dart server. | `mrtr` scenarios in alpha.6. | Verified |
+| Subscriptions | [Subscriptions](https://modelcontextprotocol.io/specification/draft/basic/utilities/subscriptions) | `subscriptions/listen` acknowledges before list-change notifications, filters unsupported notification types, and correlates notifications through `io.modelcontextprotocol/subscriptionId`. | [`test/mcp_2026_07_28_test.dart`](../test/mcp_2026_07_28_test.dart), [`test/conformance/mcp_2026_07_28_rc_server.dart`](../test/conformance/mcp_2026_07_28_rc_server.dart) | TypeScript preview fixture validates `subscriptions/listen` acknowledgment and list-change notification correlation against the Dart server. | Subscription scenarios in alpha.6. | Verified |
+| Request-scoped logging and removed core RPCs | [Logging](https://modelcontextprotocol.io/specification/draft/server/utilities/logging), [Key changes](https://modelcontextprotocol.io/specification/draft/changelog) | 2026 stateless requests use request-scoped logging metadata, and removed stable-era core RPCs/notifications are rejected in the 2026 profile. | [`test/mcp_2026_07_28_test.dart`](../test/mcp_2026_07_28_test.dart), [`test/server/server_advanced_test.dart`](../test/server/server_advanced_test.dart) | TypeScript preview fixture validates raw removed-RPC rejection against the Dart server. | Removed-RPC and logging scenarios in alpha.6. | Verified |
+| Draft-only public APIs | [Schema reference](https://modelcontextprotocol.io/specification/draft/schema) | APIs that are useful only for 2026, such as non-object structured tool output and 2026 protocol profiles, are documented as draft/RC APIs and do not change stable defaults. | [`doc/mcp-2026-07-28-rc.md`](mcp-2026-07-28-rc.md), public dartdoc on protocol profiles and draft-only helpers. | Not cross-SDK specific. | Covered indirectly by 2026 conformance and local parser/serializer tests. | Verified |
+
+## Known Gaps
+
+- The official conformance package is still alpha. The 2026 client suite keeps
+  `json-schema-ref-no-deref` expected-failed because the alpha.6 mock server for
+  that scenario still behaves like a stable-only server.
+- The TypeScript 2026-07-28 fixture depends on `pkg.pr.new` preview artifacts
+  from the TypeScript SDK branch. Keep the CI workflow, but re-pin it to a
+  published alpha package once upstream provides one.
+- The reverse Dart preview client -> TypeScript preview server path currently
+  covers discovery, `tools/list`, and `tools/call`. Broader reverse-path
+  coverage should follow as the TypeScript preview server surface stabilizes.

--- a/test/conformance/2026_07_28_rc_client_expected_failures.txt
+++ b/test/conformance/2026_07_28_rc_client_expected_failures.txt
@@ -1,10 +1,10 @@
-# Expected failures for @modelcontextprotocol/conformance@0.2.0-alpha.5
+# Expected failures for @modelcontextprotocol/conformance@0.2.0-alpha.6
 # against the 2026-07-28 RC/DRAFT client suite.
 #
 # Keep this list scenario-based so the baseline is easy to review. When a
 # scenario turns green, remove it from this file in the same PR as the fix.
 #
-# Upstream alpha.5 fixture gap: this scenario's mock server still rejects
+# Upstream alpha.6 fixture gap: this scenario's mock server still rejects
 # 2026-07-28 with HTTP 400 and advertises only stable protocol versions.
 # Keep it expected-fail until the conformance fixture is draft-capable.
 json-schema-ref-no-deref

--- a/test/conformance/2026_07_28_rc_expected_failures.txt
+++ b/test/conformance/2026_07_28_rc_expected_failures.txt
@@ -1,4 +1,4 @@
-# Expected failures for @modelcontextprotocol/conformance@0.2.0-alpha.5
+# Expected failures for @modelcontextprotocol/conformance@0.2.0-alpha.6
 # against the full 2026-07-28 RC/DRAFT server suite.
 #
 # Keep this list scenario-based so the baseline is easy to review. When a

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -26,14 +26,14 @@ dart run test/conformance/run_2025_server_conformance.dart
 ```
 
 The runner starts `mcp_2025_server.dart`, runs
-`@modelcontextprotocol/conformance@0.2.0-alpha.5 server --suite all
+`@modelcontextprotocol/conformance@0.2.0-alpha.6 server --suite all
 --spec-version 2025-11-25`, and writes artifacts under
 `.dart_tool/conformance/2025_server/`.
 
 Run the stable client suite from the repository root:
 
 ```bash
-npx -y @modelcontextprotocol/conformance@0.2.0-alpha.5 client \
+npx -y @modelcontextprotocol/conformance@0.2.0-alpha.6 client \
   --command "dart run test/conformance/mcp_2026_07_28_rc_client.dart" \
   --suite all \
   --spec-version 2025-11-25 \
@@ -55,14 +55,14 @@ dart run test/conformance/run_2026_07_28_rc_server_conformance.dart
 
 The runner starts a local `StreamableMcpServer` in default Streamable HTTP SSE
 response mode, runs the full `2026-07-28` server scenario list from
-`@modelcontextprotocol/conformance@0.2.0-alpha.5` one by one with `--suite all`
+`@modelcontextprotocol/conformance@0.2.0-alpha.6` one by one with `--suite all`
 and `--spec-version 2026-07-28`, and writes per-run artifacts under
 `.dart_tool/conformance/2026_07_28_rc/`.
 
 Expected failures live in `2026_07_28_rc_expected_failures.txt`. When a scenario is
 fixed, remove it from that file so the baseline remains useful.
 
-As of `@modelcontextprotocol/conformance@0.2.0-alpha.5`, the full 2026-07-28 RC server
+As of `@modelcontextprotocol/conformance@0.2.0-alpha.6`, the full 2026-07-28 RC server
 suite has no expected failures against the Dart fixture.
 
 Run the current client baseline from the repository root:

--- a/test/conformance/run_2025_server_conformance.dart
+++ b/test/conformance/run_2025_server_conformance.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 const _defaultConformancePackage =
-    '@modelcontextprotocol/conformance@0.2.0-alpha.5';
+    '@modelcontextprotocol/conformance@0.2.0-alpha.6';
 const _defaultTimeout = Duration(seconds: 60);
 
 Future<void> main(List<String> args) async {

--- a/test/conformance/run_2026_07_28_rc_client_conformance.dart
+++ b/test/conformance/run_2026_07_28_rc_client_conformance.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 const _defaultConformancePackage =
-    '@modelcontextprotocol/conformance@0.2.0-alpha.5';
+    '@modelcontextprotocol/conformance@0.2.0-alpha.6';
 const _defaultTimeout = Duration(seconds: 30);
 
 const _draftClientScenarios = [

--- a/test/conformance/run_2026_07_28_rc_server_conformance.dart
+++ b/test/conformance/run_2026_07_28_rc_server_conformance.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 const _defaultConformancePackage =
-    '@modelcontextprotocol/conformance@0.2.0-alpha.5';
+    '@modelcontextprotocol/conformance@0.2.0-alpha.6';
 const _defaultTimeout = Duration(seconds: 25);
 
 const _serverScenarios = [
@@ -406,7 +406,8 @@ class _Options {
     int? port;
     String? scenario;
     String? outputDir;
-    var expectedFailuresPath = 'test/conformance/2026_07_28_rc_expected_failures.txt';
+    var expectedFailuresPath =
+        'test/conformance/2026_07_28_rc_expected_failures.txt';
     var conformancePackage = _defaultConformancePackage;
     var timeout = _defaultTimeout;
 

--- a/test/interop/ts_2026_07_28_rc/README.md
+++ b/test/interop/ts_2026_07_28_rc/README.md
@@ -64,6 +64,8 @@ only the draft-permitted primitive types: `string`, `integer`, and `boolean`.
 When TypeScript preview behavior conflicts with the draft, keep the draft as the
 assertion source and document the preview gap near the test.
 
-Keep this as a manual, non-blocking check until the TypeScript SDK publishes a
-stable 2026-07-28-compatible alpha package instead of requiring `pkg.pr.new` preview
-artifacts.
+CI runs this fixture in the dedicated
+`Run MCP 2026-07-28 TypeScript Interop` workflow for relevant PRs,
+`dev/2026-07-28-rc` pushes, daily scheduled drift checks, and manual dispatch.
+Keep the fixture pinned to a published TypeScript SDK alpha once upstream no
+longer requires `pkg.pr.new` preview artifacts.

--- a/test/interop/ts_2026_07_28_rc/package.json
+++ b/test/interop/ts_2026_07_28_rc/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Manual TypeScript SDK 2026-07-28 RC interop fixture for mcp_dart.",
+  "description": "TypeScript SDK 2026-07-28 RC interop fixture for mcp_dart.",
   "scripts": {
     "client": "node src/client.mjs"
   },

--- a/tool/testing/run_ts_2026_07_28_rc_interop.dart
+++ b/tool/testing/run_ts_2026_07_28_rc_interop.dart
@@ -103,7 +103,9 @@ Future<void> _runTsClientAgainstDartServer(
     await Future.wait([clientStdout, clientStderr]);
 
     if (clientExit != 0) {
-      throw StateError('TypeScript 2026-07-28 RC client exited with $clientExit');
+      throw StateError(
+        'TypeScript 2026-07-28 RC client exited with $clientExit',
+      );
     }
   } finally {
     await _terminate(server);
@@ -151,7 +153,10 @@ Future<void> _runDartClientAgainstTsServer(
 Future<void> _exerciseDartClient(String url) async {
   final transport = StreamableHttpClientTransport(Uri.parse(url));
   final client = McpClient(
-    const Implementation(name: 'mcp-dart-2026-07-28-rc-client', version: '0.0.0'),
+    const Implementation(
+      name: 'mcp-dart-2026-07-28-rc-client',
+      version: '0.0.0',
+    ),
     options: const McpClientOptions(
       protocol: McpProtocol.preview2026,
       capabilities: ClientCapabilities(),


### PR DESCRIPTION
## Summary

- Update official conformance package pins and docs to `@modelcontextprotocol/conformance@0.2.0-alpha.6`.
- Add a dedicated TypeScript SDK 2026-07-28 RC interop workflow for relevant PRs, `dev/2026-07-28-rc` pushes, daily schedule, and manual dispatch.
- Add an MCP 2026-07-28 draft/RC spec coverage matrix linking local tests, official conformance, and TypeScript preview interop evidence.

## Validation

- `dart format .`
- `npm ci` in `test/interop/ts_2026_07_28_rc`
- `dart run test/conformance/run_2025_server_conformance.dart --timeout-seconds 90 --output-dir .dart_tool/conformance/alpha6_2025_server` - 49 passed, 0 failed
- `npx -y @modelcontextprotocol/conformance@0.2.0-alpha.6 client --command "dart run test/conformance/mcp_2026_07_28_rc_client.dart" --suite all --spec-version 2025-11-25 --verbose -o .dart_tool/conformance/alpha6_2025_client` - 221 passed, 0 failed
- `dart run test/conformance/run_2026_07_28_rc_server_conformance.dart --timeout-seconds 90 --output-dir .dart_tool/conformance/alpha6_2026_server` - 40 passed, 0 failed/timeout
- `dart run test/conformance/run_2026_07_28_rc_client_conformance.dart --timeout-seconds 90 --output-dir .dart_tool/conformance/alpha6_2026_client` - 31 passed, 1 expected failure (`json-schema-ref-no-deref` upstream fixture gap)
- `dart run tool/testing/run_ts_2026_07_28_rc_interop.dart`
- `dart analyze`
- `dart test test/docs/markdown_docs_test.dart`
- `dart test` - 1433 passed
- `dart pub publish --dry-run` - 0 warnings
