### PR TITLE
Prepare mcp_dart 2.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 2.5.0
+## 2.4.2
 
-`mcp_dart 2.5.0` prevents unbounded buffering of incoming stdio and IO stream
+`mcp_dart 2.4.2` prevents unbounded buffering of incoming stdio and IO stream
 messages and adds configurable per-message byte limits.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,32 @@
-## Unreleased
+## 2.5.0
 
-### Fixed
+`mcp_dart 2.5.0` prevents unbounded buffering of incoming stdio and IO stream
+messages and adds configurable per-message byte limits.
+
+### Security
 
 - Bounded each incoming stdio and IO stream message to 10 MiB by default. Each
   transport now reports an error and closes when a peer exceeds its configured
-  `maxIncomingMessageBytes` limit.
+  `maxIncomingMessageBytes` limit. In 2.4.1, a faulty or hostile peer could
+  exhaust process memory by sending an unbounded frame without a newline.
 - Stopped stdio client message delivery immediately on oversized input, including
   while a blocked outgoing write delays process shutdown.
+
+### Upgrade notes
+
+- Integrations that intentionally exchange messages larger than 10 MiB must
+  configure a suitable finite `maxIncomingMessageBytes` on each receiving
+  transport. The limit counts UTF-8 bytes before the newline delimiter. See
+  the [transport guide](https://github.com/leehack/mcp_dart/blob/main/doc/transports.md)
+  for configuration and shutdown behavior.
+- Existing protocol profiles and minimum Dart 3.4 support are unchanged. The
+  separately versioned CLI remains at 0.2.0; its `^2.3.0` SDK constraint
+  accepts this release.
+
+### Thanks
+
+Thanks to [Leo Farias (@leoafarias)](https://github.com/leoafarias) for
+responsibly reporting the vulnerability and contributing the fix.
 
 ## 2.4.1
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ extensions, host UI behavior, an authorization-server implementation, JSON
 Schema external-reference resolution, and custom JSON Schema vocabularies.
 
 > [!IMPORTANT]
-> This release is `mcp_dart 2.5.0`. The separately versioned stable CLI remains
-> `mcp_dart_cli 0.2.0`; its `^2.3.0` SDK constraint accepts 2.5.
+> This release is `mcp_dart 2.4.2`. The separately versioned stable CLI remains
+> `mcp_dart_cli 0.2.0`; its `^2.3.0` SDK constraint accepts 2.4.
 > Current source passes every scored requirement in the official alpha.11 MCP
 > `2025-11-25` and `2026-07-28` client and server sets, including all 25
 > required 2026 authorization scenarios, plus bidirectional published
@@ -40,7 +40,7 @@ The public maintenance contract is documented in the
 
 | Package | Minimum Dart SDK |
 | --- | --- |
-| `mcp_dart 2.5.0` | 3.4 |
+| `mcp_dart 2.4.2` | 3.4 |
 | `mcp_dart_cli 0.2.0` | 3.12 |
 
 SDK-only generated projects retain the SDK's Dart 3.4 minimum. CLI projects
@@ -60,12 +60,12 @@ dart pub add mcp_dart
 
 ### Pin the stable SDK release
 
-Pin the stable 2.5 line explicitly when reproducible dependency resolution is
+Pin the stable 2.4 line explicitly when reproducible dependency resolution is
 important:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.5.0
+  mcp_dart: ^2.4.2
 ```
 
 The snippets below use the current stable SDK line. Package versions
@@ -73,7 +73,7 @@ remain separate from protocol profiles: `McpProtocol.stable` names the SDK's
 default compatibility policy.
 
 The SDK and CLI are versioned independently. The stable CLI's `^2.3.0`
-constraint remains compatible with the 2.5 SDK.
+constraint remains compatible with the 2.4 SDK.
 
 For direct SDK integration, start with the
 [getting-started guide](https://github.com/leehack/mcp_dart/blob/main/doc/getting-started.md).
@@ -99,7 +99,7 @@ commands.
   2.1.1 interoperability, real-browser transport tests, a real Flutter Web
   service integration in Chrome, deterministic widget tests, and an
   independent pinned JSON Schema Test Suite gate.
-- `mcp_dart 2.5.0` bounds incoming stdio and IO stream messages to 10 MiB by
+- `mcp_dart 2.4.2` bounds incoming stdio and IO stream messages to 10 MiB by
   default, with configurable limits for larger messages. See the
   [transport guide](doc/transports.md) before upgrading integrations that
   exchange larger frames.
@@ -242,7 +242,7 @@ surface. Re-check both packages' current releases before a production decision.
 - [Versioning policy](https://github.com/leehack/mcp_dart/blob/main/VERSIONING.md)
 - [Tier 1 roadmap](https://github.com/leehack/mcp_dart/blob/main/ROADMAP.md)
 - [SDK on pub.dev](https://pub.dev/packages/mcp_dart)
-- [2.5.0 API reference](https://pub.dev/documentation/mcp_dart/2.5.0/)
+- [2.4.2 API reference](https://pub.dev/documentation/mcp_dart/2.4.2/)
 - [Changelog](https://github.com/leehack/mcp_dart/blob/main/CHANGELOG.md)
 - [MCP 2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28)
 - [MCP 2025-11-25 specification](https://modelcontextprotocol.io/specification/2025-11-25)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ extensions, host UI behavior, an authorization-server implementation, JSON
 Schema external-reference resolution, and custom JSON Schema vocabularies.
 
 > [!IMPORTANT]
-> The current stable packages are `mcp_dart 2.4.1` and
-> `mcp_dart_cli 0.2.0`; the CLI's `^2.3.0` SDK constraint accepts 2.4.
+> This release is `mcp_dart 2.5.0`. The separately versioned stable CLI remains
+> `mcp_dart_cli 0.2.0`; its `^2.3.0` SDK constraint accepts 2.5.
 > Current source passes every scored requirement in the official alpha.11 MCP
 > `2025-11-25` and `2026-07-28` client and server sets, including all 25
 > required 2026 authorization scenarios, plus bidirectional published
@@ -40,7 +40,7 @@ The public maintenance contract is documented in the
 
 | Package | Minimum Dart SDK |
 | --- | --- |
-| `mcp_dart 2.4.1` | 3.4 |
+| `mcp_dart 2.5.0` | 3.4 |
 | `mcp_dart_cli 0.2.0` | 3.12 |
 
 SDK-only generated projects retain the SDK's Dart 3.4 minimum. CLI projects
@@ -60,12 +60,12 @@ dart pub add mcp_dart
 
 ### Pin the stable SDK release
 
-Pin the stable 2.4 line explicitly when reproducible dependency resolution is
+Pin the stable 2.5 line explicitly when reproducible dependency resolution is
 important:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.4.1
+  mcp_dart: ^2.5.0
 ```
 
 The snippets below use the current stable SDK line. Package versions
@@ -73,7 +73,7 @@ remain separate from protocol profiles: `McpProtocol.stable` names the SDK's
 default compatibility policy.
 
 The SDK and CLI are versioned independently. The stable CLI's `^2.3.0`
-constraint remains compatible with the 2.4 SDK.
+constraint remains compatible with the 2.5 SDK.
 
 For direct SDK integration, start with the
 [getting-started guide](https://github.com/leehack/mcp_dart/blob/main/doc/getting-started.md).
@@ -99,8 +99,12 @@ commands.
   2.1.1 interoperability, real-browser transport tests, a real Flutter Web
   service integration in Chrome, deterministic widget tests, and an
   independent pinned JSON Schema Test Suite gate.
-- `mcp_dart 2.4.1` hardens Streamable HTTP access and JSON-RPC error
-  diagnostics and retains the deprecated, opt-in legacy HTTP+SSE client with
+- `mcp_dart 2.5.0` bounds incoming stdio and IO stream messages to 10 MiB by
+  default, with configurable limits for larger messages. See the
+  [transport guide](doc/transports.md) before upgrading integrations that
+  exchange larger frames.
+- Hardened Streamable HTTP access and JSON-RPC error diagnostics, plus the
+  deprecated, opt-in legacy HTTP+SSE client with
   same-origin routing and bidirectional interoperability against official
   TypeScript SDK 1.30.0 and Python SDK 2.1.1 peers.
 
@@ -238,7 +242,7 @@ surface. Re-check both packages' current releases before a production decision.
 - [Versioning policy](https://github.com/leehack/mcp_dart/blob/main/VERSIONING.md)
 - [Tier 1 roadmap](https://github.com/leehack/mcp_dart/blob/main/ROADMAP.md)
 - [SDK on pub.dev](https://pub.dev/packages/mcp_dart)
-- [2.4.1 API reference](https://pub.dev/documentation/mcp_dart/2.4.1/)
+- [2.5.0 API reference](https://pub.dev/documentation/mcp_dart/2.5.0/)
 - [Changelog](https://github.com/leehack/mcp_dart/blob/main/CHANGELOG.md)
 - [MCP 2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28)
 - [MCP 2025-11-25 specification](https://modelcontextprotocol.io/specification/2025-11-25)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Security fixes target the current stable SDK and CLI release lines:
 
 | Package | Supported stable line |
 | --- | --- |
-| `mcp_dart` | `2.4.x` |
+| `mcp_dart` | `2.5.x` |
 | `mcp_dart_cli` | `0.2.x` |
 
 Older lines receive best-effort fixes only. A vulnerability may require

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Security fixes target the current stable SDK and CLI release lines:
 
 | Package | Supported stable line |
 | --- | --- |
-| `mcp_dart` | `2.5.x` |
+| `mcp_dart` | `2.4.x` |
 | `mcp_dart_cli` | `0.2.x` |
 
 Older lines receive best-effort fixes only. A vulnerability may require

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -8,7 +8,7 @@ Add the MCP Dart SDK to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.4.1
+  mcp_dart: ^2.5.0
 ```
 
 Then run:

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -8,7 +8,7 @@ Add the MCP Dart SDK to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.5.0
+  mcp_dart: ^2.4.2
 ```
 
 Then run:

--- a/doc/mcp-2026-07-28-release-runbook.md
+++ b/doc/mcp-2026-07-28-release-runbook.md
@@ -222,11 +222,11 @@ all required checks green and no unresolved review thread.
 
 On the final release-prep commit:
 
-- Set the root package version to the selected stable SDK version (`2.4.1` for
+- Set the root package version to the selected stable SDK version (`2.5.0` for
   the current follow-up release).
 - Restore root `documentation` and all user-facing repository links to `main`.
 - Replace older dependency snippets in the README, getting-started,
-  quick-reference, and current release docs with `mcp_dart: ^2.4.1`. Preserve
+  quick-reference, and current release docs with `mcp_dart: ^2.5.0`. Preserve
   version-specific historical migration guides.
 - Keep the durable `2026-07-28` document, fixture, command, and workflow names;
   update maturity wording only when it matches the reviewed upstream input.
@@ -243,7 +243,7 @@ On the final release-prep commit:
 - Stop presenting `previewProtocolVersion` as the preferred public name. Keep
   it only as a deprecated alias of `stableProtocolVersion` for prerelease
   adopters, and update examples to use the stable/default constants.
-- Move the relevant root changelog entries under `## 2.4.1` and remove wording
+- Move the relevant root changelog entries under `## 2.5.0` and remove wording
   that presents the stable package itself as a preview. Keep upstream
   release-candidate facts explicit while they remain true.
 - Keep migration and compatibility notes explicit: `McpProtocol.stable`
@@ -252,8 +252,8 @@ On the final release-prep commit:
   link it from the tagged README and changelog.
 - Run `dart pub publish --dry-run` again from a clean checkout of the exact
   release commit. Do not create the release tag until this succeeds.
-- Run the shared metadata validator with `--package mcp_dart --tag v2.4.1`.
-  It must require substantive notes under the exact `## 2.4.1` changelog
+- Run the shared metadata validator with `--package mcp_dart --tag v2.5.0`.
+  It must require substantive notes under the exact `## 2.5.0` changelog
   heading, exact reviewed input versions and pins, and verify that the default
   protocol is `2026-07-28` while the initialization and deprecated compatibility
   aliases remain at `2025-11-25`.
@@ -288,7 +288,7 @@ coordinated prep cannot mix channels.
    reuse an existing tag only when that tag resolves to the exact original
    release commit; the workflow never moves it. Manual dispatch is a recovery
    path only.
-2. Verify tag `v2.4.1`, the GitHub release, and the `Publish to pub.dev` workflow.
+2. Verify tag `v2.5.0`, the GitHub release, and the `Publish to pub.dev` workflow.
    If GitHub release creation fails after the tag was pushed, use **Re-run all
    jobs** on the original failed `Create Release` run so the workflow retains
    the original release commit. Do not start a fresh dispatch after `main`
@@ -296,22 +296,23 @@ coordinated prep cannot mix channels.
    different commit. If publication fails after the tag was pushed, rerun the
    failed tag-triggered `Publish to pub.dev` workflow; reusing a tag does not
    emit another push event.
-3. Confirm pub.dev shows version `2.4.1`, immutable `v2.4.1` documentation
+3. Confirm pub.dev shows version `2.5.0`, immutable `v2.5.0` documentation
    links, and a successful package analysis. Checked-in links on `main` remain
    pointed at `main`.
-4. Create a clean temporary Dart project, resolve `mcp_dart: ^2.4.1`, and run a
+4. Create a clean temporary Dart project, resolve `mcp_dart: ^2.5.0`, and run a
    minimal MCP 2026-07-28 client/server smoke test using only the published
-   package. For the 2.4.1 follow-up, also exercise Streamable HTTP access and
-   JSON-RPC error logging with normal and throwing application log handlers,
-   and confirm the published package earns 160/160 under the current Pana.
+   package. For this release, exercise the incoming-message limits through
+   public stdio client, stdio server, and IO stream APIs, including valid
+   custom limits and fatal-overflow shutdown with a blocked outgoing write.
+   Confirm the published package earns 160/160 under the current Pana.
 
 Do not start a selected CLI release until the published SDK dependency resolves
 publicly.
 
 ## 5. Prepare and publish `mcp_dart_cli`
 
-Skip this section for the SDK-only 2.4.1 follow-up. The already-published CLI
-remains 0.2.0 and its `^2.3.0` SDK constraint accepts 2.4.1.
+Skip this section for the SDK-only 2.5.0 release. The already-published CLI
+remains 0.2.0 and its `^2.3.0` SDK constraint accepts 2.5.0.
 
 - Set the CLI version and `packageVersion` constant to `0.2.0`, and set
   `generatedSdkConstraint` to `^2.3.0`.

--- a/doc/mcp-2026-07-28-release-runbook.md
+++ b/doc/mcp-2026-07-28-release-runbook.md
@@ -222,11 +222,11 @@ all required checks green and no unresolved review thread.
 
 On the final release-prep commit:
 
-- Set the root package version to the selected stable SDK version (`2.5.0` for
+- Set the root package version to the selected stable SDK version (`2.4.2` for
   the current follow-up release).
 - Restore root `documentation` and all user-facing repository links to `main`.
 - Replace older dependency snippets in the README, getting-started,
-  quick-reference, and current release docs with `mcp_dart: ^2.5.0`. Preserve
+  quick-reference, and current release docs with `mcp_dart: ^2.4.2`. Preserve
   version-specific historical migration guides.
 - Keep the durable `2026-07-28` document, fixture, command, and workflow names;
   update maturity wording only when it matches the reviewed upstream input.
@@ -243,7 +243,7 @@ On the final release-prep commit:
 - Stop presenting `previewProtocolVersion` as the preferred public name. Keep
   it only as a deprecated alias of `stableProtocolVersion` for prerelease
   adopters, and update examples to use the stable/default constants.
-- Move the relevant root changelog entries under `## 2.5.0` and remove wording
+- Move the relevant root changelog entries under `## 2.4.2` and remove wording
   that presents the stable package itself as a preview. Keep upstream
   release-candidate facts explicit while they remain true.
 - Keep migration and compatibility notes explicit: `McpProtocol.stable`
@@ -252,8 +252,8 @@ On the final release-prep commit:
   link it from the tagged README and changelog.
 - Run `dart pub publish --dry-run` again from a clean checkout of the exact
   release commit. Do not create the release tag until this succeeds.
-- Run the shared metadata validator with `--package mcp_dart --tag v2.5.0`.
-  It must require substantive notes under the exact `## 2.5.0` changelog
+- Run the shared metadata validator with `--package mcp_dart --tag v2.4.2`.
+  It must require substantive notes under the exact `## 2.4.2` changelog
   heading, exact reviewed input versions and pins, and verify that the default
   protocol is `2026-07-28` while the initialization and deprecated compatibility
   aliases remain at `2025-11-25`.
@@ -288,7 +288,7 @@ coordinated prep cannot mix channels.
    reuse an existing tag only when that tag resolves to the exact original
    release commit; the workflow never moves it. Manual dispatch is a recovery
    path only.
-2. Verify tag `v2.5.0`, the GitHub release, and the `Publish to pub.dev` workflow.
+2. Verify tag `v2.4.2`, the GitHub release, and the `Publish to pub.dev` workflow.
    If GitHub release creation fails after the tag was pushed, use **Re-run all
    jobs** on the original failed `Create Release` run so the workflow retains
    the original release commit. Do not start a fresh dispatch after `main`
@@ -296,10 +296,10 @@ coordinated prep cannot mix channels.
    different commit. If publication fails after the tag was pushed, rerun the
    failed tag-triggered `Publish to pub.dev` workflow; reusing a tag does not
    emit another push event.
-3. Confirm pub.dev shows version `2.5.0`, immutable `v2.5.0` documentation
+3. Confirm pub.dev shows version `2.4.2`, immutable `v2.4.2` documentation
    links, and a successful package analysis. Checked-in links on `main` remain
    pointed at `main`.
-4. Create a clean temporary Dart project, resolve `mcp_dart: ^2.5.0`, and run a
+4. Create a clean temporary Dart project, resolve `mcp_dart: ^2.4.2`, and run a
    minimal MCP 2026-07-28 client/server smoke test using only the published
    package. For this release, exercise the incoming-message limits through
    public stdio client, stdio server, and IO stream APIs, including valid
@@ -311,8 +311,8 @@ publicly.
 
 ## 5. Prepare and publish `mcp_dart_cli`
 
-Skip this section for the SDK-only 2.5.0 release. The already-published CLI
-remains 0.2.0 and its `^2.3.0` SDK constraint accepts 2.5.0.
+Skip this section for the SDK-only 2.4.2 release. The already-published CLI
+remains 0.2.0 and its `^2.3.0` SDK constraint accepts 2.4.2.
 
 - Set the CLI version and `packageVersion` constant to `0.2.0`, and set
   `generatedSdkConstraint` to `^2.3.0`.

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -8,19 +8,19 @@ Use this page for common `mcp_dart` calls. The [server guide](server-guide.md),
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.5.0
+  mcp_dart: ^2.4.2
 ```
 
 ```dart
 import 'package:mcp_dart/mcp_dart.dart';
 ```
 
-The 2.5.0 SDK requires Dart 3.4 or later. The stable 0.2.0 CLI requires
+The 2.4.2 SDK requires Dart 3.4 or later. The stable 0.2.0 CLI requires
 Dart 3.12 or later.
 
 ## Protocol profile
 
-The 2.5.0 SDK defaults to `McpProtocol.stable`: try MCP `2026-07-28`, then
+The 2.4.2 SDK defaults to `McpProtocol.stable`: try MCP `2026-07-28`, then
 fall back to legacy initialization when needed. Body-only
 discovery probes are bounded to five seconds; HTTP retains its normal request
 timeout.

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -8,19 +8,19 @@ Use this page for common `mcp_dart` calls. The [server guide](server-guide.md),
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.4.1
+  mcp_dart: ^2.5.0
 ```
 
 ```dart
 import 'package:mcp_dart/mcp_dart.dart';
 ```
 
-The 2.4.1 SDK requires Dart 3.4 or later. The stable 0.2.0 CLI requires
+The 2.5.0 SDK requires Dart 3.4 or later. The stable 0.2.0 CLI requires
 Dart 3.12 or later.
 
 ## Protocol profile
 
-The 2.4.1 SDK defaults to `McpProtocol.stable`: try MCP `2026-07-28`, then
+The 2.5.0 SDK defaults to `McpProtocol.stable`: try MCP `2026-07-28`, then
 fall back to legacy initialization when needed. Body-only
 discovery probes are bounded to five seconds; HTTP retains its normal request
 timeout.

--- a/doc/transports.md
+++ b/doc/transports.md
@@ -39,9 +39,9 @@ not automatically restart after overflow; a later explicit `start()` begins a
 new lifecycle. Set `maxIncomingMessageBytes` when a valid integration needs a
 different limit. The limit uses UTF-8 bytes and excludes the newline delimiter.
 
-### Upgrading to 2.5
+### Upgrading to 2.4.2
 
-Version 2.4.1 did not bound incoming newline-delimited frames. The 2.5 release
+Version 2.4.1 did not bound incoming newline-delimited frames. The 2.4.2 release
 closes the connection on oversized input to prevent unbounded memory growth.
 If your integration intentionally exchanges larger messages, configure a
 finite limit appropriate for its payloads and memory budget on each receiving

--- a/doc/transports.md
+++ b/doc/transports.md
@@ -39,6 +39,34 @@ not automatically restart after overflow; a later explicit `start()` begins a
 new lifecycle. Set `maxIncomingMessageBytes` when a valid integration needs a
 different limit. The limit uses UTF-8 bytes and excludes the newline delimiter.
 
+### Upgrading to 2.5
+
+Version 2.4.1 did not bound incoming newline-delimited frames. The 2.5 release
+closes the connection on oversized input to prevent unbounded memory growth.
+If your integration intentionally exchanges larger messages, configure a
+finite limit appropriate for its payloads and memory budget on each receiving
+transport. For example:
+
+```dart
+const maxMessageBytes = 16 * 1024 * 1024;
+
+final clientTransport = StdioClientTransport(
+  StdioServerParameters(
+    command: 'dart',
+    args: ['run', 'server.dart'],
+    maxIncomingMessageBytes: maxMessageBytes,
+  ),
+);
+final serverTransport = StdioServerTransport(
+  maxIncomingMessageBytes: maxMessageBytes,
+);
+```
+
+`IOStreamTransport` accepts the same named parameter. Limits apply to incoming
+messages independently at each endpoint; increasing one side's limit does not
+change its peer's limit. After overflow, correct the peer or limit before an
+explicit restart; do not retry an oversized message in an automatic loop.
+
 ### Server Setup
 
 Use `StdioServerTransport` when the server is launched as a local child process

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 `mcp_dart` is a community Dart and Flutter SDK for Model Context Protocol
 (MCP) servers, clients, and hosts.
 
-- SDK stable: `2.4.1`
+- SDK release: `2.5.0`
 - CLI stable: `0.2.0`
 - SDK minimum: Dart 3.4
 - CLI minimum: Dart 3.12
@@ -11,13 +11,17 @@
 - Package: https://pub.dev/packages/mcp_dart
 - License: MIT
 
-Stable 2.4.1 hardens Streamable HTTP access and JSON-RPC error diagnostics and
-retains an explicitly deprecated legacy HTTP+SSE client with same-origin
-endpoint enforcement. Prefer Streamable HTTP for all new integrations.
+Release 2.5.0 bounds incoming stdio and IO stream messages to 10 MiB by
+default. Set a suitable finite `maxIncomingMessageBytes` on receiving
+transports when valid messages exceed that limit. Overflow closes the
+transport; stdio clients stop message delivery immediately and do not
+automatically restart. Protocol profiles and minimum Dart support are unchanged.
+The deprecated legacy HTTP+SSE client remains available; prefer Streamable HTTP
+for new remote integrations.
 
 ## Release status
 
-The 2.4.1 release retains the complete core client/server wire surface of the
+The 2.5.0 release retains the complete core client/server wire surface of the
 final MCP `2026-07-28` specification, the MCP `2025-11-25` feature set, and
 negotiation with supported earlier initialization versions. Core
 means the normative wire requirements assigned to client and server roles by
@@ -35,11 +39,11 @@ Use the latest stable SDK for production:
 dart pub add mcp_dart
 ```
 
-Pin the stable 2.4 line explicitly:
+Pin the stable 2.5 line explicitly:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.4.1
+  mcp_dart: ^2.5.0
 ```
 
 ## Primary import

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 `mcp_dart` is a community Dart and Flutter SDK for Model Context Protocol
 (MCP) servers, clients, and hosts.
 
-- SDK release: `2.5.0`
+- SDK release: `2.4.2`
 - CLI stable: `0.2.0`
 - SDK minimum: Dart 3.4
 - CLI minimum: Dart 3.12
@@ -11,7 +11,7 @@
 - Package: https://pub.dev/packages/mcp_dart
 - License: MIT
 
-Release 2.5.0 bounds incoming stdio and IO stream messages to 10 MiB by
+Release 2.4.2 bounds incoming stdio and IO stream messages to 10 MiB by
 default. Set a suitable finite `maxIncomingMessageBytes` on receiving
 transports when valid messages exceed that limit. Overflow closes the
 transport; stdio clients stop message delivery immediately and do not
@@ -21,7 +21,7 @@ for new remote integrations.
 
 ## Release status
 
-The 2.5.0 release retains the complete core client/server wire surface of the
+The 2.4.2 release retains the complete core client/server wire surface of the
 final MCP `2026-07-28` specification, the MCP `2025-11-25` feature set, and
 negotiation with supported earlier initialization versions. Core
 means the normative wire requirements assigned to client and server roles by
@@ -39,11 +39,11 @@ Use the latest stable SDK for production:
 dart pub add mcp_dart
 ```
 
-Pin the stable 2.5 line explicitly:
+Pin the stable 2.4 line explicitly:
 
 ```yaml
 dependencies:
-  mcp_dart: ^2.5.0
+  mcp_dart: ^2.4.2
 ```
 
 ## Primary import

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mcp_dart
 description: Dart and Flutter SDK for building Model Context Protocol (MCP) servers, clients, hosts, and AI tools.
-version: 2.4.1
+version: 2.5.0
 repository: https://github.com/leehack/mcp_dart
 homepage: https://github.com/leehack/mcp_dart
 issue_tracker: https://github.com/leehack/mcp_dart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mcp_dart
 description: Dart and Flutter SDK for building Model Context Protocol (MCP) servers, clients, hosts, and AI tools.
-version: 2.5.0
+version: 2.4.2
 repository: https://github.com/leehack/mcp_dart
 homepage: https://github.com/leehack/mcp_dart
 issue_tracker: https://github.com/leehack/mcp_dart/issues

--- a/tool/release/mcp_2026_07_28_release_metadata.json
+++ b/tool/release/mcp_2026_07_28_release_metadata.json
@@ -1,5 +1,5 @@
 {
-  "sdkStableVersion": "2.5.0",
+  "sdkStableVersion": "2.4.2",
   "cliStableVersion": "0.2.0",
   "protocolVersion": "2026-07-28",
   "legacyInitializationProtocolVersion": "2025-11-25",

--- a/tool/release/mcp_2026_07_28_release_metadata.json
+++ b/tool/release/mcp_2026_07_28_release_metadata.json
@@ -1,5 +1,5 @@
 {
-  "sdkStableVersion": "2.4.1",
+  "sdkStableVersion": "2.5.0",
   "cliStableVersion": "0.2.0",
   "protocolVersion": "2026-07-28",
   "legacyInitializationProtocolVersion": "2025-11-25",


### PR DESCRIPTION
## Summary

- Prepare the SDK-only **mcp_dart 2.4.2** security release from current main, including the merged incoming-message limit fix and Dependabot updates.
- Update package/release metadata, installation snippets, and release/upgrade guidance. CLI remains **0.2.0** with its existing compatible SDK constraint.
- Credit **Leo Farias (@leoafarias)** for responsibly reporting the vulnerability and contributing the fix.

The new default is a finite 10 MiB incoming-message limit for stdio and IO stream transports. The release notes explain overflow shutdown and configuring larger finite limits where needed. This prep adds no runtime code or dependency constraints.

### Version choice

The maintainer selected 2.4.2 as a security-patch exception to the usual minor release for additive public APIs. The API comparison with published 2.4.1 found four nonbreaking additions supporting the security fix; this is not a claim that the public API is unchanged. The general versioning policy is unchanged.

## Validation

- Release metadata and SDK-only stable package selection pass for 2.4.2 after rebasing onto `b9109f3` (Dependabot #375).
- Main-source links pass; rendered release notes use immutable `v2.4.2` links and retain Leo's credit.
- Isolated 2.4.2 publish dry run: **zero warnings**.
- Public API comparison against published 2.4.1: **no breaking API changes**.
- Strict root and CLI analysis passed on the initial prep; runtime code is unchanged.
- Release-tool and affected-transport tests: **138 passed** on the initial prep; **82 release-tool tests passed** after the 2.4.2 version change.
- Local CLI suite: **125 passed, 14 optional interop-fixture tests skipped**.
- Formatting, whitespace, and release-prep workflow fixtures passed. Formatting reported missing Flutter-example lint dependencies; no example source changed.

These local results are not a substitute for exact-head PR CI. Full SDK, minimum-SDK, cross-platform, and Pana checks were not rerun locally for this prep. The final lockfile-only rebase requires fresh PR CI.

## Release boundary

This is a **draft release-prep PR**, not approval to publish. Merging this labeled PR triggers the automatic SDK release after exact-commit CI, so obtain explicit maintainer approval immediately before merging. Do not manually create or push tags. Advisory publication is separate and is not part of this PR.
