### PR TITLE
Fix MCP 2026 inspector callbacks

### DIFF
--- a/packages/mcp_dart_cli/CHANGELOG.md
+++ b/packages/mcp_dart_cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Fixed `inspect-server` support for MCP 2026-07-28 elicitation, roots, and
+  resource subscriptions.
+
 ## 0.2.0-dev.3
 
 - Development now targets Dart 3.12; the SDK and SDK-only generated projects

--- a/packages/mcp_dart_cli/CHANGELOG.md
+++ b/packages/mcp_dart_cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.2.0-dev.3
 
+- `inspect-server` now fulfills configured form-elicitation and roots callbacks
+  and uses `subscriptions/listen` for MCP 2026-07-28 resource subscriptions.
 - Development now targets Dart 3.12; the SDK and SDK-only generated projects
   support Dart 3.4.
 - Inspection recognizes stateless clients that skip optional discovery, accepts

--- a/packages/mcp_dart_cli/CHANGELOG.md
+++ b/packages/mcp_dart_cli/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## 0.2.0-dev.3
 
-- `inspect-server` now fulfills configured form-elicitation and roots callbacks
-  and uses `subscriptions/listen` for MCP 2026-07-28 resource subscriptions.
 - Development now targets Dart 3.12; the SDK and SDK-only generated projects
   support Dart 3.4.
 - Inspection recognizes stateless clients that skip optional discovery, accepts

--- a/packages/mcp_dart_cli/README.md
+++ b/packages/mcp_dart_cli/README.md
@@ -110,6 +110,11 @@ invoking every advertised operation:
   "tools": [{"name": "search", "arguments": {"query": "mcp"}}],
   "resource": {"uri": "file:///tmp/example.txt", "subscribe": false},
   "prompt": {"name": "summarize", "arguments": {"topic": "MCP"}},
+  "elicitation": {
+    "action": "accept",
+    "content": {"name": "Ada"}
+  },
+  "roots": [{"uri": "file:///workspace", "name": "workspace"}],
   "task": {
     "tool": "long_running",
     "arguments": {"duration": 250},
@@ -118,6 +123,13 @@ invoking every advertised operation:
   }
 }
 ```
+
+When a configured probe triggers MCP 2026-07-28 `input_required`, the
+inspector returns the configured elicitation response and roots. Without those
+fields it safely declines form elicitation and returns an empty roots list.
+Resource subscription probes use `subscriptions/listen` for MCP 2026-07-28
+and retain `resources/subscribe` plus `resources/unsubscribe` for older
+protocol versions.
 
 ```bash
 mcp_dart inspect-server --json --probe-config probes.json -- node server.js

--- a/packages/mcp_dart_cli/doc/inspection-coverage.md
+++ b/packages/mcp_dart_cli/doc/inspection-coverage.md
@@ -20,10 +20,10 @@ commit or upload reports unreviewed, and delete them when no longer needed.
 | Lifecycle and JSON-RPC | Stateless discovery or legacy initialization, implementation metadata, capabilities, legacy ping, IDs, and well-formed observed frames | Methods removed by MCP 2026-07-28 are reported without probing them; raw negative cases live primarily in `conformance` |
 | Transports | Live stdio and Streamable HTTP, session/protocol metadata, Origin behavior, GET/DELETE probes, stdio tracing | No automatic resumability/redelivery scenario |
 | Tools | List shape, unique names, schemas, configured calls, structured output validation | Does not invoke every ordinary tool without explicit arguments |
-| Resources | Resources/templates listing, URI shape, configured read, optional subscribe/unsubscribe | Reads and subscriptions require explicit probe configuration |
+| Resources | Resources/templates listing, URI shape, configured read, MCP 2026-07-28 `subscriptions/listen`, and legacy subscribe/unsubscribe | Reads and subscriptions require explicit probe configuration |
 | Prompts | List shape, arguments, configured `prompts/get` | Prompt retrieval requires explicit probe configuration |
 | Completions | Configured prompt-argument completion when advertised | Completion requires explicit probe configuration |
