### PR TITLE
Use package changelogs for GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
       make_latest: ${{ steps.release-type.outputs.make_latest }}
       prerelease: ${{ steps.release-type.outputs.prerelease }}
       release_sha: ${{ steps.release-source.outputs.release_sha }}
+      release_notes_artifact: ${{ steps.release-notes.outputs.artifact_name }}
+      release_notes_sha: ${{ steps.release-notes.outputs.sha256 }}
       tag: ${{ steps.release-source.outputs.tag }}
       version: ${{ steps.get-version.outputs.version }}
     steps:
@@ -159,6 +161,50 @@ jobs:
             --ref "$RELEASE_TAG"
           echo "working_directory=$PUBLISH_ROOT" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout release-note control tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: release-control
+          persist-credentials: false
+
+      - name: Prepare immutable release notes
+        id: release-notes
+        env:
+          PACKAGE: ${{ inputs.package }}
+          PACKAGE_DIRECTORY: ${{ steps.set-config.outputs.working_directory }}
+          RELEASE_TAG: ${{ steps.release-source.outputs.tag }}
+        run: |
+          NOTES_ROOT="$RUNNER_TEMP/release-notes"
+          rm -rf "$NOTES_ROOT"
+          mkdir -p "$NOTES_ROOT"
+          dart "$GITHUB_WORKSPACE/release-control/tool/release/prepare_release_notes.dart" \
+            --package "$PACKAGE" \
+            --root "$GITHUB_WORKSPACE/$PACKAGE_DIRECTORY" \
+            --ref "$RELEASE_TAG" \
+            --output "$NOTES_ROOT/release-notes.md"
+          test -f "$NOTES_ROOT/release-notes.md"
+          test ! -L "$NOTES_ROOT/release-notes.md"
+          RELEASE_NOTES_SHA=$(sha256sum "$NOTES_ROOT/release-notes.md" | awk '{print $1}')
+          if [[ ! "$RELEASE_NOTES_SHA" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "❌ Could not hash release notes."
+            exit 1
+          fi
+          ARTIFACT_NAME="release-notes-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$PACKAGE"
+          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+          echo "sha256=$RELEASE_NOTES_SHA" >> "$GITHUB_OUTPUT"
+          echo "✅ Prepared immutable release notes $RELEASE_NOTES_SHA."
+
+      - name: Upload immutable release notes
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.release-notes.outputs.artifact_name }}
+          path: ${{ runner.temp }}/release-notes/release-notes.md
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
       - name: Install release dependencies
         working-directory: ${{ steps.publish-dir.outputs.working_directory }}
         run: dart pub get
@@ -176,6 +222,7 @@ jobs:
     needs: validate-release
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write  # Required to create tags and releases
       statuses: write
     steps:
@@ -195,6 +242,27 @@ jobs:
             exit 1
           fi
           echo "✅ Checked out validated commit $ACTUAL_SHA."
+
+      - name: Download immutable release notes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.validate-release.outputs.release_notes_artifact }}
+          path: ${{ runner.temp }}/release-notes
+
+      - name: Verify immutable release notes
+        env:
+          EXPECTED_RELEASE_NOTES_SHA: ${{ needs.validate-release.outputs.release_notes_sha }}
+        run: |
+          if [[ ! "$EXPECTED_RELEASE_NOTES_SHA" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "❌ Invalid expected release-note digest."
+            exit 1
+          fi
+          cd "$RUNNER_TEMP/release-notes"
+          test -f release-notes.md
+          test ! -L release-notes.md
+          echo "$EXPECTED_RELEASE_NOTES_SHA  release-notes.md" |
+            sha256sum --check --strict -
+          echo "✅ Verified immutable release notes $EXPECTED_RELEASE_NOTES_SHA."
 
       # Keep this independent of repository scripts: this job holds write
       # permissions, while all package code ran in validate-release.
@@ -329,7 +397,8 @@ jobs:
         with:
           tag_name: ${{ steps.create-tag.outputs.tag }}
           name: ${{ inputs.package }} ${{ needs.validate-release.outputs.version }}
-          generate_release_notes: true
+          body_path: ${{ runner.temp }}/release-notes/release-notes.md
+          append_body: false
           prerelease: ${{ needs.validate-release.outputs.prerelease }}
           make_latest: ${{ needs.validate-release.outputs.make_latest }}
           draft: false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Security fixes target the current stable SDK and CLI release lines:
 
 | Package | Supported stable line |
 | --- | --- |
-| `mcp_dart` | `2.3.x` |
+| `mcp_dart` | `2.4.x` |
 | `mcp_dart_cli` | `0.2.x` |
 
 Older lines receive best-effort fixes only. A vulnerability may require

--- a/test/tool/prepare_release_notes_test.dart
+++ b/test/tool/prepare_release_notes_test.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('renders from a package checkout without release tooling', () {
+    final root = Directory.systemTemp.createTempSync(
+      'mcp_release_notes_package_',
+    );
+    addTearDown(() => root.deleteSync(recursive: true));
+    File('${root.path}/pubspec.yaml').writeAsStringSync('''
+name: mcp_dart
+version: 2.4.0
+''');
+    File('${root.path}/CHANGELOG.md').writeAsStringSync('''
+## 2.4.0
+
+- See the [migration guide](https://github.com/leehack/mcp_dart/blob/main/doc/migration.md).
+
+## 2.3.0
+
+- Older notes.
+''');
+    expect(Directory('${root.path}/tool').existsSync(), isFalse);
+
+    final output = File('${root.path}/rendered/release-notes.md');
+    final result = Process.runSync(Platform.resolvedExecutable, [
+      File('tool/release/prepare_release_notes.dart').absolute.path,
+      '--package',
+      'mcp_dart',
+      '--root',
+      root.path,
+      '--ref',
+      'v2.4.0',
+      '--output',
+      output.path,
+    ]);
+
+    expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+    expect(
+      output.readAsStringSync(),
+      '- See the [migration guide]'
+      '(https://github.com/leehack/mcp_dart/blob/v2.4.0/doc/migration.md).\n',
+    );
+  });
+}

--- a/test/tool/release_link_manager_test.dart
+++ b/test/tool/release_link_manager_test.dart
@@ -152,6 +152,38 @@ homepage: https://github.com/leehack/mcp_dart/tree/main/packages/mcp_dart_cli
       ),
     );
   });
