### PR TITLE
Prepare mcp_dart 2.4.0 release

### DIFF
--- a/.github/workflows/test_core.yml
+++ b/.github/workflows/test_core.yml
@@ -103,8 +103,14 @@ jobs:
         run: dart test
 
   api-compatibility:
-    name: public API compatibility (mcp_dart 2.2.2)
+    name: public API compatibility (mcp_dart ${{ matrix.version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - 2.2.2
+          - 2.3.0
 
     steps:
       - name: Checkout code
@@ -118,14 +124,16 @@ jobs:
       - name: Install API compatibility checker
         run: dart pub global activate dart_apitool 0.23.1
 
-      - name: Compare public API with mcp_dart 2.2.2
+      - name: Compare public API with mcp_dart ${{ matrix.version }}
+        env:
+          PUBLISHED_VERSION: ${{ matrix.version }}
         run: |
           mkdir -p "$RUNNER_TEMP/mcp_dart_api"
           git archive HEAD lib pubspec.yaml analysis_options.yaml |
             tar -x -C "$RUNNER_TEMP/mcp_dart_api"
           set +e
           dart-apitool diff \
-            --old pub://mcp_dart/2.2.2 \
+            --old "pub://mcp_dart/$PUBLISHED_VERSION" \
             --new "$RUNNER_TEMP/mcp_dart_api" \
             --version-check-mode onlyBreakingChanges \
             --ignore-prerelease \
@@ -140,10 +148,12 @@ jobs:
             exit "$API_TOOL_STATUS"
           fi
 
-          # dart_apitool 0.23.1 misclassifies these four newly added optional
-          # static-factory parameters as required. Allow only that exact set;
-          # compile fixtures cover the corresponding public call shapes.
-          if ! jq -e '
+          # Against 2.2.2, dart_apitool 0.23.1 misclassifies these four newly
+          # added optional static-factory parameters as required. Allow only
+          # that exact set on that legacy baseline; compile fixtures cover the
+          # corresponding public call shapes. The latest stable baseline must
+          # report no breaking changes.
+          if ! jq -e --arg publishedVersion "$PUBLISHED_VERSION" '
             def changes($path):
               if type == "object" and has("changeDescription") then
                 [{
@@ -160,28 +170,31 @@ jobs:
               end;
             (.report.breakingChanges | changes([]) | sort_by(.path)) as $actual
             | ($actual | length == 0)
-              or $actual == [
-                {
-                  path: "BREAKING CHANGES > Class JsonSchema > Method boolean",
-                  code: "CE02",
-                  description: "Parameter \"mcpHeader\" added (required)"
-                },
-                {
-                  path: "BREAKING CHANGES > Class JsonSchema > Method integer",
-                  code: "CE02",
-                  description: "Parameter \"mcpHeader\" added (required)"
-                },
-                {
-                  path: "BREAKING CHANGES > Class JsonSchema > Method number",
-                  code: "CE02",
-                  description: "Parameter \"mcpHeader\" added (required)"
-                },
-                {
-                  path: "BREAKING CHANGES > Class JsonSchema > Method string",
-                  code: "CE02",
-                  description: "Parameter \"mcpHeader\" added (required)"
-                }
-              ]
+              or (
+                $publishedVersion == "2.2.2"
+                and $actual == [
+                  {
+                    path: "BREAKING CHANGES > Class JsonSchema > Method boolean",
+                    code: "CE02",
+                    description: "Parameter \"mcpHeader\" added (required)"
+                  },
+                  {
+                    path: "BREAKING CHANGES > Class JsonSchema > Method integer",
+                    code: "CE02",
+                    description: "Parameter \"mcpHeader\" added (required)"
+                  },
+                  {
+                    path: "BREAKING CHANGES > Class JsonSchema > Method number",
+                    code: "CE02",
+                    description: "Parameter \"mcpHeader\" added (required)"
+                  },
+                  {
+                    path: "BREAKING CHANGES > Class JsonSchema > Method string",
+                    code: "CE02",
+                    description: "Parameter \"mcpHeader\" added (required)"
+                  }
+                ]
+              )
           ' "$RUNNER_TEMP/mcp_dart_api_report.json"; then
             jq '.report.breakingChanges' \
               "$RUNNER_TEMP/mcp_dart_api_report.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## Unreleased
+## 2.4.0
+
+`mcp_dart 2.4` adds an opt-in legacy HTTP+SSE client for connecting to older
+servers while keeping Streamable HTTP as the preferred remote transport.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ extensions, host UI behavior, an authorization-server implementation, JSON
 Schema external-reference resolution, and custom JSON Schema vocabularies.
 
 > [!IMPORTANT]
-> The coordinated stable release pairs `mcp_dart 2.3.0` with
-> `mcp_dart_cli 0.2.0`. Current source passes the official alpha.10 MCP
+> The current stable packages are `mcp_dart 2.4.0` and
+> `mcp_dart_cli 0.2.0`; the CLI's `^2.3.0` SDK constraint accepts 2.4.
+> Current source passes the official alpha.10 MCP
 > `2026-07-28` client and server suites with no expected failures, including
 > all 25 authorization scenarios, plus bidirectional published TypeScript SDK
 > 2.0.0 and Python SDK 2.0.0 interoperability.
@@ -39,7 +40,7 @@ The public maintenance contract is documented in the
 
 | Package | Minimum Dart SDK |
 | --- | --- |
-| `mcp_dart 2.3.0` | 3.4 |
+| `mcp_dart 2.4.0` | 3.4 |
 | `mcp_dart_cli 0.2.0` | 3.12 |
 
 SDK-only generated projects retain the SDK's Dart 3.4 minimum. CLI projects
@@ -57,22 +58,22 @@ Use the latest stable package for production projects:
 dart pub add mcp_dart
 ```
 
-### Pin the coordinated stable release
+### Pin the stable SDK release
 
-Pin the stable 2.3 line explicitly when reproducible dependency resolution is
+Pin the stable 2.4 line explicitly when reproducible dependency resolution is
 important:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.3.0
+  mcp_dart: ^2.4.0
 ```
 
-The snippets below use the coordinated stable package line. Package versions
+The snippets below use the current stable SDK line. Package versions
 remain separate from protocol profiles: `McpProtocol.stable` names the SDK's
 default compatibility policy.
 
-The coordinated release publishes the SDK first and the CLI after the exact SDK
-version is available on pub.dev.
+The SDK and CLI are versioned independently. The stable CLI's `^2.3.0`
+constraint remains compatible with the 2.4 SDK.
 
 For direct SDK integration, start with the
 [getting-started guide](https://github.com/leehack/mcp_dart/blob/main/doc/getting-started.md).
@@ -98,10 +99,9 @@ commands.
   2.0.0 interoperability, real-browser transport tests, a real Flutter Web
   service integration in Chrome, deterministic widget tests, and an
   independent pinned JSON Schema Test Suite gate.
-- Current unreleased source adds a deprecated, opt-in legacy HTTP+SSE client
+- `mcp_dart 2.4.0` adds a deprecated, opt-in legacy HTTP+SSE client
   with same-origin routing and bidirectional interoperability against official
-  TypeScript SDK 1.30.0 and Python SDK 2.0.0 peers. Stable `2.3.0` does not
-  include that client; it requires the next approved minor SDK release.
+  TypeScript SDK 1.30.0 and Python SDK 2.0.0 peers.
 
 MCP has three roles: a host owns the user experience, a client connects that
 host to one server, and a server exposes tools, resources, and prompts. A host
@@ -237,7 +237,7 @@ surface. Re-check both packages' current releases before a production decision.
 - [Versioning policy](https://github.com/leehack/mcp_dart/blob/main/VERSIONING.md)
 - [Tier 1 roadmap](https://github.com/leehack/mcp_dart/blob/main/ROADMAP.md)
 - [SDK on pub.dev](https://pub.dev/packages/mcp_dart)
-- [2.3.0 API reference](https://pub.dev/documentation/mcp_dart/2.3.0/)
+- [2.4.0 API reference](https://pub.dev/documentation/mcp_dart/2.4.0/)
 - [Changelog](https://github.com/leehack/mcp_dart/blob/main/CHANGELOG.md)
 - [MCP 2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28)
 - [MCP 2025-11-25 specification](https://modelcontextprotocol.io/specification/2025-11-25)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ through the
 
 ## Current baseline
 
-- Stable `mcp_dart 2.3.0` and `mcp_dart_cli 0.2.0` releases.
+- Stable `mcp_dart 2.4.0` and `mcp_dart_cli 0.2.0` releases.
 - Complete Core client/server support for MCP 2026-07-28 with an explicit
   MCP 2025-11-25 compatibility profile.
 - Exact-head CI passes the published official conformance package for both
@@ -30,7 +30,7 @@ outside the Tier 1 Core claim.
 | --- | --- | --- |
 | Publish maintenance, security, dependency, and versioning policies | Policies are linked from the README and pass the official policy evaluation | Complete: the official checker finds all required policy signals; final qualitative judgment remains with reviewers |
 | Adopt the MCP issue taxonomy | All required type, status, and priority labels exist; every open issue is triaged | Complete: 12/12 labels and 100% current open-issue triage |
-| Audit the project-maintained Tier 1 documentation inventory | All 48 items mapped from the published non-experimental tier requirements have user-facing prose and a runnable or near-runnable example | Complete in source: 48/48; published `mcp_dart 2.3.0` is 47/48 because the additive legacy SSE client requires the next approved minor release |
+| Audit the project-maintained Tier 1 documentation inventory | All 48 items mapped from the published non-experimental tier requirements have user-facing prose and a runnable or near-runnable example | Complete: published `mcp_dart 2.4.0` covers all 48 items |
 | Join the official SDK conformance matrix | The conformance repository can build and run `mcp_dart` client and server fixtures by repository/ref | Planned |
 | Resolve SDK tiering eligibility | The SDK Working Group confirms whether an external community SDK can receive a tier or accepts `mcp_dart` into the official SDK roster | Planned: the tiering page describes community-driven SDKs, while the [SDK Working Group charter](https://modelcontextprotocol.io/community/working-groups/sdk) excludes third-party SDKs outside the MCP organization |
 | Produce a repository evidence scorecard | Current client and server fixtures each score 100% for applicable dated scenarios | Complete: the pinned self-assessment returns Tier 1 on deterministic checks; official matrix integration remains planned |
@@ -56,16 +56,16 @@ interoperability instead.
 | Required issue labels | 12/12 |
 | Open-issue triage | 100% within two business days; 2 open issues, median 0 hours |
 | Open `P0` issues | 0 |
-| Published stable SDK release | `mcp_dart 2.3.0` |
-| Published stable documentation inventory | `mcp_dart 2.3.0` is 47/48; current source is 48/48 |
+| Published stable SDK release | `mcp_dart 2.4.0` |
+| Published stable documentation inventory | `mcp_dart 2.4.0` is 48/48 |
 | Latest-spec release gap | 0 days |
 | Self-assessment result | Tier 1; all deterministic checks pass |
 
 The self-assessment result does not assign a formal tier. Qualitative
 documentation, policy, and roadmap judgment, SDK eligibility, official
 SDK-matrix integration, a public advancement request, and SDK Working Group
-approval remain separate gates. Publishing the source-level legacy SSE client
-is a backward-compatibility release task, not an MCP 2026-07-28 Core blocker.
+approval remain separate gates. The deprecated legacy SSE client is published
+for backward compatibility and remains outside the MCP 2026-07-28 Core claim.
 The current triage score also does not erase that issue #177 was historically
 labeled outside the two-business-day target; that exception must be disclosed
 in any external review.

--- a/doc/client-guide.md
+++ b/doc/client-guide.md
@@ -62,7 +62,7 @@ final client = McpClient(
 
 ### Protocol Profile
 
-Clients in mcp_dart 2.3.0 use `McpProtocol.stable` by default, which
+Clients in mcp_dart 2.3 and later use `McpProtocol.stable` by default, which
 prefers MCP `2026-07-28` negotiation. The default client probes with
 `server/discover`, sends stateless request metadata for a compatible peer, and
 falls back to legacy `initialize` when discovery is unavailable. On body-only

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -8,7 +8,7 @@ Add the MCP Dart SDK to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.3.0
+  mcp_dart: ^2.4.0
 ```
 
 Then run:

--- a/doc/mcp-2026-07-28-release-runbook.md
+++ b/doc/mcp-2026-07-28-release-runbook.md
@@ -132,7 +132,8 @@ dart format --output=none --set-exit-if-changed .
 dart analyze
 dart test
 dart tool/validate_release_metadata.dart --package mcp_dart
-dart tool/validate_release_metadata.dart --package mcp_dart_cli
+# For a selected CLI release, also run:
+# dart tool/validate_release_metadata.dart --package mcp_dart_cli
 SPEC_REF="$(tr -d '[:space:]' < tool/testing/mcp_2026_07_28_spec_ref.txt)"
 git clone --filter=blob:none --no-checkout \
   https://github.com/modelcontextprotocol/modelcontextprotocol.git \
@@ -204,26 +205,33 @@ Run the schema and document audits against the final, versioned paths in the
 exact pinned Core checkout. The recorded commit SHA keeps those release
 artifacts immutable.
 
+For a single-package follow-up release, skip the other package's metadata
+command above. Its published version and compatible dependency constraints
+remain unchanged; the release-prep workflow makes the same selection from the
+version diff. Still run that package's normal analysis and tests.
+
 Also run the nested example and CLI validation already enforced by CI. Require
-the Dart 3.4 minimum-SDK lane and the `dart_apitool` comparison against
-published `mcp_dart 2.2.2` to pass, including the checked-in compile fixtures
-for interfaces and callbacks. Review any ignored requiredness diagnostics
-instead of treating the compatibility tool configuration as blanket approval.
-The release PR must have all required checks green and no unresolved review
-thread.
+the Dart 3.4 minimum-SDK lane and the `dart_apitool` comparison against the
+immediately preceding stable SDK to pass. Retain the published `mcp_dart
+2.2.2` lane and compile fixtures while that compatibility promise remains in
+force. Review any ignored requiredness diagnostics instead of treating the
+compatibility tool configuration as blanket approval. The release PR must have
+all required checks green and no unresolved review thread.
 
 ## 3. Prepare stable SDK metadata
 
 On the final release-prep commit:
 
-- Set the root package version to `2.3.0`.
+- Set the root package version to the selected stable SDK version (`2.4.0` for
+  the current follow-up release).
 - Restore root `documentation` and all user-facing repository links to `main`.
-- Replace prerelease dependency snippets in the README, getting-started,
-  quick-reference, migration guide, and release docs with `mcp_dart: ^2.3.0`.
+- Replace older dependency snippets in the README, getting-started,
+  quick-reference, and current release docs with `mcp_dart: ^2.4.0`. Preserve
+  version-specific historical migration guides.
 - Keep the durable `2026-07-28` document, fixture, command, and workflow names;
   update maturity wording only when it matches the reviewed upstream input.
-- Promote `stableProtocolVersion` and `defaultProtocolVersion` to the
-  `2026-07-28` constant, but keep `latestInitializationProtocolVersion` and
+- Keep `stableProtocolVersion` and `defaultProtocolVersion` at the
+  `2026-07-28` constant, and keep `latestInitializationProtocolVersion` and
   `legacyProtocolVersions.first` at `2025-11-25`. Run the profile regression
   tests to prove `McpProtocol.legacy` never sends a stateless version through
   `initialize`.
@@ -235,7 +243,7 @@ On the final release-prep commit:
 - Stop presenting `previewProtocolVersion` as the preferred public name. Keep
   it only as a deprecated alias of `stableProtocolVersion` for prerelease
   adopters, and update examples to use the stable/default constants.
-- Move the relevant root changelog entries under `## 2.3.0` and remove wording
+- Move the relevant root changelog entries under `## 2.4.0` and remove wording
   that presents the stable package itself as a preview. Keep upstream
   release-candidate facts explicit while they remain true.
 - Keep migration and compatibility notes explicit: `McpProtocol.stable`
@@ -244,8 +252,8 @@ On the final release-prep commit:
   link it from the tagged README and changelog.
 - Run `dart pub publish --dry-run` again from a clean checkout of the exact
   release commit. Do not create the release tag until this succeeds.
-- Run the shared metadata validator with `--package mcp_dart --tag v2.3.0`.
-  It must require substantive notes under the exact `## 2.3.0` changelog
+- Run the shared metadata validator with `--package mcp_dart --tag v2.4.0`.
+  It must require substantive notes under the exact `## 2.4.0` changelog
   heading, exact reviewed input versions and pins, and verify that the default
   protocol is `2026-07-28` while the initialization and deprecated compatibility
   aliases remain at `2025-11-25`.
@@ -280,7 +288,7 @@ coordinated prep cannot mix channels.
    reuse an existing tag only when that tag resolves to the exact original
    release commit; the workflow never moves it. Manual dispatch is a recovery
    path only.
-2. Verify tag `v2.3.0`, the GitHub release, and the `Publish to pub.dev` workflow.
+2. Verify tag `v2.4.0`, the GitHub release, and the `Publish to pub.dev` workflow.
    If GitHub release creation fails after the tag was pushed, use **Re-run all
    jobs** on the original failed `Create Release` run so the workflow retains
    the original release commit. Do not start a fresh dispatch after `main`
@@ -288,16 +296,21 @@ coordinated prep cannot mix channels.
    different commit. If publication fails after the tag was pushed, rerun the
    failed tag-triggered `Publish to pub.dev` workflow; reusing a tag does not
    emit another push event.
-3. Confirm pub.dev shows version `2.3.0`, immutable `v2.3.0` documentation
+3. Confirm pub.dev shows version `2.4.0`, immutable `v2.4.0` documentation
    links, and a successful package analysis. Checked-in links on `main` remain
    pointed at `main`.
-4. Create a clean temporary Dart project, resolve `mcp_dart: ^2.3.0`, and run a
+4. Create a clean temporary Dart project, resolve `mcp_dart: ^2.4.0`, and run a
    minimal MCP 2026-07-28 client/server smoke test using only the published
-   package.
+   package. For the 2.4 follow-up, also connect its public
+   `SseClientTransport` to published TypeScript and Python legacy SSE servers.
 
-Do not start the stable CLI release until the published SDK resolves publicly.
+Do not start a selected CLI release until the published SDK dependency resolves
+publicly.
 
 ## 5. Prepare and publish `mcp_dart_cli`
+
+Skip this section for the SDK-only 2.4.0 follow-up. The already-published CLI
+remains 0.2.0 and its `^2.3.0` SDK constraint accepts 2.4.0.
 
 - Set the CLI version and `packageVersion` constant to `0.2.0`, and set
   `generatedSdkConstraint` to `^2.3.0`.
@@ -335,7 +348,11 @@ compatible 2.3.x release.
 
 ## 6. Public day-0 verification
 
-- Activate `mcp_dart_cli 0.2.0` from pub.dev in a clean environment.
+- For an SDK release, resolve the new `mcp_dart` version from pub.dev in a
+  clean environment and repeat the public-package Core, compatibility, and
+  affected transport smoke tests.
+- When the CLI is selected, activate `mcp_dart_cli 0.2.0` from pub.dev in a
+  clean environment.
 - Generate a project and run its tests. Verify stdio with `mcp_dart inspect`
   from the generated directory. Then start Streamable HTTP with
   `mcp_dart serve --transport http --host 127.0.0.1 --port 3000` and inspect

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -8,19 +8,19 @@ Use this page for common `mcp_dart` calls. The [server guide](server-guide.md),
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.3.0
+  mcp_dart: ^2.4.0
 ```
 
 ```dart
 import 'package:mcp_dart/mcp_dart.dart';
 ```
 
-The 2.3.0 SDK requires Dart 3.4 or later. The coordinated 0.2.0 CLI requires
+The 2.4.0 SDK requires Dart 3.4 or later. The stable 0.2.0 CLI requires
 Dart 3.12 or later.
 
 ## Protocol profile
 
-The 2.3.0 SDK defaults to `McpProtocol.stable`: try MCP `2026-07-28`, then
+The 2.4.0 SDK defaults to `McpProtocol.stable`: try MCP `2026-07-28`, then
 fall back to legacy initialization when needed. Body-only
 discovery probes are bounded to five seconds; HTTP retains its normal request
 timeout.

--- a/doc/sdk-tier-1-feature-coverage.md
+++ b/doc/sdk-tier-1-feature-coverage.md
@@ -1,13 +1,13 @@
 # SDK Tier 1 feature coverage
 
-This inventory maps the canonical MCP SDK Tier 1 documentation rubric to
-user-facing `mcp_dart` guides and examples. It is evidence for a tier review,
-not a tier claim: the MCP SDK Working Group assigns tiers.
+This project-maintained inventory maps the published MCP SDK Tier 1
+requirements to user-facing `mcp_dart` guides and examples. It is evidence for
+a tier review, not a tier claim: the MCP SDK Working Group assigns tiers.
 
-The rubric currently contains 48 non-experimental features. Features removed
-or deprecated by MCP 2026-07-28 remain in the inventory because the canonical
-list still includes them. Their examples explicitly select the MCP 2025-11-25
-compatibility profile where required.
+The inventory currently contains 48 non-experimental features. Features
+removed or deprecated by MCP 2026-07-28 remain because the published
+requirements still include them. Their examples explicitly select the MCP
+2025-11-25 compatibility profile where required.
 
 ## Coverage summary
 
@@ -15,13 +15,12 @@ compatibility profile where required.
   examples in current source.
 - The deprecated legacy SSE client and server remain explicit compatibility
   surfaces. Both reference SEP-2596 and Streamable HTTP migration.
-- Published `mcp_dart 2.3.0` predates `SseClientTransport`. The source-level
-  48/48 result becomes stable-package evidence only after the next minor SDK
-  release is explicitly approved and published.
+- Published `mcp_dart 2.4.0` includes `SseClientTransport`, so all 48 items
+  have stable-package documentation and examples.
 - Experimental Tasks and MCP Apps are documented separately and do not count
   toward the 48-feature Core inventory.
 
-## Canonical feature inventory
+## Project-maintained feature inventory
 
 | # | Feature | Documentation and example | Status |
 | --- | --- | --- | --- |
@@ -63,7 +62,7 @@ compatibility profile where required.
 | 36 | Ping | [Quick reference: basic utilities](quick-reference.md#basic-utilities) | Covered |
 | 37 | Streamable HTTP transport - client | [Transport guide: client setup](transports.md#client-setup-1) | Covered |
 | 38 | Streamable HTTP transport - server | [Transport guide: high-level server](transports.md#high-level-streamable-http-server) | Covered |
-| 39 | SSE transport - legacy client | [Transport guide: legacy SSE client](transports.md#legacy-client-setup) and [runnable client](../example/client_sse.dart) | Covered in source |
+| 39 | SSE transport - legacy client | [Transport guide: legacy SSE client](transports.md#legacy-client-setup) and [runnable client](../example/client_sse.dart) | Covered |
 | 40 | SSE transport - legacy server | [Transport guide: legacy SSE](transports.md#legacy-sse-transport-deprecated) and [runnable server](../example/server_sse.dart) | Covered |
 | 41 | stdio transport - client | [Transport guide: stdio client](transports.md#client-setup) and [runnable client](../example/client_stdio.dart) | Covered |
 | 42 | stdio transport - server | [Transport guide: stdio server](transports.md#server-setup) and [runnable server](../example/server_stdio.dart) | Covered |

--- a/doc/server-guide.md
+++ b/doc/server-guide.md
@@ -65,7 +65,7 @@ final server = McpServer(
 
 ### Protocol Profile
 
-Servers in mcp_dart 2.3.0 use `McpProtocol.stable` by default. They
+Servers in mcp_dart 2.3 and later use `McpProtocol.stable` by default. They
 advertise and accept the stateless MCP `2026-07-28` protocol alongside
 legacy versions, including `server/discover`. Select the legacy profile
 explicitly to advertise only MCP `2025-11-25` and earlier versions:

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 `mcp_dart` is a community Dart and Flutter SDK for Model Context Protocol
 (MCP) servers, clients, and hosts.
 
-- SDK stable: `2.3.0`
+- SDK stable: `2.4.0`
 - CLI stable: `0.2.0`
 - SDK minimum: Dart 3.4
 - CLI minimum: Dart 3.12
@@ -11,16 +11,15 @@
 - Package: https://pub.dev/packages/mcp_dart
 - License: MIT
 
-Current unreleased source also provides an explicitly deprecated legacy
-HTTP+SSE client with same-origin endpoint enforcement. It is not part of stable
-2.3.0 and requires the next approved minor SDK release. Prefer Streamable HTTP
-for all new integrations.
+Stable 2.4.0 also provides an explicitly deprecated legacy HTTP+SSE client with
+same-origin endpoint enforcement. Prefer Streamable HTTP for all new
+integrations.
 
 ## Release status
 
-The 2.3.0 release implements the complete core client/server wire surface of
-the final MCP `2026-07-28` specification, retains the MCP `2025-11-25`
-feature set, and negotiates supported earlier initialization versions. Core
+The 2.4.0 release retains the complete core client/server wire surface of the
+final MCP `2026-07-28` specification, the MCP `2025-11-25` feature set, and
+negotiation with supported earlier initialization versions. Core
 means the normative wire requirements assigned to client and server roles by
 the pinned final specification; it excludes optional extensions, host UI
 behavior, an authorization-server implementation, JSON Schema external
@@ -34,11 +33,11 @@ Use the latest stable SDK for production:
 dart pub add mcp_dart
 ```
 
-Pin the stable 2.3 line explicitly:
+Pin the stable 2.4 line explicitly:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.3.0
+  mcp_dart: ^2.4.0
 ```
 
 ## Primary import

--- a/packages/mcp_dart_cli/test/version_test.dart
+++ b/packages/mcp_dart_cli/test/version_test.dart
@@ -25,6 +25,37 @@ void main() {
   test('build metadata does not affect prerelease classification', () {
     expect(isPrereleaseVersion('1.2.3+build-1'), isFalse);
     expect(isPrereleaseVersion('1.2.3-dev.1+build-1'), isTrue);
+    expect(
+      _stableCaretConstraintAllows('^2.3.0', '2.4.0+build-1'),
+      isTrue,
+    );
+    expect(
+      _stableCaretConstraintAllows('^2.3.0', '2.4.0-dev.1'),
+      isFalse,
+    );
+  });
+
+  test('stable caret compatibility follows semantic version bounds', () {
+    const cases = [
+      (constraint: '^2.3.0', version: '2.3.0', allows: true),
+      (constraint: '^2.3.0', version: '2.2.9', allows: false),
+      (constraint: '^2.3.0', version: '3.0.0', allows: false),
+      (constraint: '^0.3.0', version: '0.3.9', allows: true),
+      (constraint: '^0.3.0', version: '0.4.0', allows: false),
+      (constraint: '^0.0.3', version: '0.0.3', allows: true),
+      (constraint: '^0.0.3', version: '0.0.4', allows: false),
+    ];
+
+    for (final testCase in cases) {
+      expect(
+        _stableCaretConstraintAllows(
+          testCase.constraint,
+          testCase.version,
+        ),
+        testCase.allows,
+        reason: '${testCase.constraint} with ${testCase.version}',
+      );
+    }
   });
 
   test(
@@ -42,7 +73,7 @@ void main() {
     },
   );
 
-  test('CLI dependency matches the root package in a repository checkout', () {
+  test('CLI dependency accepts the root package in a repository checkout', () {
     final rootPubspecFile = File('../../pubspec.yaml');
     if (!rootPubspecFile.existsSync()) {
       markTestSkipped('Root package is unavailable outside the repository.');
@@ -62,8 +93,60 @@ void main() {
             )
             as YamlMap;
     final templateDependencies = templatePubspec['dependencies'] as YamlMap;
+    final sdkConstraint = dependencies['mcp_dart'] as String;
+    final templateSdkConstraint = templateDependencies['mcp_dart'] as String;
 
-    expect(dependencies['mcp_dart'], '^$rootVersion');
-    expect(templateDependencies['mcp_dart'], '^$rootVersion');
+    expect(templateSdkConstraint, sdkConstraint);
+    expect(
+      _stableCaretConstraintAllows(sdkConstraint, rootVersion),
+      isTrue,
+      reason:
+          'The published CLI dependency must accept the stable SDK version '
+          'checked out beside it.',
+    );
   });
+}
+
+bool _stableCaretConstraintAllows(String constraint, String version) {
+  final lower = _parseStableVersion(
+    constraint.startsWith('^') ? constraint.substring(1) : '',
+  );
+  final candidate = _parseStableVersion(version);
+  if (lower == null || candidate == null) {
+    return false;
+  }
+
+  final upper = switch (lower) {
+    [final major, _, _] when major > 0 => [major + 1, 0, 0],
+    [0, final minor, _] when minor > 0 => [0, minor + 1, 0],
+    [0, 0, final patch] => [0, 0, patch + 1],
+    _ => throw StateError('Unreachable semantic version.'),
+  };
+
+  return _compareVersions(candidate, lower) >= 0 &&
+      _compareVersions(candidate, upper) < 0;
+}
+
+List<int>? _parseStableVersion(String version) {
+  final match = RegExp(
+    r'^(\d+)\.(\d+)\.(\d+)(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$',
+  ).firstMatch(version);
+  if (match == null) {
+    return null;
+  }
+  return [
+    int.parse(match.group(1)!),
+    int.parse(match.group(2)!),
+    int.parse(match.group(3)!),
+  ];
+}
+
+int _compareVersions(List<int> left, List<int> right) {
+  for (var index = 0; index < left.length; index++) {
+    final comparison = left[index].compareTo(right[index]);
+    if (comparison != 0) {
+      return comparison;
+    }
+  }
+  return 0;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mcp_dart
 description: Dart and Flutter SDK for building Model Context Protocol (MCP) servers, clients, hosts, and AI tools.
-version: 2.3.0
+version: 2.4.0
 repository: https://github.com/leehack/mcp_dart
 homepage: https://github.com/leehack/mcp_dart
 issue_tracker: https://github.com/leehack/mcp_dart/issues

--- a/test/tool/validate_release_metadata_test.dart
+++ b/test/tool/validate_release_metadata_test.dart
@@ -926,6 +926,7 @@ Directory _stableFixture(
   required bool finalInputsReviewed,
   bool prepareStableCli = false,
 }) {
+  const fixtureSdkVersion = '2.3.0';
   final fixture = Directory.systemTemp.createTempSync(
     'mcp_dart_release_metadata_',
   );
@@ -982,12 +983,25 @@ Directory _stableFixture(
   pubspec.writeAsStringSync(
     pubspec
         .readAsStringSync()
-        .replaceFirst('version: 2.3.0-dev.3', 'version: 2.3.0')
+        .replaceFirst(
+          RegExp(r'^version:[^\r\n]*$', multiLine: true),
+          'version: $fixtureSdkVersion',
+        )
         .replaceFirst(
           'documentation: https://github.com/leehack/mcp_dart/tree/'
               'v2.3.0-dev.3/doc',
           'documentation: https://github.com/leehack/mcp_dart/tree/main/doc',
         ),
+  );
+
+  final releaseMetadata = File(
+    '${fixture.path}/tool/release/mcp_2026_07_28_release_metadata.json',
+  );
+  final metadata =
+      jsonDecode(releaseMetadata.readAsStringSync()) as Map<String, dynamic>;
+  metadata['sdkStableVersion'] = fixtureSdkVersion;
+  releaseMetadata.writeAsStringSync(
+    '${const JsonEncoder.withIndent('  ').convert(metadata)}\n',
   );
 
   final changelog = File('${fixture.path}/CHANGELOG.md');

--- a/tool/release/mcp_2026_07_28_release_metadata.json
+++ b/tool/release/mcp_2026_07_28_release_metadata.json
@@ -1,5 +1,5 @@
 {
-  "sdkStableVersion": "2.3.0",
+  "sdkStableVersion": "2.4.0",
   "cliStableVersion": "0.2.0",
   "protocolVersion": "2026-07-28",
   "legacyInitializationProtocolVersion": "2025-11-25",


### PR DESCRIPTION
## Summary

- Prepare an SDK-only stable `mcp_dart 2.4.0` release. `mcp_dart_cli`
  remains `0.2.0`; its published `^2.3.0` constraint accepts SDK 2.4.
- Promote the additive, opt-in, deprecated legacy HTTP+SSE client and its
  public options/error interfaces from source-only coverage to the stable
  package. Streamable HTTP remains the preferred remote transport.
- Update release metadata, changelog, current-version docs, Tier 1 evidence,
  and the 2.4 publish/day-0 runbook together.
- Compare the public API against immediate predecessor `2.3.0` as well as the
  retained `2.2.2` compatibility promise.
- Make the CLI repository contract verify SemVer compatibility rather than
  incorrectly requiring every compatible SDK minor to raise the CLI minimum.

## Reviewed release inputs

- Core pin `5f5440bb26a62e2cf3440b92da5a667efa03b267` exactly matches the final
  official `2026-07-28` tag.
- Tasks pin `2c1425d9a288b9b1f489430fe1e00bb392b47e48` remains current upstream;
  Tasks still has no tag or release and remains explicitly experimental.
- Published conformance `0.2.0-alpha.10` remains the newest alpha artifact.
  No newer compatible published artifact exists.
- Published TypeScript client/server `2.0.0`, Python `mcp==2.0.0` and
  `mcp-types==2.0.0`, SDK `2.3.0`, and CLI `0.2.0` remain current.
- No overlapping open PR or reusable release branch exists. Public repository
  Dependabot, code-scanning, secret-scanning, and advisory inventories contain
  no open alert.

## Validation

Release and package gates:

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- Root SDK suite: 1,960/1,960 passed on Dart 3.12.2.
- Dart 3.4.0 minimum lane: dependency downgrade, native consumer compile,
  web consumer compile, SDK analysis, conditional stdio web compile, and full
  root suite passed (1,983 passed, 3 platform skips).
- CLI: full suite 138/138, no skips; focused version contract 5/5; analysis
  clean.
- Anthropic 23/23, fetch-server 29/29, Gemini 34/34; all analyzed and compiled.
- Jaspr analysis/build passed; Flutter analysis and 9/9 widget tests passed.
- `dart pub publish --dry-run`: 0 warnings from the clean commit.
- `pana 0.23.14`: 160/160, including dependency downgrade and dartdoc.
- SDK metadata/tag validation passed for `v2.4.0`.
- Release detection from `637853e7bdb4095eccc01be24e5976da573171c3`
  reports SDK-only, stable, `2.4.0`.
- `actionlint`, release provenance/source/security/orchestration fixtures, CLI
  binary isolation fixtures, release-link checks, and `git diff --check`
  passed.

Protocol, schema, and interoperability gates:

- Published conformance `0.2.0-alpha.10`:
  - MCP 2025-11-25 client: 221/221.
  - MCP 2025-11-25 server: all isolated scenarios passed.
  - MCP 2026-07-28 client: 32/32.
  - MCP 2026-07-28 server: 40/40.
- Supplemental unpublished conformance source
  `49103de6ed70804e940637bf3e9e29e4a3f54e64`:
  - client: 388/388 assertions;
  - server: 40/40 isolated scenarios.
- Pinned Core examples: 129/129 parsed; documents: 31/31 inventoried, no
  missing/stale/invalid entries.
- Pinned Tasks contract audit passed.
- JSON Schema Test Suite:
  - Draft 2020-12: 1,244 assertions, 0 failures;
  - Draft 7: 904 assertions, 0 failures;
  - Draft 7 optional formats: 587 assertions, 0 failures.
- Published TypeScript SDK 2.0.0 and Python SDK 2.0.0 passed in both
  directions for MCP 2026-07-28.
- Actual legacy SSE peers passed bidirectionally:
  - TypeScript SDK 1.30.0 server/client;
  - Python SDK 2.0.0 server/client.
- Focused SSE lifecycle/security suite: 25/25.
- Real Chrome transport suite: 6/6, including legacy SSE endpoint discovery,
  preflight/CORS, POST routing, inbound response, close, and cancellation.
- Flutter Web service E2E in Chrome: 1/1.
- Public API:
  - versus `2.3.0`: no breaking changes; three additive SSE interfaces, with
    `2.4.0` identified as the required version;
  - versus `2.2.2`: only the four existing reviewed optional-parameter false
    positives.

## Remaining gates

- This PR is intentionally a draft and intentionally does **not** have the
  `release-prep` label.
- Require all exact-head PR checks and review threads to be green/settled.
- Applying `release-prep` and merging authorizes release automation and
  requires separate explicit approval.
- Tags, GitHub release creation, workflow dispatch, pub.dev publication, and
  public-package day-0 verification have not been performed.

## Watch item

The unpublished conformance checkout currently reports nine production-graph
`npm audit` advisories in its own transitive dependencies (three high, five
moderate, one low). Those packages are not shipped by `mcp_dart`, no newer
conformance artifact is published, and both the reviewed artifact and current
source pass. Keep this upstream-only item under observation rather than changing
the reviewed release pin.
