### PR TITLE
Fix minimum SDK release validation

### DIFF
--- a/packages/mcp_dart_cli/test/src/inspect_server_command_test.dart
+++ b/packages/mcp_dart_cli/test/src/inspect_server_command_test.dart
@@ -481,11 +481,18 @@ void main() {
 File _typescriptServerFixture() {
   final repoRoot = _findRepoRoot(Directory.current);
   return File(
-    p.join(repoRoot.path, 'test', 'interop', 'ts', 'dist', 'server.js'),
+    p.join(
+      repoRoot?.path ?? Directory.current.path,
+      'test',
+      'interop',
+      'ts',
+      'dist',
+      'server.js',
+    ),
   );
 }
 
-Directory _findRepoRoot(Directory start) {
+Directory? _findRepoRoot(Directory start) {
   var current = start.absolute;
   while (current.path != current.parent.path) {
     if (File(p.join(current.path, 'AGENTS.md')).existsSync() &&
@@ -496,7 +503,7 @@ Directory _findRepoRoot(Directory start) {
     }
     current = current.parent;
   }
-  throw StateError('Could not locate repository root from ${start.path}.');
+  return null;
 }
 
 bool _requireFile(File file, String description) {

--- a/packages/mcp_dart_cli/test/version_test.dart
+++ b/packages/mcp_dart_cli/test/version_test.dart
@@ -28,29 +28,42 @@ void main() {
   });
 
   test(
-    'CLI dependency and generated SDK constraint match the root package',
+    'CLI dependency and generated SDK constraint stay aligned',
     () {
       final cliPubspec =
           loadYaml(File('pubspec.yaml').readAsStringSync()) as YamlMap;
-      final rootPubspec =
-          loadYaml(File('../../pubspec.yaml').readAsStringSync()) as YamlMap;
-      final rootVersion = rootPubspec['version'] as String;
       final dependencies = cliPubspec['dependencies'] as YamlMap;
-      final templatePubspec =
-          loadYaml(
-                File(
-                  '../templates/simple/__brick__/pubspec.yaml',
-                ).readAsStringSync(),
-              )
-              as YamlMap;
-      final templateDependencies = templatePubspec['dependencies'] as YamlMap;
+      final sdkConstraint = dependencies['mcp_dart'] as String;
 
-      expect(dependencies['mcp_dart'], '^$rootVersion');
-      expect(templateDependencies['mcp_dart'], '^$rootVersion');
-      expect(generatedSdkConstraint, '^$rootVersion');
+      expect(generatedSdkConstraint, sdkConstraint);
       expect(isPrereleaseVersion(packageVersion), isTrue);
       expect(defaultTemplateUrl, contains('mcp_dart_cli-v$packageVersion'));
       expect(defaultTemplateUrl, isNot(contains('/main/')));
     },
   );
+
+  test('CLI dependency matches the root package in a repository checkout', () {
+    final rootPubspecFile = File('../../pubspec.yaml');
+    if (!rootPubspecFile.existsSync()) {
+      markTestSkipped('Root package is unavailable outside the repository.');
+      return;
+    }
+
+    final cliPubspec =
+        loadYaml(File('pubspec.yaml').readAsStringSync()) as YamlMap;
+    final dependencies = cliPubspec['dependencies'] as YamlMap;
+    final rootPubspec = loadYaml(rootPubspecFile.readAsStringSync()) as YamlMap;
+    final rootVersion = rootPubspec['version'] as String;
+    final templatePubspec =
+        loadYaml(
+              File(
+                '../templates/simple/__brick__/pubspec.yaml',
+              ).readAsStringSync(),
+            )
+            as YamlMap;
+    final templateDependencies = templatePubspec['dependencies'] as YamlMap;
+
+    expect(dependencies['mcp_dart'], '^$rootVersion');
+    expect(templateDependencies['mcp_dart'], '^$rootVersion');
+  });
 }

--- a/tool/release/README.md
+++ b/tool/release/README.md
@@ -125,9 +125,10 @@ CI provenance is matched by the exact workflow files
 `.github/workflows/test_core.yml`, `.github/workflows/test_cli.yml`, and, for
 the SDK, `.github/workflows/interop_2026_07_28.yml`; matching display names are
 not sufficient. For CLI candidates, both workflows remove the monorepo
-override, downgrade to and verify the declared minimum SDK from pub.dev, run
-the non-interop test suite and analysis, compile and smoke-test the binary, and
-run the publish dry-run before authorization or publication.
+override, pin and verify only the declared minimum SDK from pub.dev while
+resolving other dependencies normally, run the non-interop test suite and
+analysis, compile and smoke-test the binary, and run the publish dry-run before
+authorization or publication.
 
 Run `bash tool/release/verify_release_ci_test.sh` to exercise the local
 workflow-provenance fixtures without calling GitHub.

--- a/tool/release/verify_cli_binary_workflow_test.sh
+++ b/tool/release/verify_cli_binary_workflow_test.sh
@@ -86,7 +86,9 @@ YAML
 cat >"$FIXTURE_DIR/bin/dart" <<'DART'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "$*" == "pub downgrade" ]]; then