+
+  test('rewriteText pins only same-repository source links', () {
+    final root = Directory.systemTemp.createTempSync('mcp_release_links_text_');
+    addTearDown(() => root.deleteSync(recursive: true));
+    _write(root, 'pubspec.yaml', 'name: mcp_dart\nversion: 2.4.0\n');
+    final manager = ReleaseLinkManager(
+      packageRoot: root,
+      package: ReleasePackage.sdk,
+    );
+    const source = '''
+[Blob](https://github.com/leehack/mcp_dart/blob/main/doc/guide.md?plain=1#start)
+[Tree](https://github.com/leehack/mcp_dart/tree/main/example)
+[Pinned](https://github.com/leehack/mcp_dart/blob/v2.4.0/README.md)
+[Release](https://github.com/leehack/mcp_dart/releases/tag/v2.3.0)
+[External](https://example.com/leehack/mcp_dart/blob/main/README.md)
+''';
+
+    final rewritten = manager.rewriteText(source, 'v2.4.0');
+
+    expect(
+      rewritten,
+      contains('/blob/v2.4.0/doc/guide.md?plain=1#start'),
+    );
+    expect(rewritten, contains('/tree/v2.4.0/example'));
+    expect(rewritten, contains('/blob/v2.4.0/README.md'));
+    expect(rewritten, contains('/releases/tag/v2.3.0'));
+    expect(
+      rewritten,
+      contains('https://example.com/leehack/mcp_dart/blob/main/README.md'),
+    );
+    expect(manager.rewriteText(rewritten, 'v2.4.0'), rewritten);
+  });
 }
 
 void _writeSdkPolicyFiles(Directory root) {

--- a/test/tool/release_notes_test.dart
+++ b/test/tool/release_notes_test.dart
@@ -1,0 +1,219 @@
+import 'package:test/test.dart';
+
+import '../../tool/release/release_notes.dart';
+
+void main() {
+  test('extracts one exact section and preserves nested Markdown', () {
+    final notes = extractReleaseNotes(
+      changelog: '''
+## 2.4.0
+
+Release summary.
+
+### Added
+
+- A nested item.
+
+  ```dart
+  final heading = '## not a release';
+  ```
+
+> Compatibility note.
+
+## 2.3.0
+
+- Older notes.
+''',
+      version: '2.4.0',
+    );
+
+    expect(notes, '''
+Release summary.
+
+### Added
+
+- A nested item.
+
+  ```dart
+  final heading = '## not a release';
+  ```
+
+> Compatibility note.
+''');
+  });
+
+  test('ignores target and boundary headings in comments and fences', () {
+    final notes = extractReleaseNotes(
+      changelog: '''
+<!--
+## 2.4.0
+
+- Comment decoy with a surrogate pair: 🧪.
+-->
+
+```markdown
+## 2.4.0
+```
+
+## 2.4.0
+
+- Actual notes.
+
+<!-- ## 2.3.0 -->
+
+~~~markdown
+## 2.2.0
+~~~
+
+### Still current
+
+- More notes.
+
+## 2.1.0
+
+- Older notes.
+''',
+      version: '2.4.0',
+    );
+
+    expect(notes, contains('- Actual notes.'));
+    expect(notes, contains('<!-- ## 2.3.0 -->'));
+    expect(notes, contains('## 2.2.0'));
+    expect(notes, contains('### Still current'));
+    expect(notes, contains('- More notes.'));
+    expect(notes, isNot(contains('- Older notes.')));
+  });
+
+  test('does not let comment markers in fences hide later boundaries', () {
+    final notes = extractReleaseNotes(
+      changelog: '''
+## 2.4.0
+
+```html
+<!-- This literal is intentionally unterminated.
+```
+
+- Current notes.
+
+## 2.3.0
+
+- Older notes.
+''',
+      version: '2.4.0',
+    );
+
+    expect(notes, contains('<!-- This literal is intentionally unterminated.'));
+    expect(notes, contains('- Current notes.'));
+    expect(notes, isNot(contains('- Older notes.')));
+  });
+
+  test('does not treat comment markers in inline code as comments', () {
+    final notes = extractReleaseNotes(
+      changelog: '''
+## 2.4.0
+
+- Supports the literal marker `<!--`.
+
+## 2.3.0
+
+- Older notes.
+''',
+      version: '2.4.0',
+    );
+
+    expect(notes, contains('`<!--`'));
+    expect(notes, isNot(contains('- Older notes.')));
+  });
+
+  test('supports prerelease versions with punctuation', () {
+    expect(
+      extractReleaseNotes(
+        changelog: '''
+## 2.4.0-dev.12
+
+- Preview notes.
+''',
+        version: '2.4.0-dev.12',
+      ),
+      '- Preview notes.\n',
+    );
+  });
+
+  test('rejects a missing exact heading', () {
+    expect(
+      () => extractReleaseNotes(
+        changelog: '## 2.4.0-dev.1\n\n- Preview notes.\n',
+        version: '2.4.0',
+      ),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          'message',
+          contains('no release heading'),
+        ),
+      ),
+    );
+  });
+
+  test('rejects duplicate visible exact headings', () {
+    expect(
+      () => extractReleaseNotes(
+        changelog: '''
+## 2.4.0
+
+- First copy.
+
+## 2.4.0
+
+- Second copy.
+''',
+        version: '2.4.0',
+      ),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          'message',
+          contains('multiple release headings'),
+        ),
+      ),
+    );
+  });
+
+  test('rejects heading-only, placeholder-only, and fenced-only notes', () {
+    for (final body in <String>[
+      '### Changed\n\nTBD',
+      '- coming soon.',
+      '- TODO:',
+      '```text\nAn implementation example.\n```',
+      '<!-- Real notes were not promoted. -->',
+    ]) {
+      expect(
+        () => extractReleaseNotes(
+          changelog: '## 2.4.0\n\n$body\n',
+          version: '2.4.0',
+        ),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('no substantive release notes'),
+          ),
+        ),
+        reason: body,
+      );
+    }
+  });
+
+  test('normalizes only boundary blank lines and the final newline', () {
+    final notes = extractReleaseNotes(
+      changelog: '## 0.2.0\r\n\r\n'
+          '    Indented release detail.\r\n'
+          '\r\n\r\n'
+          '## 0.1.9\r\n'
+          '- Older notes.',
+      version: '0.2.0',
+    );
+
+    expect(notes, '    Indented release detail.\n');
+  });
+}

