### PR TITLE
Fix Dart 3.13 analyzer compatibility

### DIFF
--- a/example/flutter_http_client/lib/services/streamable_mcp_service.dart
+++ b/example/flutter_http_client/lib/services/streamable_mcp_service.dart
@@ -204,14 +204,13 @@ class StreamableMcpService extends ChangeNotifier {
 
           // Refresh resources when list changes
           try {
-            if (_client == null) return Future.value();
+            if (_client == null) return;
             await listResources();
           } catch (error) {
             // Handle error silently
           }
 
           notifyListeners();
-          return Future.value();
         },
         (params, meta) => JsonRpcResourceListChangedNotification.fromJson({
           'jsonrpc': jsonRpcVersion,

--- a/lib/src/server/streamable_https.dart
+++ b/lib/src/server/streamable_https.dart
@@ -1862,7 +1862,7 @@ class StreamableHTTPServerTransport
     try {
       final store = _eventStore;
       if (store == null) {
-        return _enqueueSseWrite(res, const <int>[]);
+        return await _enqueueSseWrite(res, const <int>[]);
       }
 
       final eventId = await store.storeEvent(streamId, _ssePrimingMessage);

--- a/lib/src/shared/iostream.dart
+++ b/lib/src/shared/iostream.dart
@@ -76,8 +76,6 @@ class IOStreamTransport implements Transport {
         onDone: _onStreamDone,
         cancelOnError: false,
       );
-
-      return Future.value();
     } catch (error, stackTrace) {
       _started = false; // Reset state
       final startError = StateError(

--- a/lib/src/shared/protocol.dart
+++ b/lib/src/shared/protocol.dart
@@ -2185,7 +2185,7 @@ abstract class Protocol {
       }
     }
 
-    Future.microtask(invokeHandler).then(
+    Future.microtask(invokeHandler).then<void>(
       (result) async {
         if (abortController.signal.aborted) {
           return;


### PR DESCRIPTION
## Summary

- await the initial SSE write so asynchronous failures remain covered by the existing error handling
- remove redundant `Future.value()` returns from async `Future<void>` flows
- make the protocol response continuation's `void` result explicit for Dart 3.13 type inference

## Root cause

Dart 3.13 introduced analyzer diagnostics for returning a future without awaiting it inside a `try` block and tightened inference for the protocol continuation. These diagnostics caused package validation and the Flutter example analyzer to fail on otherwise unrelated Dependabot PRs #358, #359, and #360.

## Impact

This restores Dart 3.13 and Flutter 3.47 analyzer compatibility without changing public APIs or MCP/JSON-RPC wire behavior. Awaiting the SSE write preserves the intended catch semantics; the other changes are equivalent async `void` control flow or explicit typing.

## Validation

- Dart 3.13.0: repository format check, `dart analyze`, and full `dart test`
- Dart 3.13.0: 101 focused IO stream, Streamable HTTP, and protocol coverage tests
- Dart 3.13.0: `dart pub publish --dry-run` with 0 warnings
- CLI on Dart 3.13.0: `dart analyze`; 125 tests passed with 14 intentional skips
- Flutter 3.47.0 example: `flutter analyze`; all 9 tests passed
