### PR TITLE
test: update 2026 TypeScript interop to beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   `@modelcontextprotocol/conformance@0.2.0-alpha.9`, including the stricter
   `MissingRequiredClientCapability` `requiredCapabilities` object assertion in
   the 2026 stateless server suite.
+- Updated the TypeScript SDK 2026-07-28 RC interop fixture to published
+  `@modelcontextprotocol/client@2.0.0-beta.2` and
+  `@modelcontextprotocol/server@2.0.0-beta.2` packages after verifying both
+  Dart -> TypeScript and TypeScript -> Dart 2026 draft/RC paths.
 - Re-pinned the TypeScript SDK 2026-07-28 RC interop fixture from `pkg.pr.new`
   previews to published `@modelcontextprotocol/client@2.0.0-beta.1` and
   `@modelcontextprotocol/server@2.0.0-beta.1` packages after verifying both

--- a/doc/interoperability.md
+++ b/doc/interoperability.md
@@ -63,8 +63,8 @@ against the TypeScript SDK beta server.
 
 The fixture previously depended on `pkg.pr.new` artifacts because published
 `2.0.0-alpha.3` packages did not expose the preview negotiation API used here.
-`@modelcontextprotocol/client@2.0.0-beta.1` and
-`@modelcontextprotocol/server@2.0.0-beta.1` expose the required modern path and
+`@modelcontextprotocol/client@2.0.0-beta.2` and
+`@modelcontextprotocol/server@2.0.0-beta.2` expose the required modern path and
 the interop runner passes against them.
 
 CI also runs this fixture in the dedicated

--- a/doc/mcp-2026-07-28-rc.md
+++ b/doc/mcp-2026-07-28-rc.md
@@ -158,8 +158,8 @@ CI also runs it in the dedicated `Run MCP 2026-07-28 TypeScript Interop`
 workflow on relevant PRs, `dev/2026-07-28-rc` pushes, a daily schedule, and
 manual dispatch. Keep it pinned to the draft behavior rather than TypeScript
 preview behavior alone. The fixture is currently pinned to published
-`@modelcontextprotocol/client@2.0.0-beta.1` and
-`@modelcontextprotocol/server@2.0.0-beta.1`, which expose the 2026 negotiation
+`@modelcontextprotocol/client@2.0.0-beta.2` and
+`@modelcontextprotocol/server@2.0.0-beta.2`, which expose the 2026 negotiation
 path and pass the checked-in interop runner.
 
 For dev packages, keep package documentation links pointed at

--- a/test/interop/ts_2026_07_28_rc/README.md
+++ b/test/interop/ts_2026_07_28_rc/README.md
@@ -6,8 +6,8 @@ progress.
 
 It is intentionally separate from `test/interop/ts`, which tracks the published
 stable TypeScript SDK and MCP `2025-11-25` behavior. The fixture pins published
-`@modelcontextprotocol/client@2.0.0-beta.1` and
-`@modelcontextprotocol/server@2.0.0-beta.1` packages. The TypeScript client path
+`@modelcontextprotocol/client@2.0.0-beta.2` and
+`@modelcontextprotocol/server@2.0.0-beta.2` packages. The TypeScript client path
 is a draft-aligned smoke check against the Dart 2026-07-28 RC server. The
 reverse Dart client path is a draft-aligned smoke check against the TypeScript
 beta server.

--- a/test/interop/ts_2026_07_28_rc/package-lock.json
+++ b/test/interop/ts_2026_07_28_rc/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@cfworker/json-schema": "4.1.1",
-        "@modelcontextprotocol/client": "2.0.0-beta.1",
-        "@modelcontextprotocol/server": "2.0.0-beta.1"
+        "@modelcontextprotocol/client": "2.0.0-beta.2",
+        "@modelcontextprotocol/server": "2.0.0-beta.2"
       },
       "engines": {
         "node": ">=20"
@@ -23,9 +23,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/client": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0-beta.1.tgz",
-      "integrity": "sha512-1YbnguKN7OFGA/lmCtgIthyE5d+j7dvu7hJld+f0mKrM0YAV4Q8TG80RBto+qyupxhHjTMEWItHu7cQlAmVtyA==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0-beta.2.tgz",
+      "integrity": "sha512-IKEJQmvM2g7HLSOofLXECjQyeryB1YWgjazHcYygyH3ERSe7b8cFS3WHlupMxees5URNXcqBLVlbDRgodaBQ9A==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.5",
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/server": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-beta.1.tgz",
-      "integrity": "sha512-83scKauajX9fWbSIC4NBYdnvXajH+cqvX8QqsrPH0XNgqtMmym1kWucMO7YyNkrBD9C7/R+FRCmkjC9kgEKXlQ==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-beta.2.tgz",
+      "integrity": "sha512-XK+sgFntT5ZzeqtTGpT9uti+Sqmq7YJZdx/N76eLJv9UA9vKvP04Qh9Hc45LCeIHGfTKRwDG6eh4C1Hs4omyIg==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.2.0"

--- a/test/interop/ts_2026_07_28_rc/package.json
+++ b/test/interop/ts_2026_07_28_rc/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@cfworker/json-schema": "4.1.1",
-    "@modelcontextprotocol/client": "2.0.0-beta.1",
-    "@modelcontextprotocol/server": "2.0.0-beta.1"
+    "@modelcontextprotocol/client": "2.0.0-beta.2",
+    "@modelcontextprotocol/server": "2.0.0-beta.2"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary
- Updates the 2026-07-28 RC TypeScript SDK interop fixture from `@modelcontextprotocol/client` / `@modelcontextprotocol/server` `2.0.0-beta.1` to the published `2.0.0-beta.2` packages.
- Refreshes the package lock plus interop docs, RC transition guide, fixture README, and changelog so the documented pin matches the executable fixture.

## Upstream evidence
- `npm view @modelcontextprotocol/client@2.0.0-beta.2 version exports --json` confirms the beta.2 client package is published and still exposes the root import used by `test/interop/ts_2026_07_28_rc/src/client.mjs`.
- `npm view @modelcontextprotocol/server@2.0.0-beta.2 version exports --json` confirms the beta.2 server package is published and still exposes the root import used by `test/interop/ts_2026_07_28_rc/src/server.mjs`.
- Official TypeScript SDK release tags show `@modelcontextprotocol/client@2.0.0-beta.2` and `@modelcontextprotocol/server@2.0.0-beta.2` published on 2026-07-02.

## Existing issue check
- Searched issues and PRs for `2.0.0-beta.2`, `@modelcontextprotocol/client beta.2`, `@modelcontextprotocol/server beta.2`, `TypeScript SDK beta.2`, and `ts_2026_07_28_rc`.
- No dedicated open issue or PR already tracks the beta.2 fixture bump. Closest prior work is merged PR #298, which moved the fixture to beta.1.

## Test Plan
- [x] `cd test/interop/ts_2026_07_28_rc && npm ci`
- [x] package verification: installed `@modelcontextprotocol/client` and `@modelcontextprotocol/server` both report `2.0.0-beta.2`
- [x] `dart test test/docs/markdown_docs_test.dart`
- [x] `dart run tool/testing/run_ts_2026_07_28_rc_interop.dart`
- [x] `dart analyze`
- [x] `git diff --check origin/dev/2026-07-28-rc...HEAD`
