### PR TITLE
Prepare mcp_dart 2.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,16 @@
-## 2.5.0
+## 2.4.1
 
-`mcp_dart 2.5` adds Streamable HTTP access and JSON-RPC error logging while
-keeping application logging failures isolated from protocol behavior.
-
-### Added
-
-- Added Streamable HTTP access and JSON-RPC error logging. Default records omit
-  request paths, JSON-RPC request IDs, MCP session IDs, and remote network
-  addresses; JSON-RPC error messages are escaped for single-record logging.
-  Thanks to [@venti1112](https://github.com/venti1112)
-  ([#350](https://github.com/leehack/mcp_dart/pull/350)).
+`mcp_dart 2.4.1` restores Dart 3.13 package-analysis compatibility and hardens
+Streamable HTTP diagnostics without changing public APIs or protocol behavior.
 
 ### Fixed
 
+- Added missing Streamable HTTP access and JSON-RPC error diagnostics. Default
+  records omit request paths, JSON-RPC request IDs, MCP session IDs, and remote
+  network addresses; JSON-RPC error messages are escaped for single-record
+  logging.
+  Thanks to [@venti1112](https://github.com/venti1112)
+  ([#350](https://github.com/leehack/mcp_dart/pull/350)).
 - Isolated application `LogHandler` failures from `StreamableMcpServer`
   diagnostics so those logs cannot change server behavior or protocol
   responses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## Unreleased
+## 2.5.0
+
+`mcp_dart 2.5` adds Streamable HTTP access and JSON-RPC error logging while
+keeping application logging failures isolated from protocol behavior.
 
 ### Added
 
@@ -13,6 +16,8 @@
 - Isolated application `LogHandler` failures from `StreamableMcpServer`
   diagnostics so those logs cannot change server behavior or protocol
   responses.
+- Restored clean static analysis and formatting with Dart 3.13
+  ([#361](https://github.com/leehack/mcp_dart/pull/361)).
 
 ## 2.4.0
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ extensions, host UI behavior, an authorization-server implementation, JSON
 Schema external-reference resolution, and custom JSON Schema vocabularies.
 
 > [!IMPORTANT]
-> The current stable packages are `mcp_dart 2.4.0` and
-> `mcp_dart_cli 0.2.0`; the CLI's `^2.3.0` SDK constraint accepts 2.4.
+> The current stable packages are `mcp_dart 2.5.0` and
+> `mcp_dart_cli 0.2.0`; the CLI's `^2.3.0` SDK constraint accepts 2.5.
 > Current source passes every scored requirement in the official alpha.11 MCP
 > `2025-11-25` and `2026-07-28` client and server sets, including all 25
 > required 2026 authorization scenarios, plus bidirectional published
@@ -40,7 +40,7 @@ The public maintenance contract is documented in the
 
 | Package | Minimum Dart SDK |
 | --- | --- |
-| `mcp_dart 2.4.0` | 3.4 |
+| `mcp_dart 2.5.0` | 3.4 |
 | `mcp_dart_cli 0.2.0` | 3.12 |
 
 SDK-only generated projects retain the SDK's Dart 3.4 minimum. CLI projects
@@ -60,12 +60,12 @@ dart pub add mcp_dart
 
 ### Pin the stable SDK release
 
-Pin the stable 2.4 line explicitly when reproducible dependency resolution is
+Pin the stable 2.5 line explicitly when reproducible dependency resolution is
 important:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.4.0
+  mcp_dart: ^2.5.0
 ```
 
 The snippets below use the current stable SDK line. Package versions
@@ -73,7 +73,7 @@ remain separate from protocol profiles: `McpProtocol.stable` names the SDK's
 default compatibility policy.
 
 The SDK and CLI are versioned independently. The stable CLI's `^2.3.0`
-constraint remains compatible with the 2.4 SDK.
+constraint remains compatible with the 2.5 SDK.
 
 For direct SDK integration, start with the
 [getting-started guide](https://github.com/leehack/mcp_dart/blob/main/doc/getting-started.md).
@@ -99,9 +99,10 @@ commands.
   2.0.0 interoperability, real-browser transport tests, a real Flutter Web
   service integration in Chrome, deterministic widget tests, and an
   independent pinned JSON Schema Test Suite gate.
-- `mcp_dart 2.4.0` adds a deprecated, opt-in legacy HTTP+SSE client
-  with same-origin routing and bidirectional interoperability against official
-  TypeScript SDK 1.30.0 and Python SDK 2.0.0 peers.
+- `mcp_dart 2.5.0` adds Streamable HTTP access and JSON-RPC error diagnostics
+  and retains the deprecated, opt-in legacy HTTP+SSE client with same-origin
+  routing and bidirectional interoperability against official TypeScript SDK
+  1.30.0 and Python SDK 2.0.0 peers.
 
 MCP has three roles: a host owns the user experience, a client connects that
 host to one server, and a server exposes tools, resources, and prompts. A host
@@ -237,7 +238,7 @@ surface. Re-check both packages' current releases before a production decision.
 - [Versioning policy](https://github.com/leehack/mcp_dart/blob/main/VERSIONING.md)
 - [Tier 1 roadmap](https://github.com/leehack/mcp_dart/blob/main/ROADMAP.md)
 - [SDK on pub.dev](https://pub.dev/packages/mcp_dart)
-- [2.4.0 API reference](https://pub.dev/documentation/mcp_dart/2.4.0/)
+- [2.5.0 API reference](https://pub.dev/documentation/mcp_dart/2.5.0/)
 - [Changelog](https://github.com/leehack/mcp_dart/blob/main/CHANGELOG.md)
 - [MCP 2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28)
 - [MCP 2025-11-25 specification](https://modelcontextprotocol.io/specification/2025-11-25)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ extensions, host UI behavior, an authorization-server implementation, JSON
 Schema external-reference resolution, and custom JSON Schema vocabularies.
 
 > [!IMPORTANT]
-> The current stable packages are `mcp_dart 2.5.0` and
-> `mcp_dart_cli 0.2.0`; the CLI's `^2.3.0` SDK constraint accepts 2.5.
+> The current stable packages are `mcp_dart 2.4.1` and
+> `mcp_dart_cli 0.2.0`; the CLI's `^2.3.0` SDK constraint accepts 2.4.
 > Current source passes every scored requirement in the official alpha.11 MCP
 > `2025-11-25` and `2026-07-28` client and server sets, including all 25
 > required 2026 authorization scenarios, plus bidirectional published
@@ -40,7 +40,7 @@ The public maintenance contract is documented in the
 
 | Package | Minimum Dart SDK |
 | --- | --- |
-| `mcp_dart 2.5.0` | 3.4 |
+| `mcp_dart 2.4.1` | 3.4 |
 | `mcp_dart_cli 0.2.0` | 3.12 |
 
 SDK-only generated projects retain the SDK's Dart 3.4 minimum. CLI projects
@@ -60,12 +60,12 @@ dart pub add mcp_dart
 
 ### Pin the stable SDK release
 
-Pin the stable 2.5 line explicitly when reproducible dependency resolution is
+Pin the stable 2.4 line explicitly when reproducible dependency resolution is
 important:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.5.0
+  mcp_dart: ^2.4.1
 ```
 
 The snippets below use the current stable SDK line. Package versions
@@ -73,7 +73,7 @@ remain separate from protocol profiles: `McpProtocol.stable` names the SDK's
 default compatibility policy.
 
 The SDK and CLI are versioned independently. The stable CLI's `^2.3.0`
-constraint remains compatible with the 2.5 SDK.
+constraint remains compatible with the 2.4 SDK.
 
 For direct SDK integration, start with the
 [getting-started guide](https://github.com/leehack/mcp_dart/blob/main/doc/getting-started.md).
@@ -99,10 +99,10 @@ commands.
   2.0.0 interoperability, real-browser transport tests, a real Flutter Web
   service integration in Chrome, deterministic widget tests, and an
   independent pinned JSON Schema Test Suite gate.
-- `mcp_dart 2.5.0` adds Streamable HTTP access and JSON-RPC error diagnostics
-  and retains the deprecated, opt-in legacy HTTP+SSE client with same-origin
-  routing and bidirectional interoperability against official TypeScript SDK
-  1.30.0 and Python SDK 2.0.0 peers.
+- `mcp_dart 2.4.1` hardens Streamable HTTP access and JSON-RPC error
+  diagnostics and retains the deprecated, opt-in legacy HTTP+SSE client with
+  same-origin routing and bidirectional interoperability against official
+  TypeScript SDK 1.30.0 and Python SDK 2.0.0 peers.
 
 MCP has three roles: a host owns the user experience, a client connects that
 host to one server, and a server exposes tools, resources, and prompts. A host
@@ -238,7 +238,7 @@ surface. Re-check both packages' current releases before a production decision.
 - [Versioning policy](https://github.com/leehack/mcp_dart/blob/main/VERSIONING.md)
 - [Tier 1 roadmap](https://github.com/leehack/mcp_dart/blob/main/ROADMAP.md)
 - [SDK on pub.dev](https://pub.dev/packages/mcp_dart)
-- [2.5.0 API reference](https://pub.dev/documentation/mcp_dart/2.5.0/)
+- [2.4.1 API reference](https://pub.dev/documentation/mcp_dart/2.4.1/)
 - [Changelog](https://github.com/leehack/mcp_dart/blob/main/CHANGELOG.md)
 - [MCP 2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28)
 - [MCP 2025-11-25 specification](https://modelcontextprotocol.io/specification/2025-11-25)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ through the
 
 ## Current baseline
 
-- Stable `mcp_dart 2.4.0` and `mcp_dart_cli 0.2.0` releases.
+- Stable `mcp_dart 2.5.0` and `mcp_dart_cli 0.2.0` releases.
 - Complete Core client/server support for MCP 2026-07-28 with an explicit
   MCP 2025-11-25 compatibility profile.
 - Exact-head CI passes the published official conformance package for both
@@ -30,7 +30,7 @@ outside the Tier 1 Core claim.
 | --- | --- | --- |
 | Publish maintenance, security, dependency, and versioning policies | Policies are linked from the README and pass the official policy evaluation | Complete: the official checker finds all required policy signals; final qualitative judgment remains with reviewers |
 | Adopt the MCP issue taxonomy | All required type, status, and priority labels exist; every open issue is triaged | Complete: 12/12 labels and 100% current open-issue triage |
-| Audit the project-maintained Tier 1 documentation inventory | All 48 items mapped from the published non-experimental tier requirements have user-facing prose and a runnable or near-runnable example | Complete: published `mcp_dart 2.4.0` covers all 48 items |
+| Audit the project-maintained Tier 1 documentation inventory | All 48 items mapped from the published non-experimental tier requirements have user-facing prose and a runnable or near-runnable example | Complete: published `mcp_dart 2.5.0` covers all 48 items |
 | Join the official SDK conformance matrix | The conformance repository can build and run `mcp_dart` client and server fixtures by repository/ref | Planned |
 | Resolve SDK tiering eligibility | The SDK Working Group confirms whether an external community SDK can receive a tier or accepts `mcp_dart` into the official SDK roster | Planned: the tiering page describes community-driven SDKs, while the [SDK Working Group charter](https://modelcontextprotocol.io/community/working-groups/sdk) excludes third-party SDKs outside the MCP organization |
 | Produce a repository evidence scorecard | Current client and server fixtures each score 100% for applicable dated scenarios | Complete: the pinned self-assessment returns Tier 1 on deterministic checks; official matrix integration remains planned |
@@ -53,8 +53,8 @@ expected-failure allowances.
 | Required issue labels | 12/12 |
 | Open-issue triage | 100% within two business days; 2 open issues, median 0 hours |
 | Open `P0` issues | 0 |
-| Published stable SDK release | `mcp_dart 2.4.0` |
-| Published stable documentation inventory | `mcp_dart 2.4.0` is 48/48 |
+| Published stable SDK release | `mcp_dart 2.5.0` |
+| Published stable documentation inventory | `mcp_dart 2.5.0` is 48/48 |
 | Latest-spec release gap | 0 days |
 | Self-assessment result | Tier 1; all deterministic checks pass |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ through the
 
 ## Current baseline
 
-- Stable `mcp_dart 2.5.0` and `mcp_dart_cli 0.2.0` releases.
+- Stable `mcp_dart 2.4.1` and `mcp_dart_cli 0.2.0` releases.
 - Complete Core client/server support for MCP 2026-07-28 with an explicit
   MCP 2025-11-25 compatibility profile.
 - Exact-head CI passes the published official conformance package for both
@@ -30,7 +30,7 @@ outside the Tier 1 Core claim.
 | --- | --- | --- |
 | Publish maintenance, security, dependency, and versioning policies | Policies are linked from the README and pass the official policy evaluation | Complete: the official checker finds all required policy signals; final qualitative judgment remains with reviewers |
 | Adopt the MCP issue taxonomy | All required type, status, and priority labels exist; every open issue is triaged | Complete: 12/12 labels and 100% current open-issue triage |
-| Audit the project-maintained Tier 1 documentation inventory | All 48 items mapped from the published non-experimental tier requirements have user-facing prose and a runnable or near-runnable example | Complete: published `mcp_dart 2.5.0` covers all 48 items |
+| Audit the project-maintained Tier 1 documentation inventory | All 48 items mapped from the published non-experimental tier requirements have user-facing prose and a runnable or near-runnable example | Complete: published `mcp_dart 2.4.1` covers all 48 items |
 | Join the official SDK conformance matrix | The conformance repository can build and run `mcp_dart` client and server fixtures by repository/ref | Planned |
 | Resolve SDK tiering eligibility | The SDK Working Group confirms whether an external community SDK can receive a tier or accepts `mcp_dart` into the official SDK roster | Planned: the tiering page describes community-driven SDKs, while the [SDK Working Group charter](https://modelcontextprotocol.io/community/working-groups/sdk) excludes third-party SDKs outside the MCP organization |
 | Produce a repository evidence scorecard | Current client and server fixtures each score 100% for applicable dated scenarios | Complete: the pinned self-assessment returns Tier 1 on deterministic checks; official matrix integration remains planned |
@@ -53,8 +53,8 @@ expected-failure allowances.
 | Required issue labels | 12/12 |
 | Open-issue triage | 100% within two business days; 2 open issues, median 0 hours |
 | Open `P0` issues | 0 |
-| Published stable SDK release | `mcp_dart 2.5.0` |
-| Published stable documentation inventory | `mcp_dart 2.5.0` is 48/48 |
+| Published stable SDK release | `mcp_dart 2.4.1` |
+| Published stable documentation inventory | `mcp_dart 2.4.1` is 48/48 |
 | Latest-spec release gap | 0 days |
 | Self-assessment result | Tier 1; all deterministic checks pass |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Security fixes target the current stable SDK and CLI release lines:
 
 | Package | Supported stable line |
 | --- | --- |
-| `mcp_dart` | `2.4.x` |
+| `mcp_dart` | `2.5.x` |
 | `mcp_dart_cli` | `0.2.x` |
 
 Older lines receive best-effort fixes only. A vulnerability may require

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Security fixes target the current stable SDK and CLI release lines:
 
 | Package | Supported stable line |
 | --- | --- |
-| `mcp_dart` | `2.5.x` |
+| `mcp_dart` | `2.4.x` |
 | `mcp_dart_cli` | `0.2.x` |
 
 Older lines receive best-effort fixes only. A vulnerability may require

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -8,7 +8,7 @@ Add the MCP Dart SDK to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.5.0
+  mcp_dart: ^2.4.1
 ```
 
 Then run:

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -8,7 +8,7 @@ Add the MCP Dart SDK to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.4.0
+  mcp_dart: ^2.5.0
 ```
 
 Then run:

--- a/doc/mcp-2026-07-28-release-runbook.md
+++ b/doc/mcp-2026-07-28-release-runbook.md
@@ -222,11 +222,11 @@ all required checks green and no unresolved review thread.
 
 On the final release-prep commit:
 
-- Set the root package version to the selected stable SDK version (`2.5.0` for
+- Set the root package version to the selected stable SDK version (`2.4.1` for
   the current follow-up release).
 - Restore root `documentation` and all user-facing repository links to `main`.
 - Replace older dependency snippets in the README, getting-started,
-  quick-reference, and current release docs with `mcp_dart: ^2.5.0`. Preserve
+  quick-reference, and current release docs with `mcp_dart: ^2.4.1`. Preserve
   version-specific historical migration guides.
 - Keep the durable `2026-07-28` document, fixture, command, and workflow names;
   update maturity wording only when it matches the reviewed upstream input.
@@ -243,7 +243,7 @@ On the final release-prep commit:
 - Stop presenting `previewProtocolVersion` as the preferred public name. Keep
   it only as a deprecated alias of `stableProtocolVersion` for prerelease
   adopters, and update examples to use the stable/default constants.
-- Move the relevant root changelog entries under `## 2.5.0` and remove wording
+- Move the relevant root changelog entries under `## 2.4.1` and remove wording
   that presents the stable package itself as a preview. Keep upstream
   release-candidate facts explicit while they remain true.
 - Keep migration and compatibility notes explicit: `McpProtocol.stable`
@@ -252,8 +252,8 @@ On the final release-prep commit:
   link it from the tagged README and changelog.
 - Run `dart pub publish --dry-run` again from a clean checkout of the exact
   release commit. Do not create the release tag until this succeeds.
-- Run the shared metadata validator with `--package mcp_dart --tag v2.5.0`.
-  It must require substantive notes under the exact `## 2.5.0` changelog
+- Run the shared metadata validator with `--package mcp_dart --tag v2.4.1`.
+  It must require substantive notes under the exact `## 2.4.1` changelog
   heading, exact reviewed input versions and pins, and verify that the default
   protocol is `2026-07-28` while the initialization and deprecated compatibility
   aliases remain at `2025-11-25`.
@@ -288,7 +288,7 @@ coordinated prep cannot mix channels.
    reuse an existing tag only when that tag resolves to the exact original
    release commit; the workflow never moves it. Manual dispatch is a recovery
    path only.
-2. Verify tag `v2.5.0`, the GitHub release, and the `Publish to pub.dev` workflow.
+2. Verify tag `v2.4.1`, the GitHub release, and the `Publish to pub.dev` workflow.
    If GitHub release creation fails after the tag was pushed, use **Re-run all
    jobs** on the original failed `Create Release` run so the workflow retains
    the original release commit. Do not start a fresh dispatch after `main`
@@ -296,12 +296,12 @@ coordinated prep cannot mix channels.
    different commit. If publication fails after the tag was pushed, rerun the
    failed tag-triggered `Publish to pub.dev` workflow; reusing a tag does not
    emit another push event.
-3. Confirm pub.dev shows version `2.5.0`, immutable `v2.5.0` documentation
+3. Confirm pub.dev shows version `2.4.1`, immutable `v2.4.1` documentation
    links, and a successful package analysis. Checked-in links on `main` remain
    pointed at `main`.
-4. Create a clean temporary Dart project, resolve `mcp_dart: ^2.5.0`, and run a
+4. Create a clean temporary Dart project, resolve `mcp_dart: ^2.4.1`, and run a
    minimal MCP 2026-07-28 client/server smoke test using only the published
-   package. For the 2.5 follow-up, also exercise Streamable HTTP access and
+   package. For the 2.4.1 follow-up, also exercise Streamable HTTP access and
    JSON-RPC error logging with normal and throwing application log handlers,
    and confirm the published package earns 160/160 under the current Pana.
 
@@ -310,8 +310,8 @@ publicly.
 
 ## 5. Prepare and publish `mcp_dart_cli`
 
-Skip this section for the SDK-only 2.5.0 follow-up. The already-published CLI
-remains 0.2.0 and its `^2.3.0` SDK constraint accepts 2.5.0.
+Skip this section for the SDK-only 2.4.1 follow-up. The already-published CLI
+remains 0.2.0 and its `^2.3.0` SDK constraint accepts 2.4.1.
 
 - Set the CLI version and `packageVersion` constant to `0.2.0`, and set
   `generatedSdkConstraint` to `^2.3.0`.

--- a/doc/mcp-2026-07-28-release-runbook.md
+++ b/doc/mcp-2026-07-28-release-runbook.md
@@ -222,11 +222,11 @@ all required checks green and no unresolved review thread.
 
 On the final release-prep commit:
 
-- Set the root package version to the selected stable SDK version (`2.4.0` for
+- Set the root package version to the selected stable SDK version (`2.5.0` for
   the current follow-up release).
 - Restore root `documentation` and all user-facing repository links to `main`.
 - Replace older dependency snippets in the README, getting-started,
-  quick-reference, and current release docs with `mcp_dart: ^2.4.0`. Preserve
+  quick-reference, and current release docs with `mcp_dart: ^2.5.0`. Preserve
   version-specific historical migration guides.
 - Keep the durable `2026-07-28` document, fixture, command, and workflow names;
   update maturity wording only when it matches the reviewed upstream input.
@@ -243,7 +243,7 @@ On the final release-prep commit:
 - Stop presenting `previewProtocolVersion` as the preferred public name. Keep
   it only as a deprecated alias of `stableProtocolVersion` for prerelease
   adopters, and update examples to use the stable/default constants.
-- Move the relevant root changelog entries under `## 2.4.0` and remove wording
+- Move the relevant root changelog entries under `## 2.5.0` and remove wording
   that presents the stable package itself as a preview. Keep upstream
   release-candidate facts explicit while they remain true.
 - Keep migration and compatibility notes explicit: `McpProtocol.stable`
@@ -252,8 +252,8 @@ On the final release-prep commit:
   link it from the tagged README and changelog.
 - Run `dart pub publish --dry-run` again from a clean checkout of the exact
   release commit. Do not create the release tag until this succeeds.
-- Run the shared metadata validator with `--package mcp_dart --tag v2.4.0`.
-  It must require substantive notes under the exact `## 2.4.0` changelog
+- Run the shared metadata validator with `--package mcp_dart --tag v2.5.0`.
+  It must require substantive notes under the exact `## 2.5.0` changelog
   heading, exact reviewed input versions and pins, and verify that the default
   protocol is `2026-07-28` while the initialization and deprecated compatibility
   aliases remain at `2025-11-25`.
@@ -288,7 +288,7 @@ coordinated prep cannot mix channels.
    reuse an existing tag only when that tag resolves to the exact original
    release commit; the workflow never moves it. Manual dispatch is a recovery
    path only.
-2. Verify tag `v2.4.0`, the GitHub release, and the `Publish to pub.dev` workflow.
+2. Verify tag `v2.5.0`, the GitHub release, and the `Publish to pub.dev` workflow.
    If GitHub release creation fails after the tag was pushed, use **Re-run all
    jobs** on the original failed `Create Release` run so the workflow retains
    the original release commit. Do not start a fresh dispatch after `main`
@@ -296,21 +296,22 @@ coordinated prep cannot mix channels.
    different commit. If publication fails after the tag was pushed, rerun the
    failed tag-triggered `Publish to pub.dev` workflow; reusing a tag does not
    emit another push event.
-3. Confirm pub.dev shows version `2.4.0`, immutable `v2.4.0` documentation
+3. Confirm pub.dev shows version `2.5.0`, immutable `v2.5.0` documentation
    links, and a successful package analysis. Checked-in links on `main` remain
    pointed at `main`.
-4. Create a clean temporary Dart project, resolve `mcp_dart: ^2.4.0`, and run a
+4. Create a clean temporary Dart project, resolve `mcp_dart: ^2.5.0`, and run a
    minimal MCP 2026-07-28 client/server smoke test using only the published
-   package. For the 2.4 follow-up, also connect its public
-   `SseClientTransport` to published TypeScript and Python legacy SSE servers.
+   package. For the 2.5 follow-up, also exercise Streamable HTTP access and
+   JSON-RPC error logging with normal and throwing application log handlers,
+   and confirm the published package earns 160/160 under the current Pana.
 
 Do not start a selected CLI release until the published SDK dependency resolves
 publicly.
 
 ## 5. Prepare and publish `mcp_dart_cli`
 
-Skip this section for the SDK-only 2.4.0 follow-up. The already-published CLI
-remains 0.2.0 and its `^2.3.0` SDK constraint accepts 2.4.0.
+Skip this section for the SDK-only 2.5.0 follow-up. The already-published CLI
+remains 0.2.0 and its `^2.3.0` SDK constraint accepts 2.5.0.
 
 - Set the CLI version and `packageVersion` constant to `0.2.0`, and set
   `generatedSdkConstraint` to `^2.3.0`.
@@ -331,9 +332,10 @@ cd packages/mcp_dart_cli
 dart pub global run pana --no-warning --exit-code-threshold 0
 ```
 
-When the same prep PR selects both packages, the automation waits until
-`mcp_dart 2.3.0` is visible on pub.dev and then invokes `Create Release` for
-the CLI. For a CLI-only prep, it invokes the CLI release directly. Verify the
+When the same prep PR selects both packages, the automation waits until the
+selected `mcp_dart` version is visible on pub.dev and then invokes `Create
+Release` for the CLI. For a CLI-only prep, it invokes the CLI release directly.
+Verify the
 `mcp_dart_cli-v0.2.0` publish and the standalone binary workflow and release
 assets for every supported platform. If the binary workflow must be dispatched
 manually, supply the release tag; both build and asset jobs verify and check out

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -8,19 +8,19 @@ Use this page for common `mcp_dart` calls. The [server guide](server-guide.md),
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.4.0
+  mcp_dart: ^2.5.0
 ```
 
 ```dart
 import 'package:mcp_dart/mcp_dart.dart';
 ```
 
-The 2.4.0 SDK requires Dart 3.4 or later. The stable 0.2.0 CLI requires
+The 2.5.0 SDK requires Dart 3.4 or later. The stable 0.2.0 CLI requires
 Dart 3.12 or later.
 
 ## Protocol profile
 
-The 2.4.0 SDK defaults to `McpProtocol.stable`: try MCP `2026-07-28`, then
+The 2.5.0 SDK defaults to `McpProtocol.stable`: try MCP `2026-07-28`, then
 fall back to legacy initialization when needed. Body-only
 discovery probes are bounded to five seconds; HTTP retains its normal request
 timeout.

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -8,19 +8,19 @@ Use this page for common `mcp_dart` calls. The [server guide](server-guide.md),
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.5.0
+  mcp_dart: ^2.4.1
 ```
 
 ```dart
 import 'package:mcp_dart/mcp_dart.dart';
 ```
 
-The 2.5.0 SDK requires Dart 3.4 or later. The stable 0.2.0 CLI requires
+The 2.4.1 SDK requires Dart 3.4 or later. The stable 0.2.0 CLI requires
 Dart 3.12 or later.
 
 ## Protocol profile
 
-The 2.5.0 SDK defaults to `McpProtocol.stable`: try MCP `2026-07-28`, then
+The 2.4.1 SDK defaults to `McpProtocol.stable`: try MCP `2026-07-28`, then
 fall back to legacy initialization when needed. Body-only
 discovery probes are bounded to five seconds; HTTP retains its normal request
 timeout.

--- a/doc/sdk-tier-1-feature-coverage.md
+++ b/doc/sdk-tier-1-feature-coverage.md
@@ -15,7 +15,7 @@ requirements still include them. Their examples explicitly select the MCP
   examples in current source.
 - The deprecated legacy SSE client and server remain explicit compatibility
   surfaces. Both reference SEP-2596 and Streamable HTTP migration.
-- Published `mcp_dart 2.5.0` includes `SseClientTransport`, so all 48 items
+- Published `mcp_dart 2.4.1` includes `SseClientTransport`, so all 48 items
   have stable-package documentation and examples.
 - Experimental Tasks and MCP Apps are documented separately and do not count
   toward the 48-feature Core inventory.

--- a/doc/sdk-tier-1-feature-coverage.md
+++ b/doc/sdk-tier-1-feature-coverage.md
@@ -15,7 +15,7 @@ requirements still include them. Their examples explicitly select the MCP
   examples in current source.
 - The deprecated legacy SSE client and server remain explicit compatibility
   surfaces. Both reference SEP-2596 and Streamable HTTP migration.
-- Published `mcp_dart 2.4.0` includes `SseClientTransport`, so all 48 items
+- Published `mcp_dart 2.5.0` includes `SseClientTransport`, so all 48 items
   have stable-package documentation and examples.
 - Experimental Tasks and MCP Apps are documented separately and do not count
   toward the 48-feature Core inventory.

--- a/example/anthropic-client/lib/anthropic_client.dart
+++ b/example/anthropic-client/lib/anthropic_client.dart
@@ -1,3 +1,5 @@
+// @dart=3.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/example/anthropic-client/test/anthropic_client_test.dart
+++ b/example/anthropic-client/test/anthropic_client_test.dart
@@ -1,3 +1,5 @@
+// @dart=3.9
+
 import 'dart:convert';
 
 import 'package:anthropic_client/anthropic_client.dart';

--- a/example/anthropic-client/test/fixtures/env_probe_server.dart
+++ b/example/anthropic-client/test/fixtures/env_probe_server.dart
@@ -1,3 +1,5 @@
+// @dart=3.9
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/example/flutter_http_client/lib/screens/mcp_client_screen.dart
+++ b/example/flutter_http_client/lib/screens/mcp_client_screen.dart
@@ -1,3 +1,5 @@
+// @dart=3.7
+
 import 'dart:convert';
 
 import 'package:flutter/material.dart';

--- a/example/flutter_http_client/lib/services/streamable_mcp_service.dart
+++ b/example/flutter_http_client/lib/services/streamable_mcp_service.dart
@@ -1,3 +1,5 @@
+// @dart=3.7
+
 import 'dart:async';
 
 import 'package:flutter/widgets.dart';

--- a/example/gemini-client/lib/gemini_client.dart
+++ b/example/gemini-client/lib/gemini_client.dart
@@ -1,3 +1,5 @@
+// @dart=3.7
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/example/gemini-client/test/cli_smoke_test.dart
+++ b/example/gemini-client/test/cli_smoke_test.dart
@@ -1,3 +1,5 @@
+// @dart=3.7
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/example/gemini-client/test/fixtures/env_probe_server.dart
+++ b/example/gemini-client/test/fixtures/env_probe_server.dart
@@ -1,3 +1,5 @@
+// @dart=3.7
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/example/gemini-client/test/gemini_client_test.dart
+++ b/example/gemini-client/test/gemini_client_test.dart
@@ -1,3 +1,5 @@
+// @dart=3.7
+
 import 'dart:async';
 import 'dart:convert';
 

--- a/example/jaspr-client/lib/app.dart
+++ b/example/jaspr-client/lib/app.dart
@@ -1,3 +1,5 @@
+// @dart=3.10
+
 /// Main App component for the Jaspr MCP Client.
 library;
 

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 `mcp_dart` is a community Dart and Flutter SDK for Model Context Protocol
 (MCP) servers, clients, and hosts.
 
-- SDK stable: `2.5.0`
+- SDK stable: `2.4.1`
 - CLI stable: `0.2.0`
 - SDK minimum: Dart 3.4
 - CLI minimum: Dart 3.12
@@ -11,13 +11,13 @@
 - Package: https://pub.dev/packages/mcp_dart
 - License: MIT
 
-Stable 2.5.0 adds Streamable HTTP access and JSON-RPC error diagnostics and
+Stable 2.4.1 hardens Streamable HTTP access and JSON-RPC error diagnostics and
 retains an explicitly deprecated legacy HTTP+SSE client with same-origin
 endpoint enforcement. Prefer Streamable HTTP for all new integrations.
 
 ## Release status
 
-The 2.5.0 release retains the complete core client/server wire surface of the
+The 2.4.1 release retains the complete core client/server wire surface of the
 final MCP `2026-07-28` specification, the MCP `2025-11-25` feature set, and
 negotiation with supported earlier initialization versions. Core
 means the normative wire requirements assigned to client and server roles by
@@ -35,11 +35,11 @@ Use the latest stable SDK for production:
 dart pub add mcp_dart
 ```
 
-Pin the stable 2.5 line explicitly:
+Pin the stable 2.4 line explicitly:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.5.0
+  mcp_dart: ^2.4.1
 ```
 
 ## Primary import

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 `mcp_dart` is a community Dart and Flutter SDK for Model Context Protocol
 (MCP) servers, clients, and hosts.
 
-- SDK stable: `2.4.0`
+- SDK stable: `2.5.0`
 - CLI stable: `0.2.0`
 - SDK minimum: Dart 3.4
 - CLI minimum: Dart 3.12
@@ -11,13 +11,13 @@
 - Package: https://pub.dev/packages/mcp_dart
 - License: MIT
 
-Stable 2.4.0 also provides an explicitly deprecated legacy HTTP+SSE client with
-same-origin endpoint enforcement. Prefer Streamable HTTP for all new
-integrations.
+Stable 2.5.0 adds Streamable HTTP access and JSON-RPC error diagnostics and
+retains an explicitly deprecated legacy HTTP+SSE client with same-origin
+endpoint enforcement. Prefer Streamable HTTP for all new integrations.
 
 ## Release status
 
-The 2.4.0 release retains the complete core client/server wire surface of the
+The 2.5.0 release retains the complete core client/server wire surface of the
 final MCP `2026-07-28` specification, the MCP `2025-11-25` feature set, and
 negotiation with supported earlier initialization versions. Core
 means the normative wire requirements assigned to client and server roles by
@@ -35,11 +35,11 @@ Use the latest stable SDK for production:
 dart pub add mcp_dart
 ```
 
-Pin the stable 2.4 line explicitly:
+Pin the stable 2.5 line explicitly:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.4.0
+  mcp_dart: ^2.5.0
 ```
 
 ## Primary import

--- a/packages/mcp_dart_cli/bin/mcp_dart.dart
+++ b/packages/mcp_dart_cli/bin/mcp_dart.dart
@@ -1,3 +1,5 @@
+// @dart=3.12
+
 import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:mason_logger/mason_logger.dart';

--- a/packages/mcp_dart_cli/lib/src/agent_skill_command.dart
+++ b/packages/mcp_dart_cli/lib/src/agent_skill_command.dart
@@ -1,3 +1,5 @@
+// @dart=3.12
+
 import 'dart:io';
 import 'dart:isolate';
 

--- a/packages/mcp_dart_cli/lib/src/builders/mason_bundle_builder.dart
+++ b/packages/mcp_dart_cli/lib/src/builders/mason_bundle_builder.dart
@@ -1,3 +1,5 @@
+// @dart=3.12
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/mcp_dart_cli/lib/src/conformance_command.dart
+++ b/packages/mcp_dart_cli/lib/src/conformance_command.dart
@@ -1,3 +1,5 @@
+// @dart=3.12
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/packages/mcp_dart_cli/lib/src/create_command.dart
+++ b/packages/mcp_dart_cli/lib/src/create_command.dart
@@ -1,3 +1,5 @@
+// @dart=3.12
+
 import 'dart:io';
 
 import 'package:args/command_runner.dart';

--- a/packages/mcp_dart_cli/lib/src/inspectors/inspection_report.dart
+++ b/packages/mcp_dart_cli/lib/src/inspectors/inspection_report.dart
@@ -1,3 +1,5 @@
+// @dart=3.12
+
 /// Shared report model for MCP inspector commands.
 class InspectionReport {
   /// Creates an inspector report.

--- a/packages/mcp_dart_cli/lib/src/serve_command.dart
+++ b/packages/mcp_dart_cli/lib/src/serve_command.dart
@@ -1,3 +1,5 @@
+// @dart=3.12
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/mcp_dart_cli/lib/src/trace_command.dart
+++ b/packages/mcp_dart_cli/lib/src/trace_command.dart
@@ -1,3 +1,5 @@
+// @dart=3.12
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/mcp_dart_cli/lib/src/update_command.dart
+++ b/packages/mcp_dart_cli/lib/src/update_command.dart
@@ -1,3 +1,5 @@
+// @dart=3.12
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/packages/mcp_dart_cli/lib/src/utils/inspect_handlers.dart
+++ b/packages/mcp_dart_cli/lib/src/utils/inspect_handlers.dart
@@ -1,3 +1,5 @@
+// @dart=3.12
+
 import 'dart:async';
 
 import 'package:mason/mason.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mcp_dart
 description: Dart and Flutter SDK for building Model Context Protocol (MCP) servers, clients, hosts, and AI tools.
-version: 2.4.0
+version: 2.5.0
 repository: https://github.com/leehack/mcp_dart
 homepage: https://github.com/leehack/mcp_dart
 issue_tracker: https://github.com/leehack/mcp_dart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mcp_dart
 description: Dart and Flutter SDK for building Model Context Protocol (MCP) servers, clients, hosts, and AI tools.
-version: 2.5.0
+version: 2.4.1
 repository: https://github.com/leehack/mcp_dart
 homepage: https://github.com/leehack/mcp_dart
 issue_tracker: https://github.com/leehack/mcp_dart/issues

--- a/test/tool/validate_release_metadata_test.dart
+++ b/test/tool/validate_release_metadata_test.dart
@@ -1160,7 +1160,10 @@ Directory _stableFixture(
 
   final securityPolicy = File('${fixture.path}/SECURITY.md');
   securityPolicy.writeAsStringSync(
-    securityPolicy.readAsStringSync().replaceFirst('2.4.x', '2.3.x'),
+    securityPolicy.readAsStringSync().replaceFirst(
+          RegExp(r'^\| `mcp_dart` \| `[^`]+` \|$', multiLine: true),
+          '| `mcp_dart` | `2.3.x` |',
+        ),
   );
 
   final constants = File('${fixture.path}/lib/src/types/json_rpc.dart');

--- a/tool/release/mcp_2026_07_28_release_metadata.json
+++ b/tool/release/mcp_2026_07_28_release_metadata.json
@@ -1,5 +1,5 @@
 {
-  "sdkStableVersion": "2.5.0",
+  "sdkStableVersion": "2.4.1",
   "cliStableVersion": "0.2.0",
   "protocolVersion": "2026-07-28",
   "legacyInitializationProtocolVersion": "2025-11-25",

--- a/tool/release/mcp_2026_07_28_release_metadata.json
+++ b/tool/release/mcp_2026_07_28_release_metadata.json
@@ -1,5 +1,5 @@
 {
-  "sdkStableVersion": "2.4.0",
+  "sdkStableVersion": "2.5.0",
   "cliStableVersion": "0.2.0",
   "protocolVersion": "2026-07-28",
   "legacyInitializationProtocolVersion": "2025-11-25",


### PR DESCRIPTION
## Summary

- prepare the stable `mcp_dart 2.4.1` SDK release while leaving `mcp_dart_cli` at `0.2.0`
- restore the published package's Pana score from 140/160 to 160/160 under Pana 0.23.18 and Dart 3.13.1
- update exact-version changelog, release metadata, security policy, runbook, and release-facing documentation

## Root cause

The published 2.4.0 archive has three Dart 3.13 analyzer diagnostics. PR #361 fixed all three on current main, but Pana's temporary monorepo formatting still treated selected nested-package files as Dart 3.13 sources instead of using those packages' declared language versions. File-level language markers now preserve the existing package minimums without changing runtime, public API, or MCP protocol behavior.

This is a patch release because the unreleased Streamable HTTP logging work hardens diagnostics without adding or changing public API or wire behavior. An exact API comparison against published 2.4.0 reports zero breaking and zero non-breaking API changes.

## Validation

- Pana 0.23.18 / Dart 3.13.1: 160/160
- clean `dart pub publish --dry-run`: 0 warnings
- Dart 3.13.1 format, analyze, Core tests, docs, release metadata and workflow-security suites
- Dart 3.4 minimum-SDK consumer, analysis, web compile, and serialized Core suite
- Dart 3.12 CLI analysis, compile/version smoke, tests, and TypeScript/Python E2E
- API compatibility against published 2.4.0, 2.3.0, and the allowlisted 2.2.2 baseline
- pinned Core/Tasks/schema audits and 2025/2026 official conformance
- TypeScript/Python bidirectional, legacy SSE, browser, and Flutter Web interoperability
- Anthropic, Gemini, fetch, Jaspr, and Flutter nested example gates

## Release boundary

This PR is intentionally draft. Merging a `release-prep` PR authorizes the automatic release, so merge requires separate explicit approval.