### PR TITLE
Keep legacy Python interop on MCP SDK v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,9 +46,22 @@ updates:
           - version-update:semver-major
 
   - package-ecosystem: pip
-    directories:
-      - /test/interop/python
-      - /test/interop/python_2026_07_28
+    directory: /test/interop/python
+    schedule:
+      interval: weekly
+    groups:
+      python-dependencies:
+        group-by: dependency-name
+    ignore:
+      # This fixture intentionally exercises Python SDK 1.x interoperability.
+      # Python SDK 2.x is covered by /test/interop/python_2026_07_28. Remove this
+      # exception when the legacy interoperability lane is retired.
+      - dependency-name: mcp
+        update-types:
+          - version-update:semver-major
+
+  - package-ecosystem: pip
+    directory: /test/interop/python_2026_07_28
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION
## Summary

- split the legacy and 2026-07-28 Python Dependabot configurations
- ignore MCP SDK semver-major updates only for the intentional Python 1.x interoperability fixture
- keep the Python 2.x fixture monitored for all updates

Supersedes #343, whose MCP 2.0 upgrade breaks the legacy fixture and its mcp-server-time dependency.

## Validation

- parsed .github/dependabot.yml successfully
- asserted separate legacy and modern pip entries
- asserted the major-version ignore is scoped only to the legacy fixture
- git diff --check