### PR TITLE
Stabilize stdio crash fixture on Windows

### DIFF
--- a/test/client/fixtures/stdio_restart_server.dart
+++ b/test/client/fixtures/stdio_restart_server.dart
@@ -331,8 +331,9 @@ Future<void> main(List<String> arguments) async {
     }
 
     if (method == 'fixture/crash') {
-      exitCode = 17;
-      return;
+      // Model an abrupt crash without waiting for stdin cancellation, which
+      // can stall when an await-for loop unwinds on Windows.
+      exit(17);
     }
 
     if (method == 'fixture/exit') {


### PR DESCRIPTION
## Summary

- make the deliberate `fixture/crash` path terminate immediately with exit code 17
- avoid waiting for stdin stream cancellation while an `await for` loop unwinds on Windows
- keep graceful fixture exit paths unchanged

## Why

During the final 2.4.0 exact-merge verification, two Windows attempts timed out in different stdio restart tests. In both cases, the child process remained alive after handling `fixture/crash` until test cleanup closed stdin and terminated it. A third attempt at the identical release-prep head passed, which made this a timing-sensitive fixture failure rather than a product regression.

The fixture is intended to model an abrupt process crash. Calling `exit(17)` does that directly and matches the fixture's other deliberate crash paths. This is test-only: it does not change the SDK, public API, MCP wire behavior, documentation, conformance, or interoperability behavior.

## Validation

- `dart format --output=none --set-exit-if-changed test/client/fixtures/stdio_restart_server.dart`
- `dart analyze`
- `dart test test/client/stdio_client_test.dart --reporter expanded` — 44/44 passed
- targeted formerly failing cases — 20 consecutive combined runs passed
- `dart test --reporter compact` — 1,960/1,960 passed
- `git diff --check`
- [complete exact-head Core run](https://github.com/leehack/mcp_dart/actions/runs/30597303629) — all jobs passed, including conformance, interop, Dart 3.4, macOS, examples, pana, and public API compatibility
- exact-head Windows platform suite — five consecutive passes:
  [1](https://github.com/leehack/mcp_dart/actions/runs/30597303629/job/91052370940),
  [2](https://github.com/leehack/mcp_dart/actions/runs/30597303629/job/91053561574),
  [3](https://github.com/leehack/mcp_dart/actions/runs/30597303629/job/91053968433),
  [4](https://github.com/leehack/mcp_dart/actions/runs/30597303629/job/91054417400),
  [5](https://github.com/leehack/mcp_dart/actions/runs/30597303629/job/91054890255)

No technical blocker remains. The PR is kept as a draft for maintainer review.