-| Client roots, sampling, elicitation | Records capabilities; probes legacy clients only with explicit `inspect-client --active-probes` | Active probes can expose roots, incur model cost, or open UI; stateless clients use MCP 2026-07-28 MRTR |
+| Client roots, sampling, elicitation | Handles MCP 2026-07-28 MRTR during configured server probes; probes legacy clients with explicit `inspect-client --active-probes` | Server probes safely decline form elicitation and return no roots unless explicit responses are configured; sampling uses a placeholder response |
 | Logging, progress, notifications | Logging level, observed notifications, numeric/non-decreasing progress | Does not trigger every list-change notification |
 | Cancellation | Task cancellation through configured probes | General request cancellation is not actively inspected |
 | Authorization | Same-origin protected-resource and authorization-server discovery, bearer challenges, PKCE S256 metadata | Server-advertised cross-origin OAuth URLs are reported but not followed; no credentialed token exchange |

--- a/packages/mcp_dart_cli/lib/src/inspect_server_command.dart
+++ b/packages/mcp_dart_cli/lib/src/inspect_server_command.dart
@@ -245,7 +245,13 @@ class McpServerInspector {
   /// Inspects [target].
   Future<InspectionReport> inspect(ServerInspectionTarget target) async {
     final checks = InspectionCheckBuilder();
-    final handlers = InspectHandlers(_logger, silent: silentHandlers);
+    final handlers = InspectHandlers(
+      _logger,
+      silent: silentHandlers,
+      elicitationResponse: probeConfig.elicitationResponse,
+      roots: probeConfig.roots,
+      handleRoots: true,
+    );
     final inventory = <String, dynamic>{};
     final metadata = <String, dynamic>{
       'transport': target.transport,
@@ -857,6 +863,15 @@ class McpServerInspector {
       return;
     }
     try {
+      if (_usesStatelessProtocol(client)) {
+        await _probeStatelessResourceSubscription(
+          client,
+          resource.uri,
+          checks,
+          inventory,
+        );
+        return;
+      }
       await client.subscribeResource(
         SubscribeRequest(uri: resource.uri),
         const RequestOptions(timeout: Duration(seconds: 5)),
@@ -880,6 +895,59 @@ class McpServerInspector {
         'resources.subscribe',
         'Server advertises resources.subscribe but subscribe/unsubscribe failed for ${resource.uri}: $error',
       );
+    }
+  }
+
+  Future<void> _probeStatelessResourceSubscription(
+    McpClient client,
+    String resourceUri,
+    InspectionCheckBuilder checks,
+    Map<String, dynamic> inventory,
+  ) async {
+    McpSubscription? subscription;
+    try {
+      subscription = client.listenSubscriptions(
+        SubscriptionsListenRequest(
+          notifications: SubscriptionFilter(
+            resourceSubscriptions: <String>[resourceUri],
+          ),
+        ),
+      );
+      final acknowledgment = await subscription.acknowledged.timeout(
+        const Duration(seconds: 5),
+      );
+      final acknowledgedResources =
+          acknowledgment.notifications.resourceSubscriptions;
+      if (acknowledgedResources == null ||
+          !acknowledgedResources.contains(resourceUri)) {
+        throw StateError(
+          'subscriptions/listen did not acknowledge $resourceUri.',
+        );
+      }
+
+      subscription.cancel('CLI inspection completed.');
+      await subscription.done.timeout(const Duration(seconds: 5));
+      inventory['resourceSubscriptions'] = <Map<String, dynamic>>[
+        <String, dynamic>{
+          'uri': resourceUri,
+          'method': Method.subscriptionsListen,
+          'acknowledged': true,
+          'cancelled': true,
+        },
+      ];
+      checks.pass(
+        'resources.subscribe',
+        'subscriptions/listen acknowledged and cancelled cleanly for '
+            '$resourceUri.',
+      );
+    } catch (error) {
+      checks.fail(
+        'resources.subscribe',
+        'Server advertises resources.subscribe but subscriptions/listen '
+            'failed for $resourceUri: $error',
+      );
+    } finally {
+      subscription?.cancel('CLI inspection cleanup.');
     }
   }
 
@@ -2084,6 +2152,8 @@ class InspectionProbeConfig {
     this.prompt,
     this.completion,
     this.task,
+    this.elicitationResponse,
+    this.roots = const <Root>[],
   });
 
   /// Tool calls to execute with caller-provided arguments.
@@ -2100,6 +2170,16 @@ class InspectionProbeConfig {
 
   /// Task probe override.
   final TaskProbe? task;
+
+  /// Response returned when a configured probe triggers form elicitation.
+  ///
+  /// When omitted, the inspector safely declines the request.
+  final ElicitResult? elicitationResponse;
+
+  /// Roots returned when a configured probe triggers `roots/list`.
+  ///
+  /// When omitted, the inspector returns an empty roots list.
+  final List<Root> roots;
 
   /// Parses a JSON probe configuration.
   factory InspectionProbeConfig.fromJson(Map<String, dynamic> json) {
@@ -2127,6 +2207,12 @@ class InspectionProbeConfig {
               (json['task'] as Map).cast<String, dynamic>(),
             )
           : null,
+      elicitationResponse: json['elicitation'] is Map
+          ? ElicitResult.fromJson(
+              (json['elicitation'] as Map).cast<String, dynamic>(),
+            )
+          : null,
+      roots: _readObjectList(json['roots']).map(Root.fromJson).toList(),
     );
   }
 }

--- a/packages/mcp_dart_cli/lib/src/inspect_server_command.dart
+++ b/packages/mcp_dart_cli/lib/src/inspect_server_command.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -905,6 +906,7 @@ class McpServerInspector {
     Map<String, dynamic> inventory,
   ) async {
     McpSubscription? subscription;
+    StreamSubscription<JsonRpcNotification>? notificationDrain;
     try {
       subscription = client.listenSubscriptions(
         SubscriptionsListenRequest(
@@ -912,6 +914,12 @@ class McpServerInspector {
             resourceSubscriptions: <String>[resourceUri],
           ),
         ),
+      );
+      // The request's `done` future remains authoritative for failures. Drain
+      // notifications so the client can close the observed stream cleanly.
+      notificationDrain = subscription.notifications.listen(
+        (_) {},
+        onError: (Object _) {},
       );
       final acknowledgment = await subscription.acknowledged.timeout(
         const Duration(seconds: 5),
@@ -948,6 +956,7 @@ class McpServerInspector {
       );
     } finally {
       subscription?.cancel('CLI inspection cleanup.');
+      await notificationDrain?.cancel();
     }
   }
 

--- a/packages/mcp_dart_cli/lib/src/utils/inspect_handlers.dart
+++ b/packages/mcp_dart_cli/lib/src/utils/inspect_handlers.dart
@@ -5,10 +5,21 @@ import 'package:mcp_dart/mcp_dart.dart' hide Logger;
 
 /// Manages client-side handlers for server notifications and requests.
 class InspectHandlers {
-  InspectHandlers(this._logger, {this._silent = false});
+  InspectHandlers(
+    this._logger, {
+    this._silent = false,
+    ElicitResult? elicitationResponse,
+    List<Root> roots = const <Root>[],
+    this._handleRoots = false,
+  }) : _elicitationResponse =
+           elicitationResponse ?? const ElicitResult(action: 'decline'),
+       _roots = List<Root>.unmodifiable(roots);
 
   final Logger _logger;
   final bool _silent;
+  final ElicitResult _elicitationResponse;
+  final List<Root> _roots;
+  final bool _handleRoots;
   final List<Map<String, dynamic>> _notifications = <Map<String, dynamic>>[];
   final Map<String, num> _lastProgressByToken = <String, num>{};
   final List<Map<String, dynamic>> _progressIssues = <Map<String, dynamic>>[];
@@ -32,11 +43,40 @@ class InspectHandlers {
 
   /// Registers all handlers with the given client.
   void registerHandlers(McpClient client) {
+    client.onElicitRequest = _handleElicitRequest;
     // Register sampling request handler
     client.onSamplingRequest = _handleSamplingRequest;
+    if (_handleRoots) {
+      client.setRequestHandler<JsonRpcListRootsRequest>(
+        Method.rootsList,
+        (request, extra) async => ListRootsResult(roots: _roots),
+        (id, params, meta) => JsonRpcListRootsRequest.fromJson(
+          <String, dynamic>{
+            'jsonrpc': jsonRpcVersion,
+            'id': id,
+            'method': Method.rootsList,
+            'params': ?params,
+            '_meta': ?meta,
+          },
+        ),
+      );
+    }
 
     // Register notification handlers using fallback
     client.fallbackNotificationHandler = _handleNotification;
+  }
+
+  /// Handles elicitation/create requests from the server.
+  Future<ElicitResult> _handleElicitRequest(ElicitRequest params) async {
+    if (!_silent) {
+      _logger.info('\n[Elicitation Request]');
+      _logger.info('Mode: ${params.mode?.name ?? ElicitationMode.form.name}');
+      _logger.info('Message: ${params.message}');
+      _logger.info(
+        'Returning the configured response without interactive input.',
+      );
+    }
+    return _elicitationResponse;
   }
 
   /// Handles sampling/createMessage requests from the server.

--- a/packages/mcp_dart_cli/lib/src/utils/inspect_handlers.dart
+++ b/packages/mcp_dart_cli/lib/src/utils/inspect_handlers.dart
@@ -50,15 +50,7 @@ class InspectHandlers {
       client.setRequestHandler<JsonRpcListRootsRequest>(
         Method.rootsList,
         (request, extra) async => ListRootsResult(roots: _roots),
-        (id, params, meta) => JsonRpcListRootsRequest.fromJson(
-          <String, dynamic>{
-            'jsonrpc': jsonRpcVersion,
-            'id': id,
-            'method': Method.rootsList,
-            'params': ?params,
-            '_meta': ?meta,
-          },
-        ),
+        (id, params, meta) => JsonRpcListRootsRequest(id: id, meta: meta),
       );
     }
 
@@ -73,7 +65,8 @@ class InspectHandlers {
       _logger.info('Mode: ${params.mode?.name ?? ElicitationMode.form.name}');
       _logger.info('Message: ${params.message}');
       _logger.info(
-        'Returning the configured response without interactive input.',
+        'Returning the configured or safe default response without '
+        'interactive input.',
       );
     }
     return _elicitationResponse;

--- a/packages/mcp_dart_cli/test/fixtures/stateless_input_required_server.dart
+++ b/packages/mcp_dart_cli/test/fixtures/stateless_input_required_server.dart
@@ -1,0 +1,129 @@
+import 'package:mcp_dart/mcp_dart.dart';
+
+const _resourceUri = 'demo://status';
+
+Future<void> main() async {
+  late final McpServer server;
+  server = McpServer(
+    const Implementation(
+      name: 'stateless-input-required-fixture',
+      version: '1.0.0',
+    ),
+    options: const McpServerOptions(
+      protocol: McpProtocol.require2026,
+      capabilities: ServerCapabilities(
+        tools: ServerCapabilitiesTools(),
+        resources: ServerCapabilitiesResources(subscribe: true),
+      ),
+    ),
+  );
+
+  server.registerStatelessTool(
+    'collect_profile',
+    description: 'Requests form input from the inspecting client.',
+    callback: (args, extra) async {
+      final response = extra.inputResponses?['profile'];
+      if (response != null) {
+        return CallToolResult.fromStructuredContent(response.toJson());
+      }
+      return InputRequiredResult(
+        inputRequests: <String, InputRequest>{
+          'profile': InputRequest.elicit(
+            ElicitRequest.form(
+              message: 'What name should the fixture use?',
+              requestedSchema: JsonSchema.object(
+                properties: <String, JsonSchema>{
+                  'name': JsonSchema.string(minLength: 1),
+                },
+                required: <String>['name'],
+              ),
+            ),
+          ),
+        },
+      );
+    },
+  );
+
+  server.registerStatelessTool(
+    'list_client_roots',
+    description: 'Requests roots from the inspecting client.',
+    callback: (args, extra) async {
+      final response = extra.inputResponses?['roots'];
+      if (response != null) {
+        return CallToolResult.fromStructuredContent(response.toJson());
+      }
+      return InputRequiredResult(
+        inputRequests: <String, InputRequest>{
+          'roots': InputRequest.listRoots(),
+        },
+      );
+    },
+  );
+
+  server.registerStatelessTool(
+    'sample_text',
+    description: 'Requests sampling from the inspecting client.',
+    callback: (args, extra) async {
+      final response = extra.inputResponses?['sample'];
+      if (response != null) {
+        return CallToolResult.fromStructuredContent(response.toJson());
+      }
+      return InputRequiredResult(
+        inputRequests: <String, InputRequest>{
+          'sample': InputRequest.createMessage(
+            const CreateMessageRequest(
+              messages: <SamplingMessage>[
+                SamplingMessage(
+                  role: SamplingMessageRole.user,
+                  content: SamplingTextContent(text: 'Say hello.'),
+                ),
+              ],
+              maxTokens: 8,
+            ),
+          ),
+        },
+      );
+    },
+  );
+
+  server.registerResource(
+    'status',
+    _resourceUri,
+    (
+      description: 'Fixture status.',
+      mimeType: 'text/plain',
+    ),
+    (uri, extra) async => ReadResourceResult(
+      contents: <ResourceContents>[
+        TextResourceContents(
+          uri: uri.toString(),
+          mimeType: 'text/plain',
+          text: 'ready',
+        ),
+      ],
+    ),
+  );
+
+  server.server.setRequestHandler<JsonRpcSubscriptionsListenRequest>(
+    Method.subscriptionsListen,
+    (request, extra) async {
+      final acknowledged = request.listenParams.notifications.acknowledgedBy(
+        server.server.getCapabilities(),
+      );
+      await extra.sendSubscriptionAcknowledged(acknowledged);
+      await extra.sendSubscriptionNotification(
+        JsonRpcResourceUpdatedNotification(
+          updatedParams: const ResourceUpdatedNotification(uri: _resourceUri),
+        ),
+      );
+      return const EmptyResult();
+    },
+    (id, params, meta) => JsonRpcSubscriptionsListenRequest(
+      id: id,
+      listenParams: SubscriptionsListenRequest.fromJson(params!),
+      meta: meta,
+    ),
+  );
+
+  await server.connect(StdioServerTransport());
+}

--- a/packages/mcp_dart_cli/test/src/inspect_handlers_test.dart
+++ b/packages/mcp_dart_cli/test/src/inspect_handlers_test.dart
@@ -110,13 +110,11 @@ void main() {
           action: 'accept',
           content: <String, dynamic>{'name': 'Ada'},
         ),
-        handleRoots: true,
       );
       final client = McpClient(
         const Implementation(name: 'test-client', version: '1.0.0'),
         options: const McpClientOptions(
           capabilities: ClientCapabilities(
-            roots: ClientCapabilitiesRoots(),
             elicitation: ClientElicitation.formOnly(),
           ),
         ),

--- a/packages/mcp_dart_cli/test/src/inspect_handlers_test.dart
+++ b/packages/mcp_dart_cli/test/src/inspect_handlers_test.dart
@@ -13,6 +13,13 @@ void main() {
       final handlers = InspectHandlers(logger, silent: true);
       final client = McpClient(
         const Implementation(name: 'test-client', version: '1.0.0'),
+        options: const McpClientOptions(
+          capabilities: ClientCapabilities(
+            roots: ClientCapabilitiesRoots(),
+            sampling: ClientCapabilitiesSampling(),
+            elicitation: ClientElicitation.formOnly(),
+          ),
+        ),
       );
       var toolsChanged = 0;
       handlers.onToolsListChanged = () => toolsChanged++;
@@ -69,6 +76,16 @@ void main() {
           maxTokens: 1,
         ),
       );
+      final elicitationResult = await client.onElicitRequest!(
+        ElicitRequest.form(
+          message: 'Name?',
+          requestedSchema: JsonSchema.object(
+            properties: <String, JsonSchema>{
+              'name': JsonSchema.string(),
+            },
+          ),
+        ),
+      );
 
       expect(toolsChanged, equals(1));
       expect(handlers.notifications, hasLength(5));
@@ -77,10 +94,49 @@ void main() {
         containsPair('issue', 'progress decreased for token'),
       );
       expect(samplingResult.model, equals('mcp-dart-cli-placeholder'));
+      expect(elicitationResult.declined, isTrue);
       verifyNever(() => logger.detail(any()));
       verifyNever(() => logger.info(any()));
       verifyNever(() => logger.warn(any()));
       verifyNever(() => logger.err(any()));
+    });
+
+    test('returns a configured elicitation response', () async {
+      final logger = MockLogger();
+      final handlers = InspectHandlers(
+        logger,
+        silent: true,
+        elicitationResponse: const ElicitResult(
+          action: 'accept',
+          content: <String, dynamic>{'name': 'Ada'},
+        ),
+        handleRoots: true,
+      );
+      final client = McpClient(
+        const Implementation(name: 'test-client', version: '1.0.0'),
+        options: const McpClientOptions(
+          capabilities: ClientCapabilities(
+            roots: ClientCapabilitiesRoots(),
+            elicitation: ClientElicitation.formOnly(),
+          ),
+        ),
+      );
+      handlers.registerHandlers(client);
+
+      final result = await client.onElicitRequest!(
+        ElicitRequest.form(
+          message: 'Name?',
+          requestedSchema: JsonSchema.object(
+            properties: <String, JsonSchema>{
+              'name': JsonSchema.string(),
+            },
+            required: <String>['name'],
+          ),
+        ),
+      );
+
+      expect(result.accepted, isTrue);
+      expect(result.content, containsPair('name', 'Ada'));
     });
   });
 }

