### PR TITLE
Fix Windows discovery-exit test fixture

### DIFF
--- a/test/client/fixtures/stdio_restart_server.dart
+++ b/test/client/fixtures/stdio_restart_server.dart
@@ -82,7 +82,9 @@ Future<void> main(List<String> arguments) async {
 
     if (method == 'server/discover') {
       if (replayBehavior == 'legacy-exit-on-discover') {
-        return;
+        // Exiting the async stdin loop can wait for input cancellation on
+        // Windows. This fixture must terminate the child before fallback.
+        exit(0);
       }
       final exercisesModernDiscoveryRecovery = launchCount == 1 &&
           (replayBehavior == 'modern-discovery-error-exit' ||


### PR DESCRIPTION
The legacy discovery fixture could close stdin without exiting promptly on Windows. The client then reached its discovery timeout and attempted initialization against the old process, intermittently failing the platform smoke test.

Explicitly exit the fixture with status 0 when it receives `server/discover`, so the existing tests exercise recovery after a child exit. SDK runtime behavior and dependency versions are unchanged.

Validation: all 1,986 SDK tests pass locally, including the 46 stdio client tests, fresh-child fallback, and the `require2026` rejection case. Static analysis, formatting, and diff checks pass. The unchanged dependency PR #378 also passed its targeted Windows rerun, confirming that the original failure is intermittent. Windows CI for this fixture change is still required after pushing.
