### PR TITLE
ci: work around Dependabot group rebase bug

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
         patterns:
           - '*'
 
+  # Keep non-Actions updates ungrouped until
+  # https://github.com/dependabot/dependabot-core/issues/14780 is fixed.
+  # Dynamic group-by PRs cannot currently be rebased or recreated.
   - package-ecosystem: pub
     directories:
       - /
@@ -22,9 +25,6 @@ updates:
       - /example/jaspr-client
     schedule:
       interval: weekly
-    groups:
-      pub-dependencies:
-        group-by: dependency-name
 
   - package-ecosystem: npm
     directories:
@@ -32,9 +32,6 @@ updates:
       - /test/interop/ts_2026_07_28
     schedule:
       interval: weekly
-    groups:
-      npm-dependencies:
-        group-by: dependency-name
     ignore:
       # Keep compile-time Node APIs aligned with the Node 24 CI baseline.
       - dependency-name: '@types/node'
@@ -49,9 +46,6 @@ updates:
     directory: /test/interop/python
     schedule:
       interval: weekly
-    groups:
-      python-dependencies:
-        group-by: dependency-name
     ignore:
       # This fixture intentionally exercises Python SDK 1.x interoperability.
       # Python SDK 2.x is covered by /test/interop/python_2026_07_28. Remove this
@@ -64,6 +58,3 @@ updates:
     directory: /test/interop/python_2026_07_28
     schedule:
       interval: weekly
-    groups:
-      python-dependencies:
-        group-by: dependency-name


### PR DESCRIPTION
## Summary

- keep the static GitHub Actions dependency group
- remove `group-by: dependency-name` from pub, npm, and pip updates
- document the upstream Dependabot refresh bug that requires this workaround

## Why

Dependabot PRs #352, #353, and #355 could not be rebased or recreated. The bot reported that an `unknown` group had been removed even though the configuration was unchanged.

This matches [dependabot/dependabot-core#14780](https://github.com/dependabot/dependabot-core/issues/14780): dynamic subgroups created by `group-by: dependency-name` cannot currently be refreshed. Falling back to Dependabot's default individual PRs restores normal rebase and recreate behavior.

The tradeoff is that the same dependency may receive separate PRs when it appears in multiple directories. Runtime dependencies, version policies, and ignore rules are unchanged.

## Validation

- `git diff --check`
- parsed `.github/dependabot.yml` with Ruby `YAML.safe_load`
- asserted all five ecosystem entries retain their required directory and weekly schedule
- asserted the static GitHub Actions group remains and dynamic groups are absent
