### PR TITLE
Fix CI fixture process shutdown and HTTP isolation

### DIFF
--- a/test/client/fixtures/stdio_restart_server.dart
+++ b/test/client/fixtures/stdio_restart_server.dart
@@ -350,7 +350,9 @@ Future<void> main(List<String> arguments) async {
     }
 
     if (method == 'fixture/exit-zero-request') {
-      return;
+      // Exit without awaiting stdin cancellation, which can block on Windows
+      // while the parent keeps the request pipe open.
+      exit(0);
     }
 
     if (method == 'fixture/final-response-exit') {

--- a/test/interop/dart_client_with_ts_server_test.dart
+++ b/test/interop/dart_client_with_ts_server_test.dart
@@ -182,9 +182,10 @@ void main() {
       late StreamableHttpClientTransport transport;
       late McpClient client;
       late io.Process serverProcess;
-      final port = 3001;
+      late int port;
 
       setUp(() async {
+        port = await _findAvailablePort();
         // 1. Manually spawn the external HTTP server
         serverProcess = await io.Process.start(
           'node',
@@ -219,7 +220,7 @@ void main() {
         // This closes the client and its underlying transport
         await client.close();
         // Kill the manually spawned server
-        serverProcess.kill();
+        await _terminateProcess(serverProcess);
       });
 
       test('tools', () async {


### PR DESCRIPTION
## Summary
- Explicitly exit the code-zero request fixture without waiting for stdin cancellation on Windows.
- Allocate a fresh HTTP fixture port per test and await server termination to avoid observing a previous server during startup.
- No SDK runtime changes.

## Validation
- 53 stdio and TypeScript interoperability tests passed locally.
- HTTP tests passed in five repeated runs.
- Dart analysis, formatting, and git diff checks passed.
- Windows validation remains dependent on CI.