### PR TITLE
fix(deps): override vulnerable Hono interop dependency

### DIFF
--- a/test/interop/ts/package-lock.json
+++ b/test/interop/ts/package-lock.json
@@ -157,12 +157,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/test/interop/ts/package.json
+++ b/test/interop/ts/package.json
@@ -28,6 +28,9 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0"
   },
+  "overrides": {
+    "@hono/node-server": "2.0.11"
+  },
   "engines": {
     "node": ">=24"
   }


### PR DESCRIPTION
## Summary

- override the TypeScript interoperability fixture's transitive `@hono/node-server` dependency to `2.0.11`
- regenerate the fixture lockfile with the patched release
- keep the published MCP TypeScript SDK fixture at `1.29.0`

## Why

`@modelcontextprotocol/sdk` 1.29.0 currently requests `@hono/node-server ^1.19.9`, but every Hono Node server version below 2.0.5 is affected by GHSA-frvp-7c67-39w9. The fixture already requires Node 24, so the patched package's Node 20 minimum is compatible.

This dependency is confined to repository interoperability tests. The change does not affect the Dart SDK package dependency graph, public API, minimum Dart version, or MCP wire behavior.

## Validation

- `npm ci`
- `npm audit --audit-level=low` — 0 vulnerabilities
- `npm ls @modelcontextprotocol/sdk @hono/node-server fast-uri`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `dart test -t interop` — 24 passed
- `dart analyze`
- `dart test` — 1,935 passed
- CLI TypeScript interoperability E2E — 7 passed; 5 optional Python scenarios skipped because the local Python SDK environment is not installed

Closes the remaining Dependabot alert for GHSA-frvp-7c67-39w9.