--- a/test/tool/validate_release_metadata_test.dart
+++ b/test/tool/validate_release_metadata_test.dart
@@ -699,6 +699,74 @@ mcp-types==2.0.0b1
     );
   });
 
+  test('rejects a stale supported stable SDK line', () {
+    final fixture = _stableFixture(repoRoot, finalInputsReviewed: true);
+    addTearDown(() => fixture.deleteSync(recursive: true));
+    final securityPolicy = File('${fixture.path}/SECURITY.md');
+    securityPolicy.writeAsStringSync(
+      securityPolicy.readAsStringSync().replaceFirst('2.3.x', '2.2.x'),
+    );
+
+    final result = ReleaseMetadataValidator(fixture).validate(
+      package: ReleasePackage.sdk,
+      tag: 'v2.3.0',
+    );
+
+    expect(
+      result.errors,
+      contains(
+        'SECURITY.md must list mcp_dart 2.3.x as its supported stable line.',
+      ),
+    );
+  });
+
+  test('rejects supported SDK rows hidden in comments or fences', () {
+    final fixture = _stableFixture(repoRoot, finalInputsReviewed: true);
+    addTearDown(() => fixture.deleteSync(recursive: true));
+    final securityPolicy = File('${fixture.path}/SECURITY.md');
+    securityPolicy.writeAsStringSync(
+      '${securityPolicy.readAsStringSync().replaceFirst('2.3.x', '2.2.x')}'
+      '<!-- | `mcp_dart` | `2.3.x` | -->\n'
+      '```markdown\n'
+      '| `mcp_dart` | `2.3.x` |\n'
+      '```\n',
+    );
+
+    final result = ReleaseMetadataValidator(fixture).validate(
+      package: ReleasePackage.sdk,
+      tag: 'v2.3.0',
+    );
+
+    expect(
+      result.errors,
+      contains(
+        'SECURITY.md must list mcp_dart 2.3.x as its supported stable line.',
+      ),
+    );
+  });
+
+  test('rejects a stale supported stable CLI line', () {
+    final fixture = _stableFixture(repoRoot, finalInputsReviewed: true);
+    addTearDown(() => fixture.deleteSync(recursive: true));
+    final securityPolicy = File('${fixture.path}/SECURITY.md');
+    securityPolicy.writeAsStringSync(
+      securityPolicy.readAsStringSync().replaceFirst('0.2.x', '0.1.x'),
+    );
+
+    final result = ReleaseMetadataValidator(fixture).validate(
+      package: ReleasePackage.sdk,
+      tag: 'v2.3.0',
+    );
+
+    expect(
+      result.errors,
+      contains(
+        'SECURITY.md must list mcp_dart_cli 0.2.x as its supported stable '
+        'line.',
+      ),
+    );
+  });
+
   test('rejects a stale generated-project SDK dependency', () {
     final fixture = _stableFixture(
       repoRoot,
@@ -1010,6 +1078,11 @@ Directory _stableFixture(
           '## 2.3.0-dev.3',
           '## 2.3.0',
         ),
+  );
+
+  final securityPolicy = File('${fixture.path}/SECURITY.md');
+  securityPolicy.writeAsStringSync(
+    securityPolicy.readAsStringSync().replaceFirst('2.4.x', '2.3.x'),
   );
 
   final constants = File('${fixture.path}/lib/src/types/json_rpc.dart');

--- a/tool/release/README.md
+++ b/tool/release/README.md
@@ -37,6 +37,15 @@ starts `Publish to pub.dev`, which publishes the already validated immutable
 candidate through pub.dev OIDC. Manual `Create Release` dispatch remains only
 as a recovery path; never push release tags by hand or move an existing tag.
 
+The selected package's exact-version changelog section is the source of truth
+for its GitHub release body. The read-only release job extracts that section,
+rewrites same-repository source links to the package's immutable tag, and
+passes the rendered file to the write job with a verified SHA-256 digest.
+Recovery of an existing exact tag replaces the release body with that same
+rendered section; it never appends generated notes. Historical body-only
+repairs remain a separate, explicitly approved API operation because rerunning
+the release workflow can also affect the repository's latest-release marker.
+
 Before using the automation, create the repository label `release-prep` and
 keep the existing `RELEASE_PAT` Actions secret available for the narrowly
 scoped tag push. Branch protection should require the normal SDK, CLI, interop,
@@ -120,10 +129,13 @@ and regression tests pass.
 Every tag requires exact-commit `mcp_dart/release/<package>` authorization from
 `Create Release`; manually pushed stable and prerelease tags cannot publish.
 The workflow validates metadata and the pub.dev dry run in a read-only job,
-then a minimal write job checks the exact validated commit and tag before
-writing authorization. New-tag authorization transitions through `pending`
-and becomes `success` only after the PAT-backed tag push succeeds; failures
-overwrite it with `failure`. The publish workflow waits for that transition.
+then a minimal write job checks the exact validated commit, release-note
+digest, and tag before writing authorization. The renderer comes from the
+exact workflow source, so recovery also works for older tags that predate the
+renderer without executing unvalidated package code in the write job. New-tag
+authorization transitions through `pending` and becomes `success` only after
+the PAT-backed tag push succeeds; failures overwrite it with `failure`. The
+publish workflow waits for that transition.
 Every tag additionally requires the latest default-branch source and exact-SHA
 CI runs, and the publish workflow repeats the exact-SHA CI check.
 CI provenance is matched by the exact workflow files

--- a/tool/release/prepare_release_notes.dart
+++ b/tool/release/prepare_release_notes.dart
@@ -1,0 +1,92 @@
+import 'dart:io';
+
+import 'release_link_manager.dart';
+import 'release_notes.dart';
+
+void main(List<String> args) {
+  String? packageName;
+  String? rootPath;
+  String? expectedRef;
+  String? outputPath;
+
+  for (var index = 0; index < args.length; index += 1) {
+    switch (args[index]) {
+      case '--package':
+        packageName = _value(args, ++index, '--package');
+      case '--root':
+        rootPath = _value(args, ++index, '--root');
+      case '--ref':
+        expectedRef = _value(args, ++index, '--ref');
+      case '--output':
+        outputPath = _value(args, ++index, '--output');
+      case '--help':
+      case '-h':
+        _printUsage();
+        return;
+      default:
+        _usageError('Unknown argument: ${args[index]}');
+    }
+  }
+
+  if (packageName == null ||
+      rootPath == null ||
+      expectedRef == null ||
+      outputPath == null) {
+    _usageError('--package, --root, --ref, and --output are required.');
+  }
+
+  try {
+    final package = ReleasePackage.parse(packageName);
+    final packageRoot = Directory(rootPath);
+    final manager = ReleaseLinkManager(
+      packageRoot: packageRoot,
+      package: package,
+    );
+    final changelog = File('${packageRoot.path}/CHANGELOG.md');
+    if (!changelog.existsSync()) {
+      throw FileSystemException('Missing package changelog.', changelog.path);
+    }
+    final notes = extractReleaseNotes(
+      changelog: changelog.readAsStringSync(),
+      version: manager.version,
+    );
+    final rendered = manager.rewriteText(notes, expectedRef);
+    final output = File(outputPath);
+    output.parent.createSync(recursive: true);
+    output.writeAsStringSync(rendered);
+    stdout.writeln(
+      'Prepared ${package.packageName} ${manager.version} release notes at '
+      '${output.path}.',
+    );
+  } on Object catch (error) {
+    stderr.writeln('Could not prepare release notes: $error');
+    exitCode = 65;
+  }
+}
+
+String _value(List<String> args, int index, String option) {
+  if (index >= args.length) {
+    _usageError('$option requires a value.');
+  }
+  return args[index];
+}
+
+Never _usageError(String message) {
+  stderr.writeln(message);
+  _printUsage();
+  exit(64);
+}
+
+void _printUsage() {
+  stdout.writeln('''
+Usage: dart tool/release/prepare_release_notes.dart \\
+  --package <mcp_dart|mcp_dart_cli> \\
+  --root <package-root> \\
+  --ref <release-tag> \\
+  --output <release-notes.md>
+
+Extracts the package's exact-version changelog section, rewrites
+same-repository source links to the immutable release tag, and writes the
+GitHub release body.
+''');
+}

--- a/tool/release/release_link_manager.dart
+++ b/tool/release/release_link_manager.dart
@@ -95,9 +95,7 @@ class ReleaseLinkManager {
     final changedFiles = <String>[];
     for (final file in _releaseFacingFiles()) {
       final source = file.readAsStringSync();
-      final updated = source.replaceAllMapped(_repositoryLinkPattern, (match) {
-        return '$_repositoryUrl${match.group(1)}/$expectedRef';
-      });
+      final updated = _rewriteText(source, expectedRef);
       if (updated == source) {
         continue;
       }
@@ -108,6 +106,18 @@ class ReleaseLinkManager {
       changedFiles: List.unmodifiable(changedFiles),
       issues: List.unmodifiable(_issues(expectedRef)),
     );
+  }
+
+  /// Rewrites same-repository source links to [expectedRef].
+  String rewriteText(String source, String expectedRef) {
+    _validateExpectedRef(expectedRef);
+    return _rewriteText(source, expectedRef);
+  }
+
+  String _rewriteText(String source, String expectedRef) {
+    return source.replaceAllMapped(_repositoryLinkPattern, (match) {
+      return '$_repositoryUrl${match.group(1)}/$expectedRef';
+    });
   }
 
   void _validateExpectedRef(String expectedRef) {

--- a/tool/release/release_metadata_validator.dart
+++ b/tool/release/release_metadata_validator.dart
@@ -603,6 +603,11 @@ class ReleaseMetadataValidator {
     if (sdkVersion is! String || cliVersion is! String) {
       return;
     }
+    _validateSupportedReleasePolicy(
+      sdkVersion: sdkVersion,
+      cliVersion: cliVersion,
+      errors: errors,
+    );
 
     final paths = <String>{'README.md', 'llms.txt'};
     if (package == ReleasePackage.sdk) {
@@ -662,6 +667,39 @@ class ReleaseMetadataValidator {
         errors.add(
           'Stable ${package.packageName} release documentation still contains '
           'stale release marker "$marker" in $path.',
+        );
+      }
+    }
+  }
+
+  void _validateSupportedReleasePolicy({
+    required String sdkVersion,
+    required String cliVersion,
+    required List<String> errors,
+  }) {
+    final securityPolicy = maskMarkdownCommentsAndFences(
+      _readText('SECURITY.md', errors),
+    );
+    for (final entry in <(ReleasePackage, String)>[
+      (ReleasePackage.sdk, sdkVersion),
+      (ReleasePackage.cli, cliVersion),
+    ]) {
+      ReleaseVersion parsedVersion;
+      try {
+        parsedVersion = ReleaseVersion.parse(entry.$2);
+      } on FormatException {
+        continue;
+      }
+      final expectedLine = '${parsedVersion.major}.${parsedVersion.minor}.x';
+      final expectedRow = RegExp(
+        '^\\|[ \\t]*`${RegExp.escape(entry.$1.packageName)}`[ \\t]*'
+        '\\|[ \\t]*`${RegExp.escape(expectedLine)}`[ \\t]*\\|[ \\t]*\\r?\$',
+        multiLine: true,
+      );
+      if (!expectedRow.hasMatch(securityPolicy)) {
+        errors.add(
+          'SECURITY.md must list ${entry.$1.packageName} $expectedLine as its '
+          'supported stable line.',
         );
       }
     }

--- a/tool/release/release_metadata_validator.dart
+++ b/tool/release/release_metadata_validator.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'release_link_manager.dart';
+import 'release_notes.dart';
 import 'release_prep_plan.dart';
 
 export 'release_link_manager.dart' show ReleasePackage;
@@ -358,7 +359,7 @@ class ReleaseMetadataValidator {
       if (input.isEmpty && !File(_path(path)).existsSync()) {
         continue;
       }
-      final source = _stripMarkdownCommentsAndFences(input);
+      final source = maskMarkdownCommentsAndFences(input);
       final identifiesExperimental = RegExp(
         r'experimental\s+Tasks extension',
         caseSensitive: false,
@@ -503,16 +504,12 @@ class ReleaseMetadataValidator {
         ? 'CHANGELOG.md'
         : 'packages/mcp_dart_cli/CHANGELOG.md';
     final changelog = _readText(changelogPath, errors);
-    final releaseSection =
-        version.isEmpty ? null : _releaseSection(changelog, version);
-    if (version.isNotEmpty && releaseSection == null) {
-      errors.add('$changelogPath has no release heading for $version.');
-    } else if (releaseSection != null &&
-        !_hasSubstantiveReleaseNotes(releaseSection)) {
-      errors.add(
-        '$changelogPath release section for $version has no substantive '
-        'release notes.',
-      );
+    if (version.isNotEmpty) {
+      try {
+        extractReleaseNotes(changelog: changelog, version: version);
+      } on FormatException catch (error) {
+        errors.add('$changelogPath ${error.message}');
+      }
     }
 
     if (package == ReleasePackage.sdk) {
@@ -594,61 +591,6 @@ class ReleaseMetadataValidator {
         'CLI defaultTemplateUrl must use the immutable package release tag.',
       );
     }
-  }
-
-  String? _releaseSection(String changelog, String version) {
-    final searchable = _stripMarkdownCommentsAndFences(changelog);
-    final heading = RegExp(
-      '^##[ \\t]+${RegExp.escape(version)}[ \\t]*\$',
-      multiLine: true,
-    ).firstMatch(searchable);
-    if (heading == null) {
-      return null;
-    }
-
-    final remainder = searchable.substring(heading.end);
-    final nextHeading = RegExp(
-      r'^##[ \t]+\S.*$',
-      multiLine: true,
-    ).firstMatch(remainder);
-    final end = nextHeading == null
-        ? searchable.length
-        : heading.end + nextHeading.start;
-    return searchable.substring(heading.end, end);
-  }
-
-  bool _hasSubstantiveReleaseNotes(String section) {
-    final withoutComments = section.replaceAll(
-      RegExp(r'<!--[\s\S]*?-->'),
-      '',
-    );
-    const placeholders = <String>{
-      'coming soon',
-      'n/a',
-      'none',
-      'tbd',
-      'todo',
-      'unreleased',
-    };
-    for (final line in withoutComments.split('\n')) {
-      var content = line.trim();
-      if (content.isEmpty ||
-          RegExp(r'^#{1,6}(?:[ \t]|$)').hasMatch(content) ||
-          RegExp(r'^[-*_]{3,}$').hasMatch(content)) {
-        continue;
-      }
-      content = content
-          .replaceFirst(RegExp(r'^(?:[-*+]|\d+[.)])[ \t]+'), '')
-          .replaceFirst(RegExp(r'^>[ \t]*'), '')
-          .replaceAll(RegExp(r'[`*_~]'), '')
-          .trim();
-      final normalized =
-          content.replaceFirst(RegExp(r'[.!?]+$'), '').trim().toLowerCase();
-      if (normalized.isNotEmpty && !placeholders.contains(normalized)) {
-        return true;
-      }
-    }
-    return false;
   }
 
   void _validateStableDocumentation(
@@ -1059,41 +1001,6 @@ String _stripShellComments(String source) {
     while (index + 1 < source.length && source[index + 1] != '\n') {
       index += 1;
     }
-  }
-  return result.toString();
-}
-
-String _stripMarkdownCommentsAndFences(String source) {
-  final withoutComments = source.replaceAll(
-    RegExp(r'<!--[\s\S]*?-->'),
-    '',
-  );
-  final result = StringBuffer();
-  String? fenceCharacter;
-  var minimumFenceLength = 0;
-  final fence = RegExp(r'^[ \t]*(`{3,}|~{3,})');
-
-  for (final line in withoutComments.split('\n')) {
-    final fenceMatch = fence.firstMatch(line);
-    final marker = fenceMatch?.group(1);
-    if (fenceCharacter == null) {
-      if (marker == null) {
-        result.writeln(line);
-      } else {
-        fenceCharacter = marker[0];
-        minimumFenceLength = marker.length;
-        result.writeln();
-      }
-      continue;
-    }
-    if (marker != null &&
-        marker[0] == fenceCharacter &&
-        marker.length >= minimumFenceLength &&
-        line.substring(fenceMatch!.end).trim().isEmpty) {
-      fenceCharacter = null;
-      minimumFenceLength = 0;
-    }
-    result.writeln();
   }
   return result.toString();
 }

--- a/tool/release/release_notes.dart
+++ b/tool/release/release_notes.dart
@@ -1,0 +1,206 @@
+/// Extracts the exact-version body used for a GitHub release.
+///
+/// The matching `## <version>` heading and the next visible level-two heading
+/// are excluded. Headings inside HTML comments or fenced code blocks are
+/// ignored. The returned Markdown has boundary blank lines removed and exactly
+/// one trailing newline.
+String extractReleaseNotes({
+  required String changelog,
+  required String version,
+}) {
+  final masked = maskMarkdownCommentsAndFences(changelog);
+  final targetHeading = RegExp(
+    '^##[ \\t]+${RegExp.escape(version)}[ \\t]*\\r?\$',
+    multiLine: true,
+  );
+  final matches = targetHeading.allMatches(masked).toList(growable: false);
+  if (matches.isEmpty) {
+    throw FormatException('has no release heading for $version.');
+  }
+  if (matches.length > 1) {
+    throw FormatException('has multiple release headings for $version.');
+  }
+
+  final heading = matches.single;
+  final remainder = masked.substring(heading.end);
+  final nextHeading = RegExp(
+    r'^##[ \t]+\S.*\r?$',
+    multiLine: true,
+  ).firstMatch(remainder);
+  final end =
+      nextHeading == null ? changelog.length : heading.end + nextHeading.start;
+  final body = changelog.substring(heading.end, end);
+
+  if (!_hasSubstantiveReleaseNotes(body)) {
+    throw FormatException(
+      'release section for $version has no substantive release notes.',
+    );
+  }
+  return _normalizeBoundaries(body);
+}
+
+bool _hasSubstantiveReleaseNotes(String section) {
+  final masked = maskMarkdownCommentsAndFences(section);
+  const placeholders = <String>{
+    'coming soon',
+    'n/a',
+    'none',
+    'tbd',
+    'todo',
+    'unreleased',
+  };
+  for (final line in masked.split(RegExp(r'\r\n?|\n'))) {
+    var content = line.trim();
+    if (content.isEmpty ||
+        RegExp(r'^#{1,6}(?:[ \t]|$)').hasMatch(content) ||
+        RegExp(r'^[-*_]{3,}$').hasMatch(content)) {
+      continue;
+    }
+    content = content
+        .replaceFirst(RegExp(r'^(?:[-*+]|\d+[.)])[ \t]+'), '')
+        .replaceFirst(RegExp(r'^>[ \t]*'), '')
+        .replaceAll(RegExp(r'[`*_~]'), '')
+        .trim();
+    final normalized =
+        content.replaceFirst(RegExp(r'[.!?:;]+$'), '').trim().toLowerCase();
+    if (normalized.isNotEmpty && !placeholders.contains(normalized)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+String _normalizeBoundaries(String source) {
+  final normalized = source.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+  final lines = normalized.split('\n');
+  var start = 0;
+  while (start < lines.length && lines[start].trim().isEmpty) {
+    start += 1;
+  }
+  var end = lines.length;
+  while (end > start && lines[end - 1].trim().isEmpty) {
+    end -= 1;
+  }
+  return '${lines.sublist(start, end).join('\n')}\n';
+}
+
+/// Masks HTML comments and fenced code while preserving every source offset.
+String maskMarkdownCommentsAndFences(String source) {
+  final original = source.codeUnits;
+  final masked = List<int>.of(original);
+  var inComment = false;
+  int? inlineBacktickLength;
+  final fence = RegExp(r'^[ \t]*(`{3,}|~{3,})');
+  int? fenceCharacter;
+  var minimumFenceLength = 0;
+  var lineStart = 0;
+  while (lineStart < masked.length) {
+    var lineEnd = lineStart;
+    while (lineEnd < masked.length &&
+        masked[lineEnd] != 0x0a &&
+        masked[lineEnd] != 0x0d) {
+      lineEnd += 1;
+    }
+    final originalLine = source.substring(lineStart, lineEnd);
+    if (fenceCharacter != null) {
+      final match = fence.firstMatch(originalLine);
+      final marker = match?.group(1);
+      _maskRange(masked, lineStart, lineEnd);
+      if (marker != null &&
+          marker.codeUnitAt(0) == fenceCharacter &&
+          marker.length >= minimumFenceLength &&
+          originalLine.substring(match!.end).trim().isEmpty) {
+        fenceCharacter = null;
+        minimumFenceLength = 0;
+      }
+    } else {
+      var index = lineStart;
+      while (index < lineEnd) {
+        if (inComment) {
+          if (_matchesAscii(original, index, '-->')) {
+            _maskRange(masked, index, index + 3);
+            index += 3;
+            inComment = false;
+          } else {
+            masked[index] = 0x20;
+            index += 1;
+          }
+          continue;
+        }
+        if (original[index] == 0x60) {
+          final runLength = _backtickRunLength(original, index, lineEnd);
+          if (inlineBacktickLength == null) {
+            inlineBacktickLength = runLength;
+          } else if (inlineBacktickLength == runLength) {
+            inlineBacktickLength = null;
+          }
+          index += runLength;
+          continue;
+        }
+        if (inlineBacktickLength == null &&
+            _matchesAscii(original, index, '<!--')) {
+          _maskRange(masked, index, index + 4);
+          index += 4;
+          inComment = true;
+          continue;
+        }
+        index += 1;
+      }
+
+      final visibleLine = String.fromCharCodes(
+        masked.sublist(lineStart, lineEnd),
+      );
+      final match = fence.firstMatch(visibleLine);
+      final marker = match?.group(1);
+      if (marker != null) {
+        final markerStart = match!.end - marker.length;
+        final originalPrefix = originalLine.substring(0, markerStart);
+        if (originalPrefix.trim().isEmpty) {
+          fenceCharacter = marker.codeUnitAt(0);
+          minimumFenceLength = marker.length;
+          inComment = false;
+          inlineBacktickLength = null;
+          _maskRange(masked, lineStart, lineEnd);
+        }
+      }
+    }
+
+    if (lineEnd < masked.length &&
+        masked[lineEnd] == 0x0d &&
+        lineEnd + 1 < masked.length &&
+        masked[lineEnd + 1] == 0x0a) {
+      lineStart = lineEnd + 2;
+    } else {
+      lineStart = lineEnd + 1;
+    }
+  }
+  return String.fromCharCodes(masked);
+}
+
+int _backtickRunLength(List<int> source, int start, int end) {
+  var index = start + 1;
+  while (index < end && source[index] == 0x60) {
+    index += 1;
+  }
+  return index - start;
+}
+
+bool _matchesAscii(List<int> source, int start, String value) {
+  if (start + value.length > source.length) {
+    return false;
+  }
+  for (var offset = 0; offset < value.length; offset += 1) {
+    if (source[start + offset] != value.codeUnitAt(offset)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void _maskRange(List<int> source, int start, int end) {
+  for (var index = start; index < end; index += 1) {
+    if (source[index] != 0x0a && source[index] != 0x0d) {
+      source[index] = 0x20;
+    }
+  }
+}

--- a/tool/release/verify_release_workflow_security_test.sh
+++ b/tool/release/verify_release_workflow_security_test.sh
@@ -70,9 +70,14 @@ grep -q '      contents: write' "$WRITE_JOB" ||
   fail "The release write job cannot create tags or releases."
 grep -q '      statuses: write$' "$WRITE_JOB" ||
   fail "The release write job cannot authorize the exact commit."
+grep -q '      actions: read$' "$WRITE_JOB" ||
+  fail "The release write job cannot download validated release notes."
 
-if [[ $(grep -c 'persist-credentials: false' "$WORKFLOW") -ne 2 ]]; then
-  fail "Both release checkouts must disable persisted credentials."
+if [[ $(grep -c 'uses: actions/checkout@' "$WORKFLOW") -ne 3 ]]; then
+  fail "The release workflow must have package, control, and write checkouts."
+fi
+if [[ $(grep -c 'persist-credentials: false' "$WORKFLOW") -ne 3 ]]; then
+  fail "All release checkouts must disable persisted credentials."
 fi
 if [[ $(grep -c 'RELEASE_PAT:' "$WORKFLOW") -ne 2 ]]; then
   fail "RELEASE_PAT must be declared for callers and exposed only to the tag push."
@@ -84,6 +89,94 @@ grep -A3 '^    secrets:$' "$WORKFLOW" | grep -q 'RELEASE_PAT:' ||
 if grep -Fq '${{ needs.validate-release.outputs' "$WRITE_RUN_SCRIPTS"; then
   fail "Validated repository values must enter privileged scripts through env."
 fi
+if grep -qE 'dart |bash .*tool/|prepare_release_notes' "$WRITE_RUN_SCRIPTS"; then
+  fail "The release write job must not execute package or release tooling."
+fi
+
+CONTROL_CHECKOUT="$FIXTURE_DIR/control-checkout.yml"
+sed -n \
+  '/- name: Checkout release-note control tooling/,/- name: Prepare immutable release notes/p' \
+  "$VALIDATION_JOB" >"$CONTROL_CHECKOUT"
+# Match the literal GitHub expressions.
+# shellcheck disable=SC2016
+grep -Fq 'repository: ${{ job.workflow_repository }}' "$CONTROL_CHECKOUT" ||
+  fail "Release-note control tooling must come from the reusable workflow repository."
+# shellcheck disable=SC2016
+grep -Fq 'ref: ${{ job.workflow_sha }}' "$CONTROL_CHECKOUT" ||
+  fail "Release-note control tooling must be pinned to the reusable workflow SHA."
+grep -q 'path: release-control' "$CONTROL_CHECKOUT" ||
+  fail "Release-note control tooling must use an isolated checkout path."
+grep -q 'persist-credentials: false' "$CONTROL_CHECKOUT" ||
+  fail "The control checkout must not persist credentials."
+# Match the literal shell path in workflow code.
+# shellcheck disable=SC2016
+grep -Fq \
+  'dart "$GITHUB_WORKSPACE/release-control/tool/release/prepare_release_notes.dart"' \
+  "$VALIDATION_JOB" ||
+  fail "Release notes must use the pinned control renderer."
+if grep -q 'dart tool/release/prepare_release_notes.dart' "$VALIDATION_JOB"; then
+  fail "Release notes must not execute a renderer from the release checkout."
+fi
+
+CANDIDATE_LINE=$(grep -n -- '- name: Prepare release candidate' \
+  "$VALIDATION_JOB" | cut -d: -f1)
+CONTROL_LINE=$(grep -n -- '- name: Checkout release-note control tooling' \
+  "$VALIDATION_JOB" | cut -d: -f1)
+RENDER_LINE=$(grep -n -- '- name: Prepare immutable release notes' \
+  "$VALIDATION_JOB" | cut -d: -f1)
+UPLOAD_LINE=$(grep -n -- '- name: Upload immutable release notes' \
+  "$VALIDATION_JOB" | cut -d: -f1)
+DEPENDENCIES_LINE=$(grep -n -- '- name: Install release dependencies' \
+  "$VALIDATION_JOB" | cut -d: -f1)
+if [[ -z "$CANDIDATE_LINE" || -z "$CONTROL_LINE" || -z "$RENDER_LINE" ||
+  -z "$UPLOAD_LINE" || -z "$DEPENDENCIES_LINE" ]] ||
+  ((CANDIDATE_LINE >= CONTROL_LINE ||
+    CONTROL_LINE >= RENDER_LINE ||
+    RENDER_LINE >= UPLOAD_LINE ||
+    UPLOAD_LINE >= DEPENDENCIES_LINE)); then
+  fail "Release notes must be rendered and uploaded after staging and before dependencies."
+fi
+grep -qE 'actions/upload-artifact@[0-9a-f]{40} ' "$VALIDATION_JOB" ||
+  fail "The release-note upload action must be pinned to a commit SHA."
+grep -q 'path:.*release-notes/release-notes.md' "$VALIDATION_JOB" ||
+  fail "Only the rendered release-note file should be uploaded."
+grep -q 'sha256sum.*release-notes.md' "$VALIDATION_JOB" ||
+  fail "The read-only job must hash the rendered release notes."
+
+VALIDATION_OUTPUTS="$FIXTURE_DIR/validation-outputs.yml"
+sed -n '/^    outputs:/,/^    steps:/p' \
+  "$VALIDATION_JOB" >"$VALIDATION_OUTPUTS"
+grep -q 'release_notes_artifact:' "$VALIDATION_OUTPUTS" ||
+  fail "The release-note artifact name must cross the job boundary."
+grep -q 'release_notes_sha:' "$VALIDATION_OUTPUTS" ||
+  fail "The release-note digest must cross the job boundary."
+if grep -qE 'release_notes_(body|path)' "$VALIDATION_OUTPUTS"; then
+  fail "Release-note bodies and paths must not cross through job outputs."
+fi
+
+grep -qE 'actions/download-artifact@[0-9a-f]{40} ' "$WRITE_JOB" ||
+  fail "The release-note download action must be pinned to a commit SHA."
+grep -q 'sha256sum --check --strict' "$WRITE_JOB" ||
+  fail "The release write job must verify the release-note digest."
+DOWNLOAD_LINE=$(grep -n -- '- name: Download immutable release notes' \
+  "$WRITE_JOB" | cut -d: -f1)
+VERIFY_LINE=$(grep -n -- '- name: Verify immutable release notes' \
+  "$WRITE_JOB" | cut -d: -f1)
+RESOLVE_TAG_LINE=$(grep -n -- '- name: Resolve release tag' \
+  "$WRITE_JOB" | cut -d: -f1)
+if [[ -z "$DOWNLOAD_LINE" || -z "$VERIFY_LINE" ||
+  -z "$RESOLVE_TAG_LINE" ]] ||
+  ((DOWNLOAD_LINE >= VERIFY_LINE || VERIFY_LINE >= RESOLVE_TAG_LINE)); then
+  fail "Release notes must be downloaded and verified before tag mutation."
+fi
+grep -q 'body_path:.*release-notes/release-notes.md' "$WRITE_JOB" ||
+  fail "GitHub releases must use the verified release-note file."
+grep -q 'append_body: false' "$WRITE_JOB" ||
+  fail "Recovery must replace stale release text instead of appending to it."
+if grep -qE 'generate_release_notes:|^          body:' "$WRITE_JOB"; then
+  fail "GitHub-generated or inline release bodies must stay disabled."
+fi
+
 grep -A12 -- '- name: Push new release tag' "$WORKFLOW" |
   grep -q 'RELEASE_PAT:' ||
   fail "The new-tag push step is missing RELEASE_PAT."

--- a/tool/release/verify_release_workflow_security_test.sh
+++ b/tool/release/verify_release_workflow_security_test.sh
@@ -89,8 +89,31 @@ grep -A3 '^    secrets:$' "$WORKFLOW" | grep -q 'RELEASE_PAT:' ||
 if grep -Fq '${{ needs.validate-release.outputs' "$WRITE_RUN_SCRIPTS"; then
   fail "Validated repository values must enter privileged scripts through env."
 fi
-if grep -qE 'dart |bash .*tool/|prepare_release_notes' "$WRITE_RUN_SCRIPTS"; then
-  fail "The release write job must not execute package or release tooling."
+# Privileged scripts must neither execute Dart nor reference repository tooling.
+FORBIDDEN_WRITE_TOOLING_PATTERN='(^|[^[:alnum:]_.-])dart([^[:alnum:]_.-]|$)|tool/|prepare_release_notes'
+for forbidden_command in \
+  'dart' \
+  $'dart\t--version' \
+  '"/opt/sdk/bin/dart" --version' \
+  $'bash \\\n  tool/release/example.sh' \
+  'sh tool/release/example.sh' \
+  './tool/release/example.sh'; do
+  if ! grep -qE "$FORBIDDEN_WRITE_TOOLING_PATTERN" \
+    <<<"$forbidden_command"; then
+    fail "The write-job tooling guard must reject: $forbidden_command"
+  fi
+done
+for allowed_command in \
+  'echo dartboard' \
+  'echo dart-sdk' \
+  'echo example.dart' \
+  'echo my_dart_tool'; do
+  if grep -qE "$FORBIDDEN_WRITE_TOOLING_PATTERN" <<<"$allowed_command"; then
+    fail "The write-job tooling guard must allow: $allowed_command"
+  fi
+done
+if grep -qE "$FORBIDDEN_WRITE_TOOLING_PATTERN" "$WRITE_RUN_SCRIPTS"; then
+  fail "The release write job must not execute Dart or reference repository tooling."
 fi
 
 CONTROL_CHECKOUT="$FIXTURE_DIR/control-checkout.yml"


### PR DESCRIPTION
## Summary

- Use each package's exact-version `CHANGELOG.md` section as the GitHub release body.
- Render notes in the read-only job from the immutable workflow source, rewrite same-repository links to the release tag, and transfer only the rendered file plus its SHA-256 digest.
- Verify the artifact before any tag mutation and publish it with `body_path`, replacing broad GitHub-generated notes on both new releases and exact-tag recovery.
- Share the Markdown parser with release metadata validation and document the recovery/backfill boundary.
- Keep `SECURITY.md` on the current SDK/CLI stable lines and reject future release prep when either policy row drifts.

## Why

`generate_release_notes: true` can choose an unsuitable previous tag in this multi-package repository and produce very large cross-package compare ranges. The checked-in changelogs already contain the curated, package-specific release notes.

This PR changes future release creation and exact-tag recovery only. It does **not** edit any existing GitHub release, tag, issue, or publication. Historical body-only repairs remain a separate operation requiring explicit approval; rerunning the release workflow solely for a body repair could also change the repository's latest-release marker.

## Security and recovery properties

- Release candidates are staged before the control checkout, so control files cannot enter a published package.
- The renderer is checked out from `${{ job.workflow_repository }}` at `${{ job.workflow_sha }}`, allowing historical exact-tag recovery even when the tag predates the renderer.
- The write-capable job downloads one pinned artifact, rejects symlinks, verifies its SHA-256 digest, and executes no repository Dart or release tooling.
- Release notes reject missing, duplicate, placeholder-only, comment-only, or fence-only version sections.
- HTML comments, fenced code, inline code markers, CRLF input, prerelease versions, nested Markdown, and immutable link rewriting have regressions.
- Supported-release policy validation ignores rows hidden in HTML comments or fenced examples.

## Validation

- `dart format --output=none --set-exit-if-changed .` — 319 files, clean
- Root `dart analyze` — clean
- Root `dart test` — 1,974 passed
- CLI `dart analyze` — clean
- CLI `dart test` — 125 passed, 14 skipped because optional external TypeScript/Python fixtures were not installed
- Focused release-tool suite — 50 passed
- Release workflow security, release-prep, publish security/provenance, CLI binary, release CI, and release-source shell gates — passed
- `shellcheck tool/release/verify_release_workflow_security_test.sh` — passed
- `actionlint` — passed with only the local 1.7.12 schema checks for `job.workflow_repository` and `job.workflow_sha` ignored; both fields are defined in the current [GitHub job context documentation](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/workflows-and-actions/contexts#job-context)
- `dart tool/validate_release_metadata.dart --package mcp_dart --tag v2.4.0` — passed
- Current v2.4.0 SDK and v0.2.0 CLI notes rendered with exact final newlines and no mutable same-repository links
- Minimal historical v2.3.0 SDK and v0.2.0 CLI tag checkouts rendered successfully with current control tooling
- Independent final review — no remaining actionable findings

## Remaining release-state note

The current main-branch CLI metadata gate intentionally remains outside this PR: CLI 0.2.0 still declares the previously published SDK range while main is SDK 2.4.0. A future coordinated CLI release-prep change must update that dependency. Historical CLI recovery was validated against its exact tag checkout.
