### PR TITLE
docs: clarify TypeScript alpha interop blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Conformance and interoperability
 
+- Documented that published TypeScript SDK `2.0.0-alpha.3` packages are not yet
+  valid replacements for the `pkg.pr.new` 2026-07-28 RC interop fixture because
+  the alpha.3 client is missing the preview negotiation API used by the fixture.
 - Updated official conformance gates to
   `@modelcontextprotocol/conformance@0.2.0-alpha.7`. The 2026-07-28 RC server suite
   now has no expected failures; the 2026 client suite keeps only the upstream

--- a/doc/interoperability.md
+++ b/doc/interoperability.md
@@ -61,6 +61,14 @@ This starts the Dart 2026-07-28 RC conformance server, runs the pinned TypeScrip
 preview client against it, then runs the reverse Dart preview client smoke check
 against the TypeScript preview server.
 
+Published `@modelcontextprotocol/client@2.0.0-alpha.3` and
+`@modelcontextprotocol/server@2.0.0-alpha.3` packages are not yet suitable
+replacements for this fixture: the published alpha.3 client does not expose the
+preview `versionNegotiation` / `getProtocolEra` APIs used here, and a direct
+`supportedProtocolVersions: ["2026-07-28"]` repin fails the handshake. Keep the
+`pkg.pr.new` pin until a published TypeScript SDK package exposes the 2026 draft
+path and this interop runner passes against it.
+
 CI also runs this fixture in the dedicated
 `Run MCP 2026-07-28 TypeScript Interop` workflow for relevant PRs,
 `dev/2026-07-28-rc` pushes, daily scheduled drift checks, and manual dispatch.
@@ -89,8 +97,10 @@ When adding a new interoperability claim:
 
 - Automated Python SDK fixture coverage.
 - Re-pin the TypeScript 2026-07-28 RC interop fixture to a published upstream
-  alpha package once the TypeScript SDK no longer requires `pkg.pr.new`
-  previews.
+  alpha package once that package exposes the 2026 draft path. The published
+  `@modelcontextprotocol/client/server@2.0.0-alpha.3` packages are not enough
+  because the client is missing the preview negotiation API used by this
+  fixture.
 - Broader reverse-path TypeScript preview server coverage beyond discovery,
   `tools/list`, and `tools/call`.
 - Host-specific MCP Apps rendering compatibility notes.

--- a/doc/mcp-2026-07-28-rc.md
+++ b/doc/mcp-2026-07-28-rc.md
@@ -158,7 +158,10 @@ CI also runs it in the dedicated `Run MCP 2026-07-28 TypeScript Interop`
 workflow on relevant PRs, `dev/2026-07-28-rc` pushes, a daily schedule, and
 manual dispatch. Keep it pinned to the draft behavior rather than TypeScript
 preview behavior alone; re-pin from `pkg.pr.new` to a published TypeScript SDK
-alpha when upstream provides one.
+alpha only when the published package advertises `2026-07-28` support. The
+published `@modelcontextprotocol/client/server@2.0.0-alpha.3` packages are
+missing the preview negotiation API used by this fixture, so they are not a
+replacement for the current preview pin.
 
 For dev packages, keep package documentation links pointed at
 `dev/2026-07-28-rc` until the draft work is ready to merge back to `main`.

--- a/doc/spec-coverage-2026-07-28-rc.md
+++ b/doc/spec-coverage-2026-07-28-rc.md
@@ -59,7 +59,10 @@ and manual dispatch.
   that scenario still behaves like a stable-only server.
 - The TypeScript 2026-07-28 fixture depends on `pkg.pr.new` preview artifacts
   from the TypeScript SDK branch. Keep the CI workflow, but re-pin it to a
-  published alpha package once upstream provides one.
+  published alpha package once upstream provides one that advertises the 2026
+  draft path. The published `@modelcontextprotocol/client/server@2.0.0-alpha.3`
+  packages are missing the preview negotiation API used by this fixture, so
+  they are not a valid replacement for the current preview pin.
 - The reverse Dart preview client -> TypeScript preview server path currently
   covers discovery, `tools/list`, and `tools/call`. Broader reverse-path
   coverage should follow as the TypeScript preview server surface stabilizes.

--- a/test/interop/ts_2026_07_28_rc/README.md
+++ b/test/interop/ts_2026_07_28_rc/README.md
@@ -68,4 +68,10 @@ CI runs this fixture in the dedicated
 `Run MCP 2026-07-28 TypeScript Interop` workflow for relevant PRs,
 `dev/2026-07-28-rc` pushes, daily scheduled drift checks, and manual dispatch.
 Keep the fixture pinned to a published TypeScript SDK alpha once upstream no
-longer requires `pkg.pr.new` preview artifacts.
+longer requires `pkg.pr.new` preview artifacts. Do not treat publication alone
+as enough to re-pin: `@modelcontextprotocol/client@2.0.0-alpha.3` and
+`@modelcontextprotocol/server@2.0.0-alpha.3` are published, but the published
+client does not expose the preview `versionNegotiation` / `getProtocolEra` APIs
+used here, and a direct `supportedProtocolVersions: ["2026-07-28"]` repin fails
+the handshake. Keep this fixture on the `pkg.pr.new` preview until a published
+package exposes the 2026 draft path and this runner passes against it.


### PR DESCRIPTION
## Summary
- Documents that published `@modelcontextprotocol/client/server@2.0.0-alpha.3` are not yet valid replacements for the 2026-07-28 RC TypeScript interop fixture.
- Keeps the guidance on the current `pkg.pr.new` preview pin until a published TypeScript SDK package exposes the preview negotiation APIs and passes the runner.
- Updates the interoperability docs, RC coverage matrix, fixture README, and changelog so future drift checks do not recommend an unsafe re-pin from publication alone.

## Existing issue check
- Searched existing issues and PRs for `TypeScript alpha.3 pkg.pr.new 2026 interop` and `versionNegotiation getProtocolEra alpha.3`; no matching dedicated issue/PR found.

## Test Plan
- [x] `npm ci` in `test/interop/ts_2026_07_28_rc`
- [x] `git diff --check`
- [x] `dart analyze`
- [x] `dart run tool/testing/run_ts_2026_07_28_rc_interop.dart`
- [x] `dart test`

## Notes
A direct attempted re-pin to `@modelcontextprotocol/client/server@2.0.0-alpha.3` was rejected: the published client is missing the preview `versionNegotiation` / `getProtocolEra` APIs used by the fixture, and a direct `supportedProtocolVersions: ["2026-07-28"]` handshake fails. The package files are therefore left unchanged in this PR.