### PR TITLE
chore: update Jaspr example to 0.23.2

### DIFF
--- a/.github/workflows/test_core.yml
+++ b/.github/workflows/test_core.yml
@@ -367,7 +367,7 @@ jobs:
         run: dart analyze
 
       - name: Install Jaspr CLI
-        run: dart pub global activate jaspr_cli 0.22.3
+        run: dart pub global activate jaspr_cli 0.23.2
 
       - name: Build production bundle
         working-directory: example/jaspr-client

--- a/example/jaspr-client/README.md
+++ b/example/jaspr-client/README.md
@@ -20,7 +20,7 @@ A modern, web-based MCP (Model Context Protocol) client built with [Jaspr](https
 ## Prerequisites
 
 - Dart 3.10 or later
-- Jaspr CLI 0.22.3 (`dart pub global activate jaspr_cli 0.22.3`)
+- Jaspr CLI 0.23.2 (`dart pub global activate jaspr_cli 0.23.2`)
 
 ## Quick Start
 

--- a/example/jaspr-client/pubspec.yaml
+++ b/example/jaspr-client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
-  jaspr: ^0.22.0
+  jaspr: ^0.23.2
   mcp_dart:
     path: ../..
   web: ^1.1.1
@@ -15,8 +15,9 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.10.0
   build_web_compilers: ^4.4.6
-  jaspr_builder: ^0.22.0
+  jaspr_builder: ^0.23.2
   lints: ^6.1.0
 
 jaspr:
   mode: client
+  styles: standalone


### PR DESCRIPTION
## What changed

- Upgrade the Jaspr example to `jaspr` and `jaspr_builder` 0.23.2.
- Use `jaspr_cli` 0.23.2 in CI and in the example prerequisites.
- Configure standalone styles explicitly for client mode.

## Why

Dependabot PRs #318 and #319 contained the same partial upgrade. Both failed because CI still installed Jaspr CLI 0.22.3, which rejects a 0.23.2 project. This coordinated update keeps the framework, builder, CLI, configuration, and docs aligned.

This supersedes #318 and #319. It does not change the published Dart SDK or CLI.

## Validation

- `dart pub get`
- `dart analyze`
- `jaspr --version` reports 0.23.2
- Production `jaspr build`
- YAML parsing
- `git diff --check`