+if [[ "$*" == "pub get" ]]; then
+  grep -q '^dependency_overrides:$' pubspec_overrides.yaml
+  grep -q '^  mcp_dart: 2.3.0$' pubspec_overrides.yaml
   exit 0
 fi
 if [[ "$*" == "pub deps --json" ]]; then
@@ -120,11 +122,15 @@ run_helper() {
 
 run_helper "$FIXTURE_DIR/hosted.json" >/dev/null ||
   fail "The hosted minimum SDK fixture should pass."
+[[ ! -e "$CLI_FIXTURE/pubspec_overrides.yaml" ]] ||
+  fail "The hosted SDK verifier left its temporary override behind."
 if run_helper "$FIXTURE_DIR/path.json" >"$FIXTURE_DIR/path.out" 2>&1; then
   fail "A workspace/path SDK unexpectedly passed hosted dependency verification."
 fi
 grep -q 'Expected hosted mcp_dart 2.3.0' "$FIXTURE_DIR/path.out" ||
   fail "The path SDK fixture did not fail for hosted-source mismatch."
+[[ ! -e "$CLI_FIXTURE/pubspec_overrides.yaml" ]] ||
+  fail "A failed hosted SDK verification left its temporary override behind."
 if run_helper "$FIXTURE_DIR/newer.json" >"$FIXTURE_DIR/newer.out" 2>&1; then
   fail "A newer caret-compatible SDK unexpectedly passed minimum verification."
 fi

--- a/tool/release/verify_cli_published_sdk.sh
+++ b/tool/release/verify_cli_published_sdk.sh
@@ -28,10 +28,21 @@ if [[ -z "$EXPECTED_SDK_VERSION" ]]; then
   echo "Could not determine the minimum mcp_dart version." >&2
   exit 65
 fi
+if [[ ! "$EXPECTED_SDK_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+  echo "Invalid minimum mcp_dart version: $EXPECTED_SDK_VERSION." >&2
+  exit 65
+fi
 
-# Exercise the lower bound of the declared hosted SDK constraint. A normal
-# `pub get` can select a newer 2.3.x and hide a 2.3.0 compatibility regression.
-dart pub downgrade
+# Exercise only the lower bound of the declared hosted SDK constraint. A
+# package-wide `pub downgrade` can select transitive versions that predate the
+# CLI's Dart SDK and fail for reasons unrelated to mcp_dart compatibility.
+cleanup() {
+  rm -f pubspec_overrides.yaml
+}
+trap cleanup EXIT
+printf 'dependency_overrides:\n  mcp_dart: %s\n' \
+  "$EXPECTED_SDK_VERSION" >pubspec_overrides.yaml
+dart pub get
 DEPENDENCIES=$(dart pub deps --json)
 RESOLVED_SDK_VERSION=$(jq -r '
   [.packages[] | select(.name == "mcp_dart")][0].version // empty


### PR DESCRIPTION
## Summary

- pin only the declared minimum hosted `mcp_dart` during CLI release validation
- keep unrelated dependencies on their normal compatible resolution
- make package tests pass in an isolated publish candidate while retaining repository-only coverage
- document and regression-test the dependency-isolation behavior

## Why

The coordinated release published SDK `2.3.0-dev.3`, then safely stopped before the CLI tag because `dart pub downgrade` selected `file 6.0.0`, which is incompatible with Dart 3.12. The CLI source and published SDK were not the cause.

## Validation

- complete isolated candidate against hosted `mcp_dart 2.3.0-dev.3`: analyze, 120 tests, compile, version smoke
- full SDK suite: 1,949 tests
- TypeScript inspector stdio and Streamable HTTP tests
- all release workflow security/provenance fixtures
- root and CLI analyzers
- formatting, diff check, and shellcheck

After this merges and main CI is green, the supported manual Create Release recovery can publish `mcp_dart_cli 0.2.0-dev.3` from the new main commit. This PR does not create or move a release tag.