### PR TITLE
Fix interop server error disclosure

### DIFF
--- a/test/interop/ts_2026_07_28/src/server.mjs
+++ b/test/interop/ts_2026_07_28/src/server.mjs
@@ -219,11 +219,13 @@ async function main() {
       const webResponse = await handler.fetch(webRequest);
       await writeWebResponse(webResponse, res);
     } catch (error) {
-      console.error(error);
-      if (!res.headersSent) {
-        res.writeHead(500);
+      console.error('TypeScript interop request failed', error);
+      if (res.headersSent) {
+        res.destroy();
+        return;
       }
-      res.end(String(error));
+      res.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end('Internal Server Error');
     }
   });
 


### PR DESCRIPTION
## Summary

- keep TypeScript interop request failures in server-side logs
- return a fixed generic HTTP 500 response before headers are sent
- destroy an already-started response instead of appending exception details

## Why

CodeQL alert #13 identified that the TypeScript MCP 2026-07-28 interop server returned `String(error)` to the HTTP client. That could disclose stack or implementation details. The fixture now preserves diagnostics in its server log without exposing them over the wire.

## Impact

This changes only the TypeScript interoperability test fixture. It does not change the Dart SDK API, protocol behavior, package dependencies, or compatibility surface.

## Validation

- `node --check test/interop/ts_2026_07_28/src/server.mjs`
- `dart analyze`
- `dart test test/tool/run_ts_2026_07_28_interop_test.dart`
- `dart run tool/testing/run_ts_2026_07_28_interop.dart --direction=dart-to-ts`
- `git diff --check`

After merge, the next default-branch CodeQL analysis should mark security alert #13 fixed.