### PR TITLE
Document the 2.2 to 2.3 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,201 +1,119 @@
 ## Unreleased
 
+`mcp_dart 2.3` adds the MCP `2026-07-28` release-candidate surface while
+preserving the public `2.2.2` API. See the
+[2.2 to 2.3 migration guide](doc/migration-2.2-to-2.3.md) for upgrade steps and
+the [MCP 2026-07-28 transition guide](doc/mcp-2026-07-28.md) for protocol
+details.
+
+### Added
+
+- Added an SDK-owned offline validator with public Draft 2020-12 and declared
+  Draft 7 APIs, removing the `json_schema` and `quiver` dependencies.
+- Added dual-era protocol profiles, `server/discover`, stateless metadata,
+  `subscriptions/listen`, multi-round tool/resource/prompt callbacks, the
+  independent Tasks extension, and any-root structured tool results for MCP
+  `2026-07-28`.
+- Added stateless registration helpers and a backward-compatible
+  `RegisteredStatelessTool` handle without widening the existing 2.2.2
+  registration interfaces.
+
 ### Changed
 
-- Removed the `json_schema` and `quiver` package dependencies in favor of an
-  SDK-owned offline validator, preserving public validation APIs, Draft 2020-12
-  and Draft 7 semantics, and canonical meta-schema references. Draft 7 format
-  checks and validation diagnostics are now stricter and more precise.
-- Preserved the `2.2.2` registration, callback, logging, request metadata, and
-  `StartSseOptions` APIs, with additive `registerStatelessTool`,
-  `registerStatelessPrompt`, `registerStatelessResource`, and
-  `registerStatelessResourceTemplate` helpers for MCP `2026-07-28` multi-round
-  results.
-- Preserved the `2.2.2` values of `latestProtocolVersion` and
+- `McpProtocol.stable` now prefers MCP `2026-07-28` and falls back to legacy
+  initialization. Silent body-only discovery probes are bounded to five
+  seconds; `McpProtocol.legacy` retains exact initialization-only behavior.
+- Preserved the 2.2.2 values of `latestProtocolVersion` and
   `supportedProtocolVersions`; use `defaultProtocolVersion` and
-  `allSupportedProtocolVersions` for the dual-era default profile.
-- Bounded silent `server/discover` probes to five seconds on body-only
-  transports before legacy fallback. HTTP discovery keeps its normal request
-  timeout, and `McpProtocol.legacy` remains the exact initialization-only
-  opt-in.
-- Hardened newline-delimited transports so malformed frames no longer strand
-  later messages in the same input chunk. Stdio servers now return the
-  appropriate JSON-RPC parse, invalid-request, or invalid-params error while
-  preserving valid request IDs and never replying to notifications or
-  responses.
-- Locked each accepted server connection to its first negotiated protocol era;
-  switching between stateless requests and the legacy initialize lifecycle now
-  requires a fresh connection.
-- Aligned MCP `2026-07-28` identity with spec PR #3002: client identity is
-  optional, and servers stamp validated identity in successful stateless result
-  `_meta` by default instead of the discovery body. A handler `null` omits the
-  optional key; received canonical `null` or malformed identities are rejected.
-- Applied era-aware MCP `2026-07-28` capability parsing: known capability
-  members must be JSON objects, removed legacy names remain valid open-ended
-  capability data, and legacy initialization boolean compatibility is unchanged.
-- Hardened raw JSON-RPC decoding by requiring IDs for built-in request methods,
-  validating `tools/list` cursors before dispatch, and enforcing 2026 request
-  metadata under `params._meta` while preserving legacy metadata and extension
-  notifications.
-- Required the logging notification `data` member on parsed wire messages while
-  continuing to accept its valid explicit JSON `null` value.
+  `allSupportedProtocolVersions` for the dual-era profile.
+- Hardened JSON-RPC parsing, protocol-era isolation, capability and metadata
+  validation, request direction, notification routing, and error-code mapping
+  while preserving legacy wire behavior.
+- Aligned stateless identity, discovery caching, tracing metadata,
+  request-scoped logging, and required client capabilities with MCP
+  `2026-07-28`.
 - Hardened OAuth discovery and authorization-code flows with exact issuer
-  matching, safe redirect URIs, client registration priority, challenge
-  parsing, token-endpoint authentication, issuer/resource-bound tokens, and
-  persisted scope accumulation.
-- Rejected MCP `2026-07-28` client-to-server JSON-RPC response POSTs, response
-  batches, mismatched request-scoped response IDs, and non-terminal HTTP `202`
-  request responses before dispatch, while retaining MCP `2025-11-25`
-  compatibility.
-- Made Streamable HTTP validation advertise only the connected server's
-  configured protocol profile, reject wire cancellation and known
-  wrong-direction notifications in stateless mode while preserving extension
-  notification methods, require the exact `application/json` request media
-  type, and classify valid JSON with malformed request parameters as
-  `invalidParams` instead of `parseError`.
-- Made `DiscoverResult` always emit and require the MCP `2026-07-28`
-  `ttlMs` and `cacheScope` fields, serializing omitted or null local hints as
-  immediately stale private caching.
-- Blocked legacy server-initiated request helpers and direct stateless client
-  response sends under MCP `2026-07-28`; legacy sessions retain their existing
-  bidirectional request flow.
-- Kept global resource, tool, prompt, and logging notification helpers scoped
-  to legacy sessions. Stateless list and resource updates use acknowledged
-  `subscriptions/listen` streams; request-scoped logging must include the
-  originating request ID when routed over Streamable HTTP.
-- Enforced tool `io.modelcontextprotocol/requiredClientCapabilities` metadata
-  consistently across Streamable HTTP, stdio, and custom transports.
-- Validated reserved `traceparent`, `tracestate`, and `baggage` metadata values
-  against their W3C wire formats under MCP `2026-07-28`.
-- Exported the JSON Schema validator through the public SDK barrel and retained
-  Draft 2020-12 and declared Draft 7 validation.
-- Aligned registered-tool input validation with the MCP error taxonomy:
-  arguments that do not satisfy a tool's `inputSchema` now return a
-  `CallToolResult` with `isError: true`, allowing models to correct and retry
-  the call under MCP `2025-11-25` and `2026-07-28`. Under those versions,
-  invalid output from a locally registered tool now reports JSON-RPC
-  `internalError` instead of blaming client params.
-- Hardened structured tool-result contracts across direct and task-backed
-  calls: output schemas are compiled before handler side effects, completed
-  task results use the immutable schema captured at acceptance whether polled
-  or notified, and initialization-era clients retain only object-root
-  structured content.
-- Aligned the Tasks extension with its independent wire contract: creation
-  results carry the base task shape, polling and notifications carry exact
-  status-specific details, task methods and embedded input requests enforce
-  per-request capabilities, and legacy task APIs stay protocol-isolated.
-- Enforced one in-scope acknowledgment and boundary-safe resource and
-  sub-resource URI matching for every `subscriptions/listen` request, buffered
-  a bounded number of early events until the first listener attaches, and made
-  stateless stdio clients recover bounded repeated child exits and broken
-  process pipes, with TERM-to-KILL cleanup, while restoring acknowledged
-  subscriptions without replaying ordinary requests. Changed replay filters are
-  exposed through
-  `McpSubscription.acknowledgmentChanges`.
-- Isolated concurrent Streamable HTTP POSTs even when independent clients reuse
-  a JSON-RPC request ID, and promoted JSON-preferred responses to SSE whenever
-  a request emits intermediate notifications or nested legacy requests.
-  JSON-only responses no longer retain unused EventStore replay ownership.
-- Made Streamable HTTP disconnects cancel pending stateless JSON and SSE work,
-  removed terminated sessions immediately, and serialized protocol and stdio
-  shutdown so close/restart races cannot leak work. Stateless JSON responses
-  use connection-close framing to keep disconnect cancellation observable.
-- Prevented completed multi-round-trip retry results from advertising reusable
-  cache hints when they depend on `inputResponses` or `requestState`.
-- Ordered stdio subscription cancellation before its terminal response or
-  error while preserving that terminal outcome for clients; Streamable HTTP
-  continues to terminate through its response stream.
-- Made `mcp_dart inspect-server` apply protocol-specific tool schema rules so
-  MCP `2026-07-28` array and primitive output schemas inspect successfully.
-- Added the backward-compatible `RegisteredStatelessTool` handle so stateless
-  registrations can inspect and update any-root output schemas without
-  widening the existing `RegisteredTool` interface.
-- Fixed registered tool, prompt, resource, and resource-template handles so
-  `remove()` reliably unregisters them; resource and template renames now keep
-  handle state and server indexes synchronized.
-- Lowered the unreleased SDK minimum to Dart 3.4, kept its oldest permitted
-  dependency graph compilable, and added a public API compatibility gate
-  against `mcp_dart 2.2.2`.
+  matching, safe redirects, endpoint validation, client registration priority,
+  and issuer/resource-bound tokens.
+- Restricted legacy server-initiated requests and global list/resource update
+  helpers to initialization-era sessions; stateless interactions use embedded
+  input requests and acknowledged subscriptions.
+- Tool input-schema failures now return `CallToolResult(isError: true)` under
+  MCP `2025-11-25` and `2026-07-28`; invalid registered schemas and output
+  contract violations are reported as server errors.
+- Structured output validation now compiles schemas before handler side
+  effects and preserves the accepted schema for task-backed results.
+- Tasks and `subscriptions/listen` now enforce their independent capabilities,
+  status shapes, acknowledgment scope, URI boundaries, and cancellation
+  lifecycle.
+- Stateless stdio clients recover from bounded child failures and restore
+  subscriptions without replaying ordinary requests.
+- Streamable HTTP now isolates concurrent requests, promotes responses to SSE
+  when intermediate traffic requires it, and cancels pending work promptly on
+  disconnect.
+- `mcp_dart inspect-server` now accepts protocol-appropriate array and primitive
+  output schemas.
+
+### Fixed
+
+- Registered tool, prompt, resource, and resource-template handles now remove
+  and rename their registrations consistently.
+- Malformed newline-delimited frames no longer strand valid messages later in
+  the same input chunk.
+- Shutdown, restart, request-ID reuse, subscription cancellation, and
+  response-stream races no longer leak work or cross request boundaries.
 
 ### Validation and documentation
 
-- The official alpha.9 MCP `2026-07-28` client suite passes, including all 25
-  authorization scenarios. Its three stale `server-stateless` diagnostics are
-  matched exactly while post-#3002 conformance semantics pass locally.
-- The independently released Tasks extension source is pinned alongside the
-  core specification so its final schema and prose receive a separate day-0
-  delta review.
-- Published TypeScript beta.5 interoperates bidirectionally on the post-#3002
-  wire. Python beta server interop retains the temporary legacy identity read;
-  its pre-#3002 client direction remains an explicit expected gap.
+- Added public API compatibility checks against `mcp_dart 2.2.2`, minimum-Dart
+  dependency testing, and pinned core, Tasks, and JSON Schema conformance data.
+- The official alpha.9 MCP `2026-07-28` client suite, including all 25 OAuth
+  scenarios, passes. Post-#3002 server semantics pass locally.
+- Published TypeScript beta.5 interoperates bidirectionally. Python beta server
+  interoperability retains a documented pre-#3002 compatibility fallback.
 
 ### Breaking and compatibility notes
 
 - `DiscoverResult.serverInfo` is now nullable because MCP `2026-07-28` permits
   anonymous servers. Check for `null` before reading identity fields. MCP
   `2025-11-25` behavior is unchanged.
-- `mcp_dart 2.3` requires Dart 3.4 or newer; the CLI continues to require Dart
-  3.12. Dart 3.4 is the lowest version supported by the current runtime
-  dependency set.
+- `mcp_dart 2.3` requires Dart 3.4 or newer; the CLI requires Dart 3.12.
 - The direct `http` constraint is now `^1.5.0` because cancellation uses APIs
-  introduced in 1.5. Existing caret constraints such as `^1.4.0` can resolve
-  compatibly; applications pinned below 1.5 must update that pin.
+  introduced in 1.5. Normal `^1.4.0` constraints remain compatible, but pins
+  below 1.5 must be updated.
 - Stateless stdio clients now restart an unexpectedly terminated child by
   default and restore active `subscriptions/listen` requests. Set
   `StdioServerParameters.restartOnUnexpectedExit` to `false` to retain the
   prior close-on-exit behavior. Ordinary in-flight requests are never replayed.
 - `ProtocolOptions.taskStore` and `taskMessageQueue` remain available for MCP
-  2025-11-25 task augmentation and may coexist with the independent
-  `io.modelcontextprotocol/tasks` extension on a dual-era server. They are not
-  adapted into modern extension persistence; modern handlers and persistence
-  remain application-owned.
-- OAuth providers with a non-empty `clientId` now use that value as
-  pre-registered client information (or a Client ID Metadata Document when
-  advertised and eligible). To opt into deprecated Dynamic Client
-  Registration, return an empty `clientId`.
+  2025-11-25 task augmentation and may coexist with the independent Tasks
+  extension, whose handlers and persistence remain application-owned.
+- OAuth providers now treat a non-empty `clientId` as pre-registered client
+  information. Return an empty `clientId` only to opt into deprecated Dynamic
+  Client Registration.
 - OAuth discovery and token endpoints on another origin now require an
   explicit `oauthUriValidator`; client redirect URIs must use HTTPS or loopback
-  HTTP. Protected-resource and authorization-server metadata factories also
-  reject malformed or incomplete documents that v2.2.2 accepted.
+  HTTP, and malformed or incomplete metadata is rejected.
 - The exact v2.2.2 `finishAuth(String)` override remains available but is
-  deprecated and assumes the application validates the OAuth redirect. New
-  integrations should call `finishAuthRedirect` with the returned `state` and
-  optional issuer for validation before token exchange.
+  deprecated. New integrations should use `finishAuthRedirect` to validate the
+  returned `state` and optional issuer.
 - A schema-invalid `tools/call` now completes at the JSON-RPC level and returns
   a tool error result instead of throwing `McpError(ErrorCode.invalidParams)`.
-  Clients that caught `invalidParams` for this case must inspect
-  `CallToolResult.isError`; unknown or unavailable tools, malformed requests,
-  and server failures remain JSON-RPC errors. Negotiated MCP `2025-06-18` and
-  earlier peers retain their frozen JSON-RPC `invalidParams` behavior,
-  including MCP `2024-10-07`. Legacy task-augmented calls also retain
-  `invalidParams` for pre-acceptance schema rejection; accepted task calls
-  still return `CreateTaskResult` and expose their final tool result through
-  `tasks/result`.
-- Malformed `tools/call` params now consistently return JSON-RPC
-  `invalidParams` instead of falling through to a generic `internalError`.
+  Inspect `CallToolResult.isError` instead; MCP `2025-06-18` and earlier peers
+  retain `invalidParams`.
 - Under MCP `2025-11-25` and `2026-07-28`, an invalid registered input or output
-  schema, or a successful tool result that omits or violates its registered
-  output schema, returns JSON-RPC `internalError`; these are server-side
-  contract failures, not invalid client requests. MCP `2025-06-18` and earlier
-  peers retain the previous `invalidParams` code for these cases.
+  schema or invalid server-produced output returns JSON-RPC `internalError`.
+  Malformed call parameters continue to return `invalidParams`.
 - Clients now reject successful tool results that omit `structuredContent` when
-  the advertised `outputSchema` requires validation. An explicit JSON `null`
-  remains distinct and valid when the schema permits it. MCP `2025-11-25` and
-  earlier clients ignore non-object output schemas and expose the result's
-  compatibility `content` without retaining non-object `structuredContent`;
-  MCP `2026-07-28` clients continue to validate and retain any JSON root.
+  the advertised `outputSchema` requires it. MCP `2025-11-25` and earlier
+  clients retain object-root compatibility; MCP `2026-07-28` accepts any JSON
+  root.
 - Under MCP `2025-11-25`, task-mode negotiation now runs before input-schema
-  validation. A required task tool called without task augmentation returns
-  JSON-RPC `methodNotFound` as before. A task-forbidden tool called with
-  augmentation now returns `methodNotFound` instead of `invalidParams`; neither
-  path invokes the handler. MCP `2025-06-18` and earlier peers retain
-  `invalidParams`.
+  validation. Task-required or task-forbidden negotiation failures return
+  `methodNotFound`; earlier protocol versions retain `invalidParams`.
 - `CallToolResult.extra` entries named `content`, `isError`, `_meta`, or
-  `structuredContent` are now ignored instead of replacing the corresponding
-  protocol fields. When contradictory `CallToolResult` or
-  `SamplingToolResultContent` constructor arguments are supplied, an explicit
-  structured value is authoritative and marks the field present; use the
-  dedicated parameters for protocol-owned values.
+  `structuredContent` no longer replace protocol-owned fields. Use their
+  dedicated constructor parameters.
 
 ## 2.3.0-dev.2
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ See the [MCP 2026-07-28 transition guide](https://github.com/leehack/mcp_dart/bl
 for fallback rules and APIs specific to MCP 2026-07-28, or run the
 [strict MCP 2026-07-28 example](https://github.com/leehack/mcp_dart/tree/v2.3.0-dev.2/example/mcp_2026_07_28).
 Applications upgrading from the stable 2.2 line should also follow the
-[2.2 to 2.3 migration guide](doc/migration-2.2-to-2.3.md).
+[2.2 to 2.3 migration guide](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/migration-2.2-to-2.3.md).
 
 ## Quick start with the CLI
 
@@ -171,7 +171,7 @@ for command options and scope.
 ## Documentation
 
 - Start: [getting started](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/getting-started.md), [server guide](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/server-guide.md), [client guide](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/client-guide.md), [quick reference](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/quick-reference.md)
-- Upgrade: [2.2 to 2.3 migration guide](doc/migration-2.2-to-2.3.md), [migration cookbooks](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/migration-cookbooks.md), [MCP 2026-07-28 transition guide](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/mcp-2026-07-28.md)
+- Upgrade: [2.2 to 2.3 migration guide](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/migration-2.2-to-2.3.md), [migration cookbooks](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/migration-cookbooks.md), [MCP 2026-07-28 transition guide](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/mcp-2026-07-28.md)
 - Build: [tools](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/tools.md), [transports](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/transports.md), [examples](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/examples.md), [MCP Apps](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/mcp-apps.md)
 - Deploy: [Streamable HTTP security](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/transports.md#dns-rebinding-protection), [OAuth examples](https://github.com/leehack/mcp_dart/tree/v2.3.0-dev.2/example/authentication), [Flutter recipes](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/flutter-recipes.md)
 - Verify: [interop matrix](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/interoperability.md), [MCP 2025-11-25 coverage](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/spec-coverage-2025-11-25.md), [MCP 2026-07-28 preview coverage](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/spec-coverage-2026-07-28.md), [day-0 runbook](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/mcp-2026-07-28-release-runbook.md)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ final strictPreviewServer = McpServer(
 See the [MCP 2026-07-28 transition guide](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/mcp-2026-07-28.md)
 for fallback rules and APIs specific to MCP 2026-07-28, or run the
 [strict MCP 2026-07-28 example](https://github.com/leehack/mcp_dart/tree/v2.3.0-dev.2/example/mcp_2026_07_28).
+Applications upgrading from the stable 2.2 line should also follow the
+[2.2 to 2.3 migration guide](doc/migration-2.2-to-2.3.md).
 
 ## Quick start with the CLI
 
@@ -169,6 +171,7 @@ for command options and scope.
 ## Documentation
 
 - Start: [getting started](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/getting-started.md), [server guide](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/server-guide.md), [client guide](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/client-guide.md), [quick reference](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/quick-reference.md)
+- Upgrade: [2.2 to 2.3 migration guide](doc/migration-2.2-to-2.3.md), [migration cookbooks](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/migration-cookbooks.md), [MCP 2026-07-28 transition guide](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/mcp-2026-07-28.md)
 - Build: [tools](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/tools.md), [transports](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/transports.md), [examples](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/examples.md), [MCP Apps](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/mcp-apps.md)
 - Deploy: [Streamable HTTP security](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/transports.md#dns-rebinding-protection), [OAuth examples](https://github.com/leehack/mcp_dart/tree/v2.3.0-dev.2/example/authentication), [Flutter recipes](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/flutter-recipes.md)
 - Verify: [interop matrix](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/interoperability.md), [MCP 2025-11-25 coverage](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/spec-coverage-2025-11-25.md), [MCP 2026-07-28 preview coverage](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/spec-coverage-2026-07-28.md), [day-0 runbook](https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/mcp-2026-07-28-release-runbook.md)

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -23,6 +23,10 @@ Or for Flutter projects:
 flutter pub get
 ```
 
+Upgrading an existing 2.2 application? Follow the
+[2.2 to 2.3 migration guide](migration-2.2-to-2.3.md) for dependency,
+protocol-default, validation, OAuth, and stdio lifecycle changes.
+
 ## Basic Concepts
 
 ### What is MCP?

--- a/doc/mcp-2026-07-28-release-runbook.md
+++ b/doc/mcp-2026-07-28-release-runbook.md
@@ -224,7 +224,7 @@ On the final release-prep commit:
 - Set the root package version to `2.3.0`.
 - Restore root `documentation` and all user-facing repository links to `main`.
 - Replace prerelease dependency snippets in the README, getting-started,
-  quick-reference, and release docs with `mcp_dart: ^2.3.0`.
+  quick-reference, migration guide, and release docs with `mcp_dart: ^2.3.0`.
 - Keep the durable `2026-07-28` document, fixture, command, and workflow names;
   update only maturity wording that changes when the final specification ships.
 - Promote `stableProtocolVersion` and `defaultProtocolVersion` to the final
@@ -244,6 +244,8 @@ On the final release-prep commit:
   that presents the now-final protocol as draft-only.
 - Keep migration and compatibility notes explicit: `McpProtocol.stable`
   selects the current stable protocol while legacy profiles remain opt-in.
+  Re-read the 2.2-to-2.3 migration guide against the final package metadata and
+  link it from the tagged README and changelog.
 - Run `dart pub publish --dry-run` again from a clean checkout of the exact
   release commit. Do not create the release tag until this succeeds.
 - Run the shared metadata validator with `--package mcp_dart --tag v2.3.0`.

--- a/doc/mcp-2026-07-28-release-runbook.md
+++ b/doc/mcp-2026-07-28-release-runbook.md
@@ -334,6 +334,11 @@ compatible 2.3.x release.
   from the generated directory. Then start Streamable HTTP with
   `mcp_dart serve --transport http --host 127.0.0.1 --port 3000` and inspect
   `http://localhost:3000/mcp` from a separate process.
+- After the official MCP Inspector V2 is published for MCP `2026-07-28`, record
+  its exact version and use it to inspect the generated server over both stdio
+  and Streamable HTTP. Verify discovery plus tool listing and invocation. The
+  classic Inspector V1 `1.0.0` does not count as new-spec interoperability
+  evidence.
 - Recheck GitHub release links, pub.dev documentation links, installer asset
   resolution, and both stable package versions.
 - Confirm the normal `main` interop schedule is active and there is no duplicate

--- a/doc/mcp-2026-07-28.md
+++ b/doc/mcp-2026-07-28.md
@@ -1,5 +1,9 @@
 # MCP 2026-07-28 Transition Guide
 
+For package requirements and application-visible changes when updating from
+the stable 2.2 line, start with the
+[2.2 to 2.3 migration guide](migration-2.2-to-2.3.md).
+
 `mcp_dart 2.3.0-dev.2` is dual-era: it implements the locked release-candidate
 core of the MCP 2026-07-28 specification while retaining the MCP 2025-11-25
 feature set and earlier initialization compatibility. Its default

--- a/doc/migration-2.2-to-2.3.md
+++ b/doc/migration-2.2-to-2.3.md
@@ -1,0 +1,280 @@
+# Upgrading from mcp_dart 2.2 to 2.3
+
+This guide covers applications upgrading from the latest `2.2` patch,
+`mcp_dart 2.2.2`, to `mcp_dart 2.3`. Projects still on `2.2.0` or `2.2.1`
+also receive the fixes documented in the intervening changelog entries.
+
+## Short version
+
+Most applications can update the package constraint without changing source
+code. The 2.3 SDK preserves the 2.2.2 registration callbacks, public
+interfaces, subclass overrides, request metadata, logging helpers, and
+`StartSseOptions` API.
+
+The automated public API comparison and checked-in compile fixtures report no
+known source incompatibility in the stable 2.2.2 API. This does not cover
+imports from undeclared transitive dependencies or reliance on permissive
+runtime behavior.
+
+The upgrade is source-compatible, but some defaults and validation behavior
+change:
+
+| Area | What changes in 2.3 |
+| --- | --- |
+| Dart SDK | The SDK requires Dart 3.4 or newer. The separate `mcp_dart_cli` package requires Dart 3.12; SDK-only applications do not inherit that requirement. |
+| HTTP dependency | `mcp_dart` requires `http ^1.5.0`. Normal `^1.4.0` constraints remain compatible, but pins below 1.5 must be updated. |
+| Protocol negotiation | Clients and servers default to `McpProtocol.stable`, which prefers MCP 2026-07-28 and falls back to legacy initialization. |
+| Stdio recovery | Stateless stdio clients restart an unexpectedly terminated child by default. |
+| Validation | OAuth metadata, JSON Schema, structured tool results, and malformed MCP messages are validated more strictly. |
+| Tool errors | Schema-invalid tool arguments return `CallToolResult(isError: true)` under MCP 2025-11-25 and 2026-07-28 instead of throwing JSON-RPC `invalidParams`. |
+
+If an application requires the 2.2 initialization-only negotiation behavior,
+select `McpProtocol.legacy` during the rollout. This restores the protocol
+lifecycle, not the permissive validation or OAuth behavior of the older SDK.
+
+## Update the dependency
+
+Update `pubspec.yaml`:
+
+```yaml
+environment:
+  sdk: ^3.4.0
+
+dependencies:
+  mcp_dart: ^2.3.0
+```
+
+Then resolve and verify the project:
+
+```bash
+dart pub get
+dart analyze
+dart test
+```
+
+Any direct or transitive constraint that excludes `http` 1.5 must be loosened.
+A normal caret constraint such as `http: ^1.4.0` already permits 1.5 and does
+not need to change.
+
+The SDK no longer depends on the `json_schema` or `quiver` packages. No change
+is needed when using JSON Schema through `package:mcp_dart/mcp_dart.dart`. If an
+application imported either transitive dependency directly, declare that
+package as a direct application dependency or migrate to the SDK's exported
+validation API.
+
+## Choose the protocol rollout behavior
+
+Existing constructors continue to compile:
+
+```dart
+final client = McpClient(
+  const Implementation(name: 'my-client', version: '1.0.0'),
+);
+
+final server = McpServer(
+  const Implementation(name: 'my-server', version: '1.0.0'),
+);
+```
+
+In 2.3, those constructors use `McpProtocol.stable`. A client first attempts
+MCP 2026-07-28 `server/discover` and falls back to the legacy `initialize`
+flow when the peer identifies itself as legacy. On body-only transports such
+as stdio, a silent discovery probe is bounded to five seconds. Servers accept
+both the stateless and initialization-era profiles.
+
+To retain the initialization-only negotiation behavior while upgrading the
+SDK:
+
+```dart
+final client = McpClient(
+  const Implementation(name: 'my-client', version: '1.0.0'),
+  options: const McpClientOptions(protocol: McpProtocol.legacy),
+);
+
+final server = McpServer(
+  const Implementation(name: 'my-server', version: '1.0.0'),
+  options: const McpServerOptions(protocol: McpProtocol.legacy),
+);
+```
+
+Use `McpProtocol.require2026` only when connecting to a legacy peer should be a
+configuration error. See the [MCP 2026-07-28 transition guide](mcp-2026-07-28.md)
+for error-specific fallback rules and stateless-only APIs. Neither
+`McpProtocol.legacy` nor an explicit legacy version disables the stricter
+schema, OAuth, or malformed-message validation in 2.3.
+
+## Review observable behavior changes
+
+### Stdio child recovery
+
+After a successful stateless connection, `StdioClientTransport` now restarts a
+child process that terminates unexpectedly. Active `subscriptions/listen`
+requests are restored, but ordinary in-flight requests are never replayed.
+Initialization-era sessions still close because their lifecycle cannot be
+restored safely. Recovery reports failures through
+`StdioClientTransport.onerror` and stops after five restarts within 30 seconds.
+
+Set the previous close-on-exit behavior explicitly when required:
+
+```dart
+final transport = StdioClientTransport(
+  StdioServerParameters(
+    command: 'my_server',
+    restartOnUnexpectedExit: false,
+  ),
+);
+```
+
+### Tool validation and structured results
+
+For MCP 2025-11-25 and 2026-07-28, tool arguments that do not satisfy a
+registered `inputSchema` now complete at the JSON-RPC layer and return a tool
+error result. Clients that previously caught `McpError` with
+`ErrorCode.invalidParams` for this case should inspect the result:
+
+```dart
+final result = await client.callTool(
+  const CallToolRequest(name: 'search'),
+);
+
+if (result.isError == true) {
+  // Let the model or caller correct the tool arguments.
+}
+```
+
+Unknown tools, malformed requests, and server failures remain JSON-RPC errors.
+MCP 2025-06-18 and earlier sessions retain the previous `invalidParams`
+behavior.
+
+Invalid registered schemas, invalid server-produced output, or a successful
+result missing required `structuredContent` are treated as server contract
+failures and surface as JSON-RPC `internalError` under MCP 2025-11-25 and
+2026-07-28. Test both successful and error tool results when an output schema
+is registered. MCP 2026-07-28 additionally supports arrays, primitives, and
+`null` as structured output through the stateless registration APIs; legacy
+registrations retain object-root output compatibility.
+
+Entries in `CallToolResult.extra` named `content`, `isError`, `_meta`, or
+`structuredContent` no longer replace those protocol-owned fields. Pass those
+values through their dedicated constructor parameters.
+
+### JSON Schema validation
+
+The public JSON Schema APIs remain available, but validation is now provided by
+an SDK-owned offline validator. Draft 2020-12 and declared Draft 7 behavior are
+supported, while malformed schemas and Draft 7 formats are diagnosed more
+strictly. External-reference resolution and custom vocabularies remain outside
+the SDK's supported validation scope; 2.3 does not remove supported external
+resolution because the SDK did not provide it in 2.2.
+
+Use the exported `JsonSchemaValidation.validate` extension when validation is
+needed directly:
+
+```dart
+final schema = JsonSchema.object(
+  properties: {'name': JsonSchema.string()},
+  required: ['name'],
+);
+
+schema.validate({'name': 'example'});
+```
+
+Invalid definitions or instances throw `JsonSchemaValidationException`.
+
+Run representative input and output schemas through tests before deploying,
+especially if the application previously relied on an invalid schema being
+accepted.
+
+### OAuth redirects and metadata
+
+The 2.2.2 `finishAuth(String)` method remains available for compatibility, but
+it is deprecated because it cannot validate the authorization response's
+`state` or issuer. New code should pass the full redirect data:
+
+```dart
+await transport.finishAuthRedirect(
+  authorizationCode,
+  state: returnedState,
+  issuer: returnedIssuer,
+);
+```
+
+OAuth discovery and token endpoints on another origin require an explicit
+`oauthUriValidator`. Redirect URIs must use HTTPS or loopback HTTP. Metadata
+factories also reject malformed or incomplete documents that 2.2.2 accepted.
+
+Keep cross-origin approval narrow:
+
+```dart
+final options = StreamableHttpClientTransportOptions(
+  oauthUriValidator: (uri, endpointKind) =>
+      uri.scheme == 'https' && uri.host == 'auth.example.com',
+);
+```
+
+An OAuth provider with a non-empty `clientId` is treated as pre-registered
+client information. Return an empty `clientId` only when intentionally opting
+into deprecated Dynamic Client Registration.
+
+### Tasks
+
+The existing `ProtocolOptions.taskStore` and `taskMessageQueue` APIs remain
+available for MCP 2025-11-25 task augmentation. They may coexist with the
+independent `io.modelcontextprotocol/tasks` extension, but they are not an
+adapter for the extension's application-owned handlers or persistence.
+
+Under MCP 2025-11-25, task-mode negotiation now happens before input-schema
+validation. A task-required tool called without task augmentation continues to
+return `methodNotFound`. A task-forbidden tool called with augmentation now
+also returns `methodNotFound` instead of `invalidParams`. Earlier protocol
+versions retain their previous behavior.
+
+### Discovery identity
+
+`DiscoverResult` is new in the 2.3 line, so this is not a break from the stable
+2.2 API. Applications that used a 2.3 prerelease must account for anonymous MCP
+2026-07-28 servers:
+
+```dart
+final discovery = await client.discoverServer();
+final serverInfo = discovery.serverInfo;
+if (serverInfo != null) {
+  print('${serverInfo.name} ${serverInfo.version}');
+}
+```
+
+## Deprecated APIs
+
+The following APIs remain callable so applications can migrate gradually:
+
+| Deprecated API | Replacement |
+| --- | --- |
+| `latestProtocolVersion` | `latestInitializationProtocolVersion` or `defaultProtocolVersion`, depending on intent |
+| `supportedProtocolVersions` | `legacyProtocolVersions` or `allSupportedProtocolVersions` |
+| `StreamableHttpClientTransport.finishAuth` | `finishAuthRedirect` |
+| Legacy elicitation ID fields and completion notifications | MCP 2026-07-28 URL-mode elicitation and current result flow |
+
+Deprecation warnings alone do not block the upgrade. The old protocol-version
+constants intentionally retain their 2.2 values.
+
+## Upgrade checklist
+
+- Confirm the application uses Dart 3.4 or newer.
+- Remove any `http` pin that prevents resolution of version 1.5 or newer.
+- Run `dart pub get`, `dart analyze`, and the full test suite.
+- Decide whether to use the default dual-era profile or temporarily select
+  `McpProtocol.legacy`.
+- Test startup against silent or legacy stdio peers; the first default-profile
+  probe can take up to five seconds before fallback.
+- Decide whether unexpected stateless stdio child exits should restart.
+- Update callers that catch `invalidParams` for tool input-schema failures.
+- Re-test registered input/output schemas and structured tool results.
+- Re-test task-required and task-forbidden tool calls if task augmentation is
+  enabled.
+- Re-test OAuth discovery, redirect validation, and persisted credentials.
+- Run analyzers and tests in nested example or Flutter packages that consume
+  the SDK.
+
+For protocol-specific behavior, continue with the
+[MCP 2026-07-28 transition guide](mcp-2026-07-28.md). For migrations from other
+SDKs or transports, see the [migration cookbooks](migration-cookbooks.md).

--- a/doc/migration-cookbooks.md
+++ b/doc/migration-cookbooks.md
@@ -2,7 +2,8 @@
 
 This page collects practical migration paths into `mcp_dart`. It complements
 the protocol-specific [MCP 2025-11-25 compatibility migration](migration_2025_11_25_compat.md)
-guide.
+guide. Existing `mcp_dart` users updating the package should start with the
+[2.2 to 2.3 migration guide](migration-2.2-to-2.3.md).
 
 ## Cookbook 1: TypeScript SDK server example -> Dart server
 

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -383,6 +383,7 @@ guidance.
 
 ## Next steps
 
+- [Upgrade from mcp_dart 2.2 to 2.3](migration-2.2-to-2.3.md)
 - [Getting started](getting-started.md)
 - [Server guide](server-guide.md)
 - [Client guide](client-guide.md)

--- a/llms.txt
+++ b/llms.txt
@@ -67,6 +67,9 @@ final client = McpClient(
 2026-only APIs, examples, and fallback rules:
 https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/mcp-2026-07-28.md
 
+Upgrade requirements and application-visible changes from 2.2 to 2.3:
+https://github.com/leehack/mcp_dart/blob/main/doc/migration-2.2-to-2.3.md
+
 Strict MCP 2026-07-28 runnable example:
 https://github.com/leehack/mcp_dart/tree/v2.3.0-dev.2/example/mcp_2026_07_28
 
@@ -261,5 +264,6 @@ Evidence and runbooks:
 - Transports: `doc/transports.md`
 - Flutter: `doc/flutter-recipes.md`
 - MCP Apps: `doc/mcp-apps.md`
-- Migration: `doc/migration-cookbooks.md`
+- Version upgrade: `doc/migration-2.2-to-2.3.md`
+- Other migrations: `doc/migration-cookbooks.md`
 - Examples: `doc/examples.md` and `example/`

--- a/llms.txt
+++ b/llms.txt
@@ -68,7 +68,7 @@ final client = McpClient(
 https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/mcp-2026-07-28.md
 
 Upgrade requirements and application-visible changes from 2.2 to 2.3:
-https://github.com/leehack/mcp_dart/blob/main/doc/migration-2.2-to-2.3.md
+https://github.com/leehack/mcp_dart/blob/v2.3.0-dev.2/doc/migration-2.2-to-2.3.md
 
 Strict MCP 2026-07-28 runnable example:
 https://github.com/leehack/mcp_dart/tree/v2.3.0-dev.2/example/mcp_2026_07_28


### PR DESCRIPTION
## Summary

- add a focused migration guide for upgrading from `mcp_dart 2.2.2` to 2.3
- document dependency, protocol-default, stdio, validation, OAuth, task, and deprecation considerations
- compact the unreleased changelog into user-facing release notes
- link the guide from the primary documentation and day-0 release runbook
- add an official Inspector V2 smoke check to the public day-0 verification

## Impact

This is a documentation-only change. It gives users a single upgrade path while making clear that 2.3 preserves the stable 2.2.2 public API but includes intentional runtime and validation changes.

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test`
- `dart test test/docs/markdown_docs_test.dart`
- `dart tool/validate_release_metadata.dart --package mcp_dart`
- migration-guide snippets analyzed in a temporary compile fixture
- fresh-reader ambiguity review