--- a/packages/mcp_dart_cli/test/src/inspect_server_command_test.dart
+++ b/packages/mcp_dart_cli/test/src/inspect_server_command_test.dart
@@ -58,6 +58,16 @@ void main() {
           'arguments': <String, dynamic>{'message': 'cancel me'},
           'cancel': true,
         },
+        'elicitation': <String, dynamic>{
+          'action': 'accept',
+          'content': <String, dynamic>{'name': 'Ada'},
+        },
+        'roots': <Map<String, dynamic>>[
+          <String, dynamic>{
+            'uri': 'file:///tmp/demo',
+            'name': 'demo',
+          },
+        ],
       });
 
       expect(config.toolCalls.single.name, equals('echo'));
@@ -67,6 +77,9 @@ void main() {
       expect(config.completion?.value, equals('D'));
       expect(config.task?.tool, equals('delayed_echo'));
       expect(config.task?.cancel, isTrue);
+      expect(config.elicitationResponse?.accepted, isTrue);
+      expect(config.elicitationResponse?.content, containsPair('name', 'Ada'));
+      expect(config.roots.single.uri, equals('file:///tmp/demo'));
     });
 
     test('inspects a Dart stdio server command', () async {
@@ -306,6 +319,117 @@ void main() {
       );
       expect(serverInfoCheck.status, 'info');
       expect(serverInfoCheck.message, contains('optional'));
+    });
+
+    test(
+      'handles 2026 elicitation, roots, sampling, and subscriptions',
+      () async {
+        final report =
+            await McpServerInspector(
+              logger: MockLogger(),
+              silentHandlers: true,
+              probeConfig: InspectionProbeConfig.fromJson(<String, dynamic>{
+                'tools': <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'name': 'collect_profile',
+                    'arguments': <String, dynamic>{},
+                  },
+                  <String, dynamic>{
+                    'name': 'list_client_roots',
+                    'arguments': <String, dynamic>{},
+                  },
+                  <String, dynamic>{
+                    'name': 'sample_text',
+                    'arguments': <String, dynamic>{},
+                  },
+                ],
+                'resource': <String, dynamic>{
+                  'uri': 'demo://status',
+                  'subscribe': true,
+                },
+                'elicitation': <String, dynamic>{
+                  'action': 'accept',
+                  'content': <String, dynamic>{'name': 'Ada'},
+                },
+                'roots': <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'uri': 'file:///tmp/demo',
+                    'name': 'demo',
+                  },
+                ],
+              }),
+            ).inspect(
+              const ServerInspectionTarget(
+                command: 'dart',
+                serverArgs: <String>[
+                  'run',
+                  'test/fixtures/stateless_input_required_server.dart',
+                ],
+                url: null,
+                env: <String, String>{},
+              ),
+            );
+
+        expect(report.passed, isTrue);
+        final checksById = <String, InspectionCheck>{
+          for (final check in report.checks) check.id: check,
+        };
+        for (final id in <String>[
+          'tools.call.collect_profile',
+          'tools.call.list_client_roots',
+          'tools.call.sample_text',
+          'resources.subscribe',
+        ]) {
+          expect(checksById[id]?.status, equals('pass'), reason: id);
+        }
+        final subscriptions =
+            report.inventory['resourceSubscriptions'] as List<dynamic>;
+        expect(
+          subscriptions.single,
+          containsPair('method', Method.subscriptionsListen),
+        );
+      },
+    );
+
+    test('uses safe defaults for 2026 elicitation and roots', () async {
+      final report =
+          await McpServerInspector(
+            logger: MockLogger(),
+            silentHandlers: true,
+            probeConfig: InspectionProbeConfig.fromJson(<String, dynamic>{
+              'tools': <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'name': 'collect_profile',
+                  'arguments': <String, dynamic>{},
+                },
+                <String, dynamic>{
+                  'name': 'list_client_roots',
+                  'arguments': <String, dynamic>{},
+                },
+              ],
+            }),
+          ).inspect(
+            const ServerInspectionTarget(
+              command: 'dart',
+              serverArgs: <String>[
+                'run',
+                'test/fixtures/stateless_input_required_server.dart',
+              ],
+              url: null,
+              env: <String, String>{},
+            ),
+          );
+
+      expect(report.passed, isTrue);
+      final checksById = <String, InspectionCheck>{
+        for (final check in report.checks) check.id: check,
+      };
+      for (final id in <String>[
+        'tools.call.collect_profile',
+        'tools.call.list_client_roots',
+      ]) {
+        expect(checksById[id]?.status, equals('pass'), reason: id);
+      }
     });
 
     test(


### PR DESCRIPTION
## Summary

- fulfill advertised form-elicitation and roots callbacks during configured MCP 2026-07-28 server probes, with safe decline/empty defaults
- probe modern resource subscriptions through `subscriptions/listen` while retaining legacy `resources/subscribe` and `resources/unsubscribe`
- add a public-API fixture, compatibility regressions, probe configuration documentation, and an unreleased CLI changelog entry

## Root cause

`inspect-server` advertised elicitation and roots capabilities but its shared handler only implemented sampling. A server that returned MCP 2026-07-28 `input_required` therefore received method-not-found responses for form elicitation and roots. The configured resource subscription probe also called the legacy `resources/subscribe` method unconditionally even though that method was removed from the 2026-07-28 protocol.

## Validation

- `dart format --output=none --set-exit-if-changed ...`
- `dart analyze` from `packages/mcp_dart_cli`: no issues
- `dart test` from `packages/mcp_dart_cli`: 133 passed, 5 optional Python fixture skips
- TypeScript fixture: `npm ci`, `npm run build`, `npm run lint`, and `npm run format:check`
- `dart test test/src/inspect_server_command_test.dart test/e2e/cli_interop_e2e_test.dart`: TypeScript stdio, HTTP, filesystem, client, server, and trace paths passed; 5 Python fixture cases skipped because the Python SDK is not installed locally
- real-user smoke with the compiled CLI against the published SDK kitchen-sink server: 33 passed, 5 informational, 0 warnings, 0 failures; add, progress, form elicitation, sampling, roots, and `subscriptions/listen` all completed

## Remaining blockers

None known for this focused fix. CI remains authoritative. The optional Python fixture cases were not run locally because that SDK is not installed in the isolated worktree.
