### PR TITLE
Prepare coordinated dev.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.3.0-dev.3
 
 `mcp_dart 2.3` adds the MCP `2026-07-28` release-candidate surface while
 preserving the public `2.2.2` API. See the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 `mcp_dart 2.3` adds the MCP `2026-07-28` release-candidate surface while
 preserving the public `2.2.2` API. See the
-[2.2 to 2.3 migration guide](doc/migration-2.2-to-2.3.md) for upgrade steps and
-the [MCP 2026-07-28 transition guide](doc/mcp-2026-07-28.md) for protocol
-details.
+[2.2 to 2.3 migration guide](https://github.com/leehack/mcp_dart/blob/main/doc/migration-2.2-to-2.3.md)
+for upgrade steps and the
+[MCP 2026-07-28 transition guide](https://github.com/leehack/mcp_dart/blob/main/doc/mcp-2026-07-28.md)
+for protocol details.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ extensions, host UI behavior, an authorization-server implementation, JSON
 Schema external-reference resolution, and custom JSON Schema vocabularies.
 
 > [!IMPORTANT]
-> The latest published prerelease coordinates `mcp_dart 2.3.0-dev.2` and
-> `mcp_dart_cli 0.2.0-dev.2`. Current source passes the official alpha.9 MCP
+> The coordinated dev.3 prerelease pairs `mcp_dart 2.3.0-dev.3` with
+> `mcp_dart_cli 0.2.0-dev.3`. It passes the official alpha.9 MCP
 > `2026-07-28` client suite, including all 25 authorization scenarios. Its
 > server suite has three exact expected diagnostics because the published
 > referee predates spec PR #3002; merged conformance PR #403 semantics pass
@@ -28,13 +28,11 @@ Schema external-reference resolution, and custom JSON Schema vocabularies.
 
 | Package | Minimum Dart SDK |
 | --- | --- |
-| `mcp_dart 2.3.0-dev.2` | 3.5 |
-| `mcp_dart_cli 0.2.0-dev.2` | 3.7 |
+| `mcp_dart 2.3.0-dev.3` | 3.4 |
+| `mcp_dart_cli 0.2.0-dev.3` | 3.12 |
 
-The current unreleased SDK source and SDK-only generated projects lower the
-minimum to Dart 3.4. The current unreleased CLI source targets Dart 3.12.
-Published dev.2 packages retain their declared Dart 3.5 SDK and Dart 3.7 CLI
-minimums.
+SDK-only generated projects retain the SDK's Dart 3.4 minimum. CLI projects
+use Dart 3.12 because the CLI and its toolchain target that release.
 
 Install Dart from [dart.dev](https://dart.dev/get-dart).
 
@@ -54,12 +52,11 @@ Select the prerelease explicitly:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.3.0-dev.2
+  mcp_dart: ^2.3.0-dev.3
 ```
 
-The installation snippets remain pinned to dev.2 until the next coordinated
-packages are published; current-source sections also describe unreleased
-release-readiness fixes. Production-channel users should follow the
+The preview snippets use the coordinated dev.3 package line.
+Production-channel users should follow the
 documentation for the version resolved in their own `pubspec.lock`. Package
 channels are separate from protocol profiles: `McpProtocol.stable` names the
 SDK's default compatibility policy, not package or wire-spec maturity.
@@ -138,13 +135,13 @@ Applications upgrading from the stable 2.2 line should also follow the
 Install the matching preview CLI:
 
 ```bash
-dart pub global activate mcp_dart_cli 0.2.0-dev.2
+dart pub global activate mcp_dart_cli 0.2.0-dev.3
 mcp_dart create my_server
 cd my_server
 mcp_dart inspect
 ```
 
-The dev.2 CLI creates a project with `mcp_dart: ^2.3.0-dev.2`. The inspector
+The dev.3 CLI creates a project with `mcp_dart: ^2.3.0-dev.3`. The inspector
 launches the generated stdio server itself. After leaving the interactive
 inspector, you can run a single tool directly:
 
@@ -218,7 +215,7 @@ surface. Re-check both packages' current releases before a production decision.
 
 - [Issues and bug reports](https://github.com/leehack/mcp_dart/issues)
 - [SDK on pub.dev](https://pub.dev/packages/mcp_dart)
-- [dev.2 API reference](https://pub.dev/documentation/mcp_dart/2.3.0-dev.2/)
+- [dev.3 API reference](https://pub.dev/documentation/mcp_dart/2.3.0-dev.3/)
 - [Changelog](https://github.com/leehack/mcp_dart/blob/main/CHANGELOG.md)
 - [MCP 2026-07-28 RC](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
 - [MCP 2025-11-25 specification](https://modelcontextprotocol.io/specification/2025-11-25)

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -8,7 +8,7 @@ Add the MCP Dart SDK to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.3.0-dev.2
+  mcp_dart: ^2.3.0-dev.3
 ```
 
 Then run:

--- a/doc/mcp-2026-07-28.md
+++ b/doc/mcp-2026-07-28.md
@@ -4,7 +4,7 @@ For package requirements and application-visible changes when updating from
 the stable 2.2 line, start with the
 [2.2 to 2.3 migration guide](migration-2.2-to-2.3.md).
 
-`mcp_dart 2.3.0-dev.2` is dual-era: it implements the locked release-candidate
+`mcp_dart 2.3.0-dev.3` is dual-era: it implements the locked release-candidate
 core of the MCP 2026-07-28 specification while retaining the MCP 2025-11-25
 feature set and earlier initialization compatibility. Its default
 `McpProtocol.stable` profile prefers `server/discover` and stateless request
@@ -264,8 +264,8 @@ with legacy fallback.
 
 Published SDK and CLI prereleases provide the MCP `2026-07-28` preview channel.
 The standalone install scripts track stable releases; activate an explicit CLI
-prerelease when testing this protocol. Projects created by the dev.2 CLI use the
-matching dev.2 SDK dependency.
+prerelease when testing this protocol. Projects created by the dev.3 CLI use the
+matching dev.3 SDK dependency.
 
 [PR #306](https://github.com/leehack/mcp_dart/pull/306) merged the MCP
 2026-07-28 implementation line into `main`. The superseded RC PR is closed,

--- a/doc/migration_2025_11_25_compat.md
+++ b/doc/migration_2025_11_25_compat.md
@@ -1,7 +1,7 @@
 # MCP 2025-11-25 Compatibility Migration
 
 > This guide covers the `McpProtocol.legacy` and MCP 2025-11-25
-> initialization-era surface. The dev.2
+> initialization-era surface. The dev.3
 > default prefers MCP `2026-07-28`; see the
 > [transition guide](mcp-2026-07-28.md) for current default behavior.
 

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -8,17 +8,15 @@ Use this page for common `mcp_dart` calls. The [server guide](server-guide.md),
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.3.0-dev.2
+  mcp_dart: ^2.3.0-dev.3
 ```
 
 ```dart
 import 'package:mcp_dart/mcp_dart.dart';
 ```
 
-The published dev.2 SDK requires Dart 3.5 or later. The current unreleased SDK
-source lowers the next 2.3 release floor to Dart 3.4. The published dev.2 CLI
-requires Dart 3.7 or later; the current unreleased CLI source targets Dart
-3.12.
+The dev.3 SDK requires Dart 3.4 or later. The coordinated dev.3 CLI requires
+Dart 3.12 or later.
 
 ## Protocol profile
 

--- a/doc/spec-coverage-2026-07-28.md
+++ b/doc/spec-coverage-2026-07-28.md
@@ -3,7 +3,7 @@
 `mcp_dart` implements the complete core client/server wire surface of the
 locked release candidate for the MCP 2026-07-28 specification. This matrix indexes the high-risk
 and release-changing requirements against checked-in evidence; it is not an
-exhaustive inventory of every schema type or API. The dev.2 preview defaults to
+exhaustive inventory of every schema type or API. The dev.3 preview defaults to
 `McpProtocol.stable`, while `McpProtocol.legacy` retains the full MCP
 2025-11-25 feature set and negotiates supported earlier initialization
 versions.

--- a/llms.txt
+++ b/llms.txt
@@ -3,12 +3,10 @@
 `mcp_dart` is a community Dart and Flutter SDK for Model Context Protocol
 (MCP) servers, clients, and hosts.
 
-- SDK preview: `2.3.0-dev.2`
-- CLI preview: `0.2.0-dev.2`
-- Published SDK preview minimum: Dart 3.5
-- Unreleased SDK source minimum: Dart 3.4
-- CLI preview minimum: Dart 3.7
-- Unreleased CLI source minimum: Dart 3.12
+- SDK preview: `2.3.0-dev.3`
+- CLI preview: `0.2.0-dev.3`
+- SDK preview minimum: Dart 3.4
+- CLI preview minimum: Dart 3.12
 - Repository: https://github.com/leehack/mcp_dart
 - Package: https://pub.dev/packages/mcp_dart
 - License: MIT
@@ -38,7 +36,7 @@ Select the preview explicitly:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.3.0-dev.2
+  mcp_dart: ^2.3.0-dev.3
 ```
 
 ## Primary import
@@ -206,7 +204,7 @@ https://github.com/leehack/mcp_dart/tree/main/example/authentication
 Install the preview after its matching SDK is public:
 
 ```bash
-dart pub global activate mcp_dart_cli 0.2.0-dev.2
+dart pub global activate mcp_dart_cli 0.2.0-dev.3
 ```
 
 Common commands:

--- a/packages/mcp_dart_cli/CHANGELOG.md
+++ b/packages/mcp_dart_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.2.0-dev.3
 
 - Development now targets Dart 3.12; the SDK and SDK-only generated projects
   support Dart 3.4.

--- a/packages/mcp_dart_cli/README.md
+++ b/packages/mcp_dart_cli/README.md
@@ -11,17 +11,16 @@ Install the stable CLI with a Dart SDK allowed by that release:
 dart pub global activate mcp_dart_cli
 ```
 
-The current unreleased source targets Dart 3.12. The published
-`0.2.0-dev.2` preview retains its Dart 3.7 minimum.
+The `0.2.0-dev.3` preview requires Dart 3.12.
 
 Install the coordinated MCP `2026-07-28` preview explicitly:
 
 ```bash
-dart pub global activate mcp_dart_cli 0.2.0-dev.2
+dart pub global activate mcp_dart_cli 0.2.0-dev.3
 ```
 
 Prerelease packages are published SDK first, then CLI. Confirm
-`mcp_dart 2.3.0-dev.2` is available before installing this CLI preview.
+`mcp_dart 2.3.0-dev.3` is available before installing this CLI preview.
 
 Without Dart, install the latest stable standalone binary:
 
@@ -48,7 +47,7 @@ cd my_server
 mcp_dart serve
 ```
 
-The dev.2 CLI writes `mcp_dart: ^2.3.0-dev.2`, the SDK channel tested with this
+The dev.3 CLI writes `mcp_dart: ^2.3.0-dev.3`, the SDK channel tested with this
 CLI. A stable CLI selects its matching stable SDK. You can also supply a local
 Mason brick, Git URL, GitHub shorthand, or tree URL:
 

--- a/packages/mcp_dart_cli/example/example.md
+++ b/packages/mcp_dart_cli/example/example.md
@@ -11,7 +11,7 @@ First, install the CLI globally:
 dart pub global activate mcp_dart_cli
 
 # Coordinated MCP 2026-07-28 preview
-dart pub global activate mcp_dart_cli 0.2.0-dev.2
+dart pub global activate mcp_dart_cli 0.2.0-dev.3
 ```
 
 ## Creating a Project

--- a/packages/mcp_dart_cli/lib/src/version.dart
+++ b/packages/mcp_dart_cli/lib/src/version.dart
@@ -1,7 +1,7 @@
-const packageVersion = '0.2.0-dev.2';
+const packageVersion = '0.2.0-dev.3';
 
 /// SDK constraint written by this CLI when it creates a project.
-const generatedSdkConstraint = '^2.3.0-dev.2';
+const generatedSdkConstraint = '^2.3.0-dev.3';
 
 /// Immutable template paired with this CLI release.
 const defaultTemplateUrl =

--- a/packages/mcp_dart_cli/pubspec.yaml
+++ b/packages/mcp_dart_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mcp_dart_cli
 description: Command-line tools for creating Dart MCP servers and inspecting, tracing, or testing Model Context Protocol servers and clients in any language.
-version: 0.2.0-dev.2
+version: 0.2.0-dev.3
 repository: https://github.com/leehack/mcp_dart
 homepage: https://github.com/leehack/mcp_dart/tree/main/packages/mcp_dart_cli
 issue_tracker: https://github.com/leehack/mcp_dart/issues
@@ -26,7 +26,7 @@ dependencies:
   build: ^4.0.3
   mason: ^0.1.2
   mason_logger: ^0.3.3
-  mcp_dart: ^2.3.0-dev.2
+  mcp_dart: ^2.3.0-dev.3
   meta: ^1.17.0
   path: ^1.9.1
   pub_updater: ^0.5.0

--- a/packages/mcp_dart_cli/test/fixtures/dart_mcp_project/pubspec.yaml
+++ b/packages/mcp_dart_cli/test/fixtures/dart_mcp_project/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   args: ^2.6.0
   logging: ^1.3.0
-  mcp_dart: ^2.3.0-dev.2
+  mcp_dart: ^2.3.0-dev.3
   mcp_dart_cli:
     path: ../../..
 

--- a/packages/templates/simple/__brick__/pubspec.yaml
+++ b/packages/templates/simple/__brick__/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   args: ^2.6.0
   logging: ^1.3.0
-  mcp_dart: ^2.3.0-dev.2
+  mcp_dart: ^2.3.0-dev.3
 
 dev_dependencies:
   # Dart 3.4 resolves lints 4.0; Dart 3.8+ can use the latest lints 6 release.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mcp_dart
 description: Dart and Flutter SDK for building Model Context Protocol (MCP) servers, clients, hosts, and AI tools.
-version: 2.3.0-dev.2
+version: 2.3.0-dev.3
 repository: https://github.com/leehack/mcp_dart
 homepage: https://github.com/leehack/mcp_dart
 issue_tracker: https://github.com/leehack/mcp_dart/issues

--- a/test/tool/release_link_manager_test.dart
+++ b/test/tool/release_link_manager_test.dart
@@ -20,6 +20,11 @@ documentation: https://github.com/leehack/mcp_dart/tree/main/doc
 ''');
     _write(
       root,
+      'CHANGELOG.md',
+      '[Migration](https://github.com/leehack/mcp_dart/blob/main/doc/migration.md)\n',
+    );
+    _write(
+      root,
       'llms.txt',
       'https://github.com/leehack/mcp_dart/tree/main/example\n',
     );
@@ -45,6 +50,7 @@ documentation: https://github.com/leehack/mcp_dart/tree/main/doc
     expect(
       first.changedFiles,
       containsAll([
+        'CHANGELOG.md',
         'README.md',
         'doc/guide.md',
         'example/README.md',
@@ -60,6 +66,10 @@ documentation: https://github.com/leehack/mcp_dart/tree/main/doc
         contains('https://example.com/blob/main/doc/guide.md'),
       ),
     );
+    expect(
+      File('${root.path}/CHANGELOG.md').readAsStringSync(),
+      contains('/blob/v2.4.0-dev.1/doc/migration.md'),
+    );
     expect(manager.update('v2.4.0-dev.1').changedFiles, isEmpty);
   });
 
@@ -72,6 +82,7 @@ documentation: https://github.com/leehack/mcp_dart/tree/main/doc
 First line
 [Old](https://github.com/leehack/mcp_dart/blob/v2.3.0/doc/guide.md)
 ''');
+    _write(root, 'CHANGELOG.md', 'No links here.\n');
     _write(root, 'llms.txt', 'No links here.\n');
 
     final result = ReleaseLinkManager(
@@ -100,6 +111,11 @@ homepage: https://github.com/leehack/mcp_dart/tree/main/packages/mcp_dart_cli
       'README.md',
       '[CLI](https://github.com/leehack/mcp_dart/blob/main/packages/mcp_dart_cli/README.md)\n',
     );
+    _write(
+      root,
+      'CHANGELOG.md',
+      '[CLI guide](https://github.com/leehack/mcp_dart/blob/main/packages/mcp_dart_cli/README.md)\n',
+    );
     _write(root, 'CONTRIBUTING.md', 'No repository links.\n');
 
     final manager = ReleaseLinkManager(
@@ -120,6 +136,12 @@ homepage: https://github.com/leehack/mcp_dart/tree/main/packages/mcp_dart_cli
     expect(
       File('${root.path}/pubspec.yaml').readAsStringSync(),
       contains('/tree/mcp_dart_cli-v0.3.0/packages/mcp_dart_cli'),
+    );
+    expect(
+      File('${root.path}/CHANGELOG.md').readAsStringSync(),
+      contains(
+        '/blob/mcp_dart_cli-v0.3.0/packages/mcp_dart_cli/README.md',
+      ),
     );
   });
 }

--- a/test/tool/validate_release_metadata_test.dart
+++ b/test/tool/validate_release_metadata_test.dart
@@ -13,11 +13,11 @@ void main() {
 
     final sdk = validator.validate(
       package: ReleasePackage.sdk,
-      tag: 'v2.3.0-dev.2',
+      tag: 'v2.3.0-dev.3',
     );
     final cli = validator.validate(
       package: ReleasePackage.cli,
-      tag: 'mcp_dart_cli-v0.2.0-dev.2',
+      tag: 'mcp_dart_cli-v0.2.0-dev.3',
     );
 
     expect(sdk.errors, isEmpty);
@@ -794,10 +794,10 @@ Directory _stableFixture(
   pubspec.writeAsStringSync(
     pubspec
         .readAsStringSync()
-        .replaceFirst('version: 2.3.0-dev.2', 'version: 2.3.0')
+        .replaceFirst('version: 2.3.0-dev.3', 'version: 2.3.0')
         .replaceFirst(
           'documentation: https://github.com/leehack/mcp_dart/tree/'
-              'v2.3.0-dev.2/doc',
+              'v2.3.0-dev.3/doc',
           'documentation: https://github.com/leehack/mcp_dart/tree/main/doc',
         ),
   );
@@ -805,7 +805,7 @@ Directory _stableFixture(
   final changelog = File('${fixture.path}/CHANGELOG.md');
   changelog.writeAsStringSync(
     changelog.readAsStringSync().replaceFirst(
-          '## Unreleased',
+          '## 2.3.0-dev.3',
           '## 2.3.0',
         ),
   );
@@ -851,7 +851,7 @@ Directory _stableFixture(
     file.writeAsStringSync(
       file
           .readAsStringSync()
-          .replaceAll('2.3.0-dev.2', '2.3.0')
+          .replaceAll('2.3.0-dev.3', '2.3.0')
           .replaceAll('2.3.0 preview', '2.3.0')
           .replaceAll('MCP 2026-07-28 preview', 'MCP 2026-07-28')
           .replaceAll('MCP `2026-07-28` preview', 'MCP `2026-07-28`')
@@ -932,8 +932,8 @@ Directory _stableFixture(
       file.writeAsStringSync(
         file
             .readAsStringSync()
-            .replaceAll('2.3.0-dev.2', '2.3.0')
-            .replaceAll('0.2.0-dev.2', '0.2.0')
+            .replaceAll('2.3.0-dev.3', '2.3.0')
+            .replaceAll('0.2.0-dev.3', '0.2.0')
             .replaceAll('2.3.0 preview', '2.3.0')
             .replaceAll('MCP 2026-07-28 preview', 'MCP 2026-07-28')
             .replaceAll('MCP `2026-07-28` preview', 'MCP `2026-07-28`')
@@ -947,21 +947,21 @@ Directory _stableFixture(
     cliPubspec.writeAsStringSync(
       cliPubspec
           .readAsStringSync()
-          .replaceFirst('version: 0.2.0-dev.2', 'version: 0.2.0')
+          .replaceFirst('version: 0.2.0-dev.3', 'version: 0.2.0')
           .replaceAll(
             'https://github.com/leehack/mcp_dart/tree/'
-                'mcp_dart_cli-v0.2.0-dev.2/packages/mcp_dart_cli',
+                'mcp_dart_cli-v0.2.0-dev.3/packages/mcp_dart_cli',
             'https://github.com/leehack/mcp_dart/tree/main/'
                 'packages/mcp_dart_cli',
           )
-          .replaceFirst('mcp_dart: ^2.3.0-dev.2', 'mcp_dart: ^2.3.0'),
+          .replaceFirst('mcp_dart: ^2.3.0-dev.3', 'mcp_dart: ^2.3.0'),
     );
     final cliChangelog = File(
       '${fixture.path}/packages/mcp_dart_cli/CHANGELOG.md',
     );
     cliChangelog.writeAsStringSync(
       cliChangelog.readAsStringSync().replaceFirst(
-            '## Unreleased',
+            '## 0.2.0-dev.3',
             '## 0.2.0',
           ),
     );
@@ -972,11 +972,11 @@ Directory _stableFixture(
       cliVersionSource
           .readAsStringSync()
           .replaceFirst(
-            "const packageVersion = '0.2.0-dev.2';",
+            "const packageVersion = '0.2.0-dev.3';",
             "const packageVersion = '0.2.0';",
           )
           .replaceFirst(
-            "const generatedSdkConstraint = '^2.3.0-dev.2';",
+            "const generatedSdkConstraint = '^2.3.0-dev.3';",
             "const generatedSdkConstraint = '^2.3.0';",
           ),
     );
@@ -985,7 +985,7 @@ Directory _stableFixture(
     );
     templatePubspec.writeAsStringSync(
       templatePubspec.readAsStringSync().replaceFirst(
-            'mcp_dart: ^2.3.0-dev.2',
+            'mcp_dart: ^2.3.0-dev.3',
             'mcp_dart: ^2.3.0',
           ),
     );

--- a/tool/release/release_link_manager.dart
+++ b/tool/release/release_link_manager.dart
@@ -144,8 +144,13 @@ class ReleaseLinkManager {
 
   List<File> _releaseFacingFiles() {
     final relativeFiles = package == ReleasePackage.sdk
-        ? <String>['README.md', 'llms.txt', 'pubspec.yaml']
-        : <String>['README.md', 'CONTRIBUTING.md', 'pubspec.yaml'];
+        ? <String>['CHANGELOG.md', 'README.md', 'llms.txt', 'pubspec.yaml']
+        : <String>[
+            'CHANGELOG.md',
+            'CONTRIBUTING.md',
+            'README.md',
+            'pubspec.yaml',
+          ];
     final files = <File>[];
     for (final relativePath in relativeFiles) {
       final file = File(_path(relativePath));


### PR DESCRIPTION
## Summary

- bump the SDK to `2.3.0-dev.3` and the CLI to `0.2.0-dev.3`
- coordinate the CLI dependency, generated project constraints, templates, version constants, changelogs, and preview documentation
- publish the accumulated MCP 2026-07-28 day-zero readiness and dependency-cleanup work as a prerelease
- retain Dart 3.4 as the SDK minimum and Dart 3.12 as the CLI minimum, with no dependency additions

## Release behavior

This is a coordinated dev release. After this labeled PR is approved and merged, release automation will publish the SDK first, wait for `mcp_dart 2.3.0-dev.3` to become visible on pub.dev, then publish `mcp_dart_cli 0.2.0-dev.3`. Final-spec acknowledgements remain intentionally deferred for this prerelease.

This PR does not publish or merge anything by itself.

## Validation

- `dart format .` — clean
- SDK analysis — clean
- CLI analysis — clean
- SDK tests — 1,949 passed
- CLI tests — 129 passed; 5 optional Python interop tests skipped because the local Python MCP SDK is absent
- release metadata tests — 28 passed
- release-plan tests — 9 passed
- CLI version tests — 3 passed
- release workflow, provenance, source, security, publish-security, and CLI binary fixtures — passed
- `actionlint`, `shellcheck`, and `git diff --check` — clean
- staged SDK `dart pub publish --dry-run` — 0 warnings
- source and immutable-candidate link checks — passed

The staged CLI hosted dry-run correctly waits for the unpublished SDK constraint `mcp_dart ^2.3.0-dev.3`; coordinated automation publishes and verifies the SDK before validating and releasing the CLI